### PR TITLE
feat: Transient Data Dissemination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,14 @@
+// Copyright SecureKey Technologies Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/trustbloc/fabric-peer-ext
 
 require (
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
 	github.com/golang/protobuf v1.2.0
 	github.com/hyperledger/fabric v1.4.1
+	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.4.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=

--- a/mod/peer/collections/dissemination/disseminationplan_test.go
+++ b/mod/peer/collections/dissemination/disseminationplan_test.go
@@ -9,13 +9,57 @@ package dissemination
 import (
 	"testing"
 
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/extensions/collections/api/dissemination"
+	"github.com/hyperledger/fabric/gossip/protoext"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDisseminationPlan(t *testing.T) {
-	assert.PanicsWithValue(t, "not implemented",
-		func() {
-			ComputeDisseminationPlan("testchannel", "ns1", nil, nil, nil, nil, nil)
-		},
+	const (
+		channelID = "testchannel"
+		ns        = "ns1"
 	)
+
+	computeTransientDataDisseminationPlan = func(
+		channelID, ns string,
+		rwSet *rwset.CollectionPvtReadWriteSet,
+		colAP privdata.CollectionAccessPolicy,
+		pvtDataMsg *protoext.SignedGossipMessage,
+		gossipAdapter gossipAdapter) ([]*dissemination.Plan, bool, error) {
+		return nil, false, nil
+	}
+
+	t.Run("Empty config", func(t *testing.T) {
+		colConfig1 := &common.CollectionConfig{}
+		_, _, err := ComputeDisseminationPlan(
+			channelID, ns, nil, colConfig1, nil, nil, nil)
+		assert.EqualError(t, err, "static collection config not defined")
+	})
+
+	t.Run("Unknown config", func(t *testing.T) {
+		colConfig2 := &common.CollectionConfig{
+			Payload: &common.CollectionConfig_StaticCollectionConfig{
+				StaticCollectionConfig: &common.StaticCollectionConfig{},
+			},
+		}
+		_, _, err := ComputeDisseminationPlan(
+			channelID, ns, nil, colConfig2, nil, nil, nil)
+		assert.EqualError(t, err, "unsupported collection type: [COL_UNKNOWN]")
+	})
+
+	t.Run("Transient Data config", func(t *testing.T) {
+		transientConfig := &common.CollectionConfig{
+			Payload: &common.CollectionConfig_StaticCollectionConfig{
+				StaticCollectionConfig: &common.StaticCollectionConfig{
+					Type: common.CollectionType_COL_TRANSIENT,
+				},
+			},
+		}
+		_, _, err := ComputeDisseminationPlan(
+			channelID, ns, nil, transientConfig, nil, nil, nil)
+		assert.NoError(t, err)
+	})
 }

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -1,3 +1,7 @@
+// Copyright SecureKey Technologies Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190510235640-ff89b7580e81
@@ -9,6 +13,7 @@ replace github.com/trustbloc/fabric-peer-ext => ../..
 require (
 	github.com/hyperledger/fabric v1.4.1
 	github.com/hyperledger/fabric/extensions v0.0.0
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
 	github.com/stretchr/testify v1.3.0
 	github.com/trustbloc/fabric-peer-ext v0.0.0

--- a/pkg/collections/transientdata/dissemination/disseminationplan.go
+++ b/pkg/collections/transientdata/dissemination/disseminationplan.go
@@ -1,0 +1,92 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dissemination
+
+import (
+	protobuf "github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/extensions/collections/api/dissemination"
+	gossipapi "github.com/hyperledger/fabric/gossip/api"
+	"github.com/hyperledger/fabric/gossip/common"
+	gdiscovery "github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/hyperledger/fabric/gossip/gossip"
+	"github.com/hyperledger/fabric/gossip/protoext"
+	"github.com/hyperledger/fabric/protos/ledger/rwset"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+)
+
+type gossipAdapter interface {
+	PeersOfChannel(common.ChainID) []gdiscovery.NetworkMember
+	SelfMembershipInfo() gdiscovery.NetworkMember
+	IdentityInfo() gossipapi.PeerIdentitySet
+}
+
+// ComputeDisseminationPlan returns the dissemination plan for transient data
+func ComputeDisseminationPlan(
+	channelID, ns string,
+	rwSet *rwset.CollectionPvtReadWriteSet,
+	colAP privdata.CollectionAccessPolicy,
+	pvtDataMsg *protoext.SignedGossipMessage,
+	gossipAdapter gossipAdapter) ([]*dissemination.Plan, bool, error) {
+	logger.Debugf("Computing transient data dissemination plan for [%s:%s]", ns, rwSet.CollectionName)
+
+	disseminator := New(channelID, ns, rwSet.CollectionName, colAP, gossipAdapter)
+
+	kvRwSet := &kvrwset.KVRWSet{}
+	if err := protobuf.Unmarshal(rwSet.Rwset, kvRwSet); err != nil {
+		return nil, true, errors.WithMessage(err, "error unmarshalling KV read/write set for transient data")
+	}
+
+	var endorsers discovery.PeerGroup
+	for _, kvWrite := range kvRwSet.Writes {
+		if kvWrite.IsDelete {
+			continue
+		}
+		endorsersForKey, err := disseminator.ResolveEndorsers(kvWrite.Key)
+		if err != nil {
+			return nil, true, errors.WithMessage(err, "error resolving endorsers for transient data")
+		}
+
+		logger.Debugf("Endorsers for key [%s:%s:%s]: %s", ns, rwSet.CollectionName, kvWrite.Key, endorsersForKey)
+
+		for _, endorser := range endorsersForKey {
+			if endorser.Local {
+				logger.Debugf("Not adding local endorser for key [%s:%s:%s]", ns, rwSet.CollectionName, kvWrite.Key)
+				continue
+			}
+			endorsers = discovery.Merge(endorsers, endorser)
+		}
+	}
+
+	logger.Debugf("Endorsers for collection [%s:%s]: %s", ns, rwSet.CollectionName, endorsers)
+
+	routingFilter := func(member gdiscovery.NetworkMember) bool {
+		if endorsers.ContainsPeer(member.Endpoint) {
+			logger.Debugf("Peer [%s] is an endorser for [%s:%s]", member.Endpoint, ns, rwSet.CollectionName)
+			return true
+		}
+
+		logger.Debugf("Peer [%s] is NOT an endorser for [%s:%s]", member.Endpoint, ns, rwSet.CollectionName)
+		return false
+	}
+
+	sc := gossip.SendCriteria{
+		Timeout:    viper.GetDuration("peer.gossip.pvtData.pushAckTimeout"),
+		Channel:    common.ChainID(channelID),
+		MaxPeers:   colAP.MaximumPeerCount(),
+		MinAck:     colAP.RequiredPeerCount(),
+		IsEligible: routingFilter,
+	}
+
+	return []*dissemination.Plan{{
+		Criteria: sc,
+		Msg:      pvtDataMsg,
+	}}, true, nil
+}

--- a/pkg/collections/transientdata/dissemination/disseminator.go
+++ b/pkg/collections/transientdata/dissemination/disseminator.go
@@ -1,0 +1,135 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dissemination
+
+import (
+	"hash/fnv"
+	"sort"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+var logger = flogging.MustGetLogger("transientdata")
+
+// Disseminator disseminates transient data to a deterministic set of endorsers
+type Disseminator struct {
+	*discovery.Discovery
+	namespace  string
+	collection string
+	policy     privdata.CollectionAccessPolicy
+}
+
+// New returns a new transient data disseminator
+func New(channelID, namespace, collection string, policy privdata.CollectionAccessPolicy, gossip gossipAdapter) *Disseminator {
+	return &Disseminator{
+		Discovery:  discovery.New(channelID, gossip),
+		namespace:  namespace,
+		collection: collection,
+		policy:     policy,
+	}
+}
+
+// ResolveEndorsers resolves to a set of endorsers to which transient data should be disseminated
+func (d *Disseminator) ResolveEndorsers(key string) (discovery.PeerGroup, error) {
+	h, err := getHash32(key)
+	if err != nil {
+		return nil, errors.WithMessage(err, "error computing int32 hash of key")
+	}
+
+	orgs := d.chooseOrgs(h)
+
+	logger.Debugf("[%s] Chosen orgs: %s", d.ChannelID(), orgs)
+
+	endorsers := d.chooseEndorsers(h, orgs)
+
+	logger.Debugf("[%s] Chosen endorsers from orgs %s: %s", d.ChannelID(), orgs, endorsers)
+	return endorsers, nil
+}
+
+func (d *Disseminator) chooseEndorsers(h uint32, orgs []string) discovery.PeerGroup {
+	var endorsers discovery.PeerGroup
+
+	for i := 0; i < d.policy.MaximumPeerCount(); i++ {
+		for _, org := range orgs {
+			if len(endorsers) == d.policy.MaximumPeerCount() {
+				// We have enough endorsers
+				break
+			}
+
+			// Get a sorted list of endorsers for the org
+			endorsersForOrg := d.getEndorsers(org).Sort()
+			if len(endorsersForOrg) == 0 {
+				logger.Debugf("[%s] There are no endorsers in org [%s]", d.ChannelID(), org)
+				continue
+			}
+
+			logger.Debugf("[%s] Endorsers for [%s]: %s", d.ChannelID(), org, endorsersForOrg)
+
+			// Deterministically choose an endorser
+			endorserForOrg := endorsersForOrg[(int(h)+i)%len(endorsersForOrg)]
+			if endorsers.Contains(endorserForOrg) {
+				logger.Debugf("[%s] Will not add endorser [%s] from org [%s] since it is already added", d.ChannelID(), endorserForOrg, org)
+				continue
+			}
+
+			endorsers = append(endorsers, endorserForOrg)
+		}
+	}
+	return endorsers
+}
+
+func (d *Disseminator) getEndorsers(mspID string) discovery.PeerGroup {
+	return d.GetMembers(func(m *discovery.Member) bool {
+		if m.MSPID != mspID {
+			logger.Debugf("[%s] Not adding peer [%s] as an endorser since it is not in org [%s]", d.ChannelID(), m.Endpoint, mspID)
+			return false
+		}
+		if !m.HasRole(roles.EndorserRole) {
+			logger.Debugf("[%s] Not adding peer [%s] as an endorser since it does not have the endorser role", d.ChannelID(), m.Endpoint)
+			return false
+		}
+		return true
+	})
+
+}
+
+func (d *Disseminator) chooseOrgs(h uint32) []string {
+	memberOrgs := d.policy.MemberOrgs()
+	numOrgs := min(d.policy.MaximumPeerCount(), len(memberOrgs))
+
+	// Copy and sort the orgs
+	var sortedOrgs []string
+	sortedOrgs = append(sortedOrgs, memberOrgs...)
+	sort.Strings(sortedOrgs)
+
+	var chosenOrgs []string
+	for i := 0; i < numOrgs; i++ {
+		chosenOrgs = append(chosenOrgs, sortedOrgs[(int(h)+i)%len(sortedOrgs)])
+	}
+
+	return chosenOrgs
+}
+
+func getHash32(key string) (uint32, error) {
+	h := fnv.New32a()
+	_, err := h.Write([]byte(key))
+	if err != nil {
+		return 0, err
+	}
+	return h.Sum32(), nil
+}
+
+func min(i, j int) int {
+	if i < j {
+		return i
+	}
+	return j
+}

--- a/pkg/collections/transientdata/dissemination/disseminator_test.go
+++ b/pkg/collections/transientdata/dissemination/disseminator_test.go
@@ -1,0 +1,316 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dissemination
+
+import (
+	"os"
+	"testing"
+
+	gcommon "github.com/hyperledger/fabric/gossip/common"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+var (
+	ns1   = "chaincode1"
+	ns2   = "chaincode2"
+	coll1 = "collection1"
+	coll2 = "collection2"
+	key1  = "key1"
+	key2  = "key2"
+
+	org1MSPID      = "Org1MSP"
+	p1Org1Endpoint = "p1.org1.com"
+	p1Org1PKIID    = gcommon.PKIidType("pkiid_P1O1")
+	p2Org1Endpoint = "p2.org1.com"
+	p2Org1PKIID    = gcommon.PKIidType("pkiid_P2O1")
+	p3Org1Endpoint = "p3.org1.com"
+	p3Org1PKIID    = gcommon.PKIidType("pkiid_P3O1")
+
+	org2MSPID      = "Org2MSP"
+	p1Org2Endpoint = "p1.org2.com"
+	p1Org2PKIID    = gcommon.PKIidType("pkiid_P1O2")
+	p2Org2Endpoint = "p2.org2.com"
+	p2Org2PKIID    = gcommon.PKIidType("pkiid_P2O2")
+	p3Org2Endpoint = "p3.org2.com"
+	p3Org2PKIID    = gcommon.PKIidType("pkiid_P3O2")
+
+	org3MSPID      = "Org3MSP"
+	p1Org3Endpoint = "p1.org3.com"
+	p1Org3PKIID    = gcommon.PKIidType("pkiid_P1O3")
+	p2Org3Endpoint = "p2.org3.com"
+	p2Org3PKIID    = gcommon.PKIidType("pkiid_P2O3")
+	p3Org3Endpoint = "p3.org3.com"
+	p3Org3PKIID    = gcommon.PKIidType("pkiid_P3O3")
+
+	validatorRole = string(roles.ValidatorRole)
+	endorserRole  = string(roles.EndorserRole)
+)
+
+func TestDissemination(t *testing.T) {
+	channelID := "testchannel"
+
+	gossip := mocks.NewMockGossipAdapter().
+		Self(org1MSPID, mocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+		Member(org1MSPID, mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, validatorRole)).
+		Member(org1MSPID, mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, validatorRole)).
+		Member(org2MSPID, mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)).
+		Member(org2MSPID, mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, validatorRole)).
+		Member(org2MSPID, mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p1Org3Endpoint, p1Org3PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p2Org3Endpoint, p2Org3PKIID, validatorRole)).
+		Member(org3MSPID, mocks.NewMember(p3Org3Endpoint, p3Org3PKIID, endorserRole))
+
+	t.Run("2 peers", func(t *testing.T) {
+		maxPeers := 2
+
+		d := New(channelID, ns1, coll1,
+			&mocks.MockAccessPolicy{
+				ReqPeerCount: 1,
+				MaxPeerCount: maxPeers,
+				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+			}, gossip)
+
+		// key1
+		endorsers, err := d.ResolveEndorsers(key1)
+		require.NoError(t, err)
+		require.Equal(t, maxPeers, len(endorsers))
+
+		t.Logf("Endorsers: %s", endorsers)
+
+		assert.Equal(t, p3Org3Endpoint, endorsers[0].Endpoint)
+		assert.Equal(t, p1Org1Endpoint, endorsers[1].Endpoint)
+
+		// key2
+		endorsers, err = d.ResolveEndorsers(key2)
+		require.NoError(t, err)
+		require.Equal(t, maxPeers, len(endorsers))
+
+		t.Logf("Endorsers: %s", endorsers)
+
+		assert.Equal(t, p1Org2Endpoint, endorsers[0].Endpoint)
+		assert.Equal(t, p1Org3Endpoint, endorsers[1].Endpoint)
+	})
+
+	t.Run("5 peers", func(t *testing.T) {
+		maxPeers := 5
+
+		d := New(channelID, ns1, coll1,
+			&mocks.MockAccessPolicy{
+				ReqPeerCount: 1,
+				MaxPeerCount: maxPeers,
+				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+			}, gossip)
+
+		// key1
+		endorsers, err := d.ResolveEndorsers(key1)
+		require.NoError(t, err)
+		require.Equal(t, maxPeers, len(endorsers))
+
+		t.Logf("Endorsers: %s", endorsers)
+
+		assert.Equal(t, p3Org3Endpoint, endorsers[0].Endpoint)
+		assert.Equal(t, p1Org1Endpoint, endorsers[1].Endpoint)
+		assert.Equal(t, p3Org2Endpoint, endorsers[2].Endpoint)
+		assert.Equal(t, p1Org3Endpoint, endorsers[3].Endpoint)
+		assert.Equal(t, p1Org2Endpoint, endorsers[4].Endpoint)
+	})
+
+	t.Run("Not enough peers", func(t *testing.T) {
+		maxPeers := 6
+
+		d := New(channelID, ns1, coll1,
+			&mocks.MockAccessPolicy{
+				ReqPeerCount: 1,
+				MaxPeerCount: maxPeers,
+				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+			}, gossip)
+
+		// key1
+		endorsers, err := d.ResolveEndorsers(key1)
+		require.NoError(t, err)
+		require.Equal(t, 5, len(endorsers))
+
+		t.Logf("Endorsers: %s", endorsers)
+
+		assert.Equal(t, p3Org3Endpoint, endorsers[0].Endpoint)
+		assert.Equal(t, p1Org1Endpoint, endorsers[1].Endpoint)
+		assert.Equal(t, p3Org2Endpoint, endorsers[2].Endpoint)
+		assert.Equal(t, p1Org3Endpoint, endorsers[3].Endpoint)
+		assert.Equal(t, p1Org2Endpoint, endorsers[4].Endpoint)
+	})
+
+	t.Run("Subset of orgs", func(t *testing.T) {
+		maxPeers := 3
+
+		d := New(channelID, ns1, coll1,
+			&mocks.MockAccessPolicy{
+				ReqPeerCount: 1,
+				MaxPeerCount: maxPeers,
+				Orgs:         []string{org2MSPID, org3MSPID},
+			}, gossip)
+
+		// key1
+		endorsers, err := d.ResolveEndorsers(key1)
+		require.NoError(t, err)
+		require.Equal(t, maxPeers, len(endorsers))
+
+		t.Logf("Endorsers: %s", endorsers)
+
+		assert.Equal(t, p3Org3Endpoint, endorsers[0].Endpoint)
+		assert.Equal(t, p3Org2Endpoint, endorsers[1].Endpoint)
+		assert.Equal(t, p1Org3Endpoint, endorsers[2].Endpoint)
+	})
+}
+
+func TestComputeDisseminationPlan(t *testing.T) {
+	channelID := "testchannel"
+
+	p1Org1 := mocks.NewMember(p1Org1Endpoint, p1Org1PKIID, endorserRole)
+	p2Org1 := mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, endorserRole)
+	p3Org1 := mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, validatorRole)
+	p1Org2 := mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)
+	p2Org2 := mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, validatorRole)
+	p3Org2 := mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole)
+	p1Org3 := mocks.NewMember(p1Org3Endpoint, p1Org3PKIID, endorserRole)
+	p2Org3 := mocks.NewMember(p2Org3Endpoint, p2Org3PKIID, validatorRole)
+	p3Org3 := mocks.NewMember(p3Org3Endpoint, p3Org3PKIID, endorserRole)
+
+	gossip := mocks.NewMockGossipAdapter().
+		Self(org1MSPID, p1Org1).
+		Member(org1MSPID, p2Org1).
+		Member(org1MSPID, p3Org1).
+		Member(org2MSPID, p1Org2).
+		Member(org2MSPID, p2Org2).
+		Member(org2MSPID, p3Org2).
+		Member(org3MSPID, p1Org3).
+		Member(org3MSPID, p2Org3).
+		Member(org3MSPID, p3Org3)
+
+	t.Run("Orgs: 2, Max Peers: 2, Keys: 1", func(t *testing.T) {
+		maxPeers := 2
+
+		colAP := &mocks.MockAccessPolicy{
+			ReqPeerCount: 1,
+			MaxPeerCount: maxPeers,
+			Orgs:         []string{org2MSPID, org3MSPID},
+		}
+
+		coll1Builder := mocks.NewPvtReadWriteSetCollectionBuilder(coll1)
+		coll1Builder.
+			Write(key1, []byte("value1")).
+			Delete(key2) // Deletes should be ignored
+
+		rwSet := coll1Builder.Build()
+
+		dPlan, handled, err := ComputeDisseminationPlan(channelID, ns1, rwSet, colAP, nil, gossip)
+		require.NoError(t, err)
+		require.True(t, handled)
+		require.Equal(t, 1, len(dPlan))
+
+		criteria := dPlan[0].Criteria
+
+		assert.Equal(t, maxPeers, criteria.MaxPeers)
+
+		assert.False(t, criteria.IsEligible(p1Org1))
+		assert.False(t, criteria.IsEligible(p2Org1))
+		assert.False(t, criteria.IsEligible(p3Org1))
+		assert.False(t, criteria.IsEligible(p1Org2))
+		assert.False(t, criteria.IsEligible(p2Org2))
+		assert.True(t, criteria.IsEligible(p3Org2))
+		assert.False(t, criteria.IsEligible(p1Org3))
+		assert.False(t, criteria.IsEligible(p2Org3))
+		assert.True(t, criteria.IsEligible(p3Org3))
+	})
+
+	t.Run("Orgs: 3, Max Peers: 3, Keys: 1", func(t *testing.T) {
+		maxPeers := 3
+
+		colAP := &mocks.MockAccessPolicy{
+			ReqPeerCount: 1,
+			MaxPeerCount: maxPeers,
+			Orgs:         []string{org2MSPID, org3MSPID},
+		}
+
+		coll1Builder := mocks.NewPvtReadWriteSetCollectionBuilder(coll1)
+		coll1Builder.
+			Write(key1, []byte("value1"))
+
+		rwSet := coll1Builder.Build()
+
+		dPlan, handled, err := ComputeDisseminationPlan(channelID, ns1, rwSet, colAP, nil, gossip)
+		require.NoError(t, err)
+		require.True(t, handled)
+		require.Equal(t, 1, len(dPlan))
+
+		criteria := dPlan[0].Criteria
+
+		assert.Equal(t, maxPeers, criteria.MaxPeers)
+
+		// The transient data should be stored to p1Org1 and p3Org3 but, since p1Org1 is
+		// a local peer, it is not included in the dissemination plan.
+		assert.False(t, criteria.IsEligible(p1Org1))
+		assert.False(t, criteria.IsEligible(p2Org1))
+		assert.False(t, criteria.IsEligible(p3Org1))
+		assert.False(t, criteria.IsEligible(p1Org2))
+		assert.False(t, criteria.IsEligible(p2Org2))
+		assert.True(t, criteria.IsEligible(p3Org2))
+		assert.True(t, criteria.IsEligible(p1Org3))
+		assert.False(t, criteria.IsEligible(p2Org3))
+		assert.True(t, criteria.IsEligible(p3Org3))
+	})
+
+	t.Run("Orgs: 3, Max Peers: 2, Keys: 2", func(t *testing.T) {
+		maxPeers := 2
+
+		colAP := &mocks.MockAccessPolicy{
+			ReqPeerCount: 1,
+			MaxPeerCount: maxPeers,
+			Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+		}
+
+		coll1Builder := mocks.NewPvtReadWriteSetCollectionBuilder(coll1)
+		coll1Builder.
+			Write(key1, []byte("value1")).
+			Write(key2, []byte("value2"))
+
+		rwSet := coll1Builder.Build()
+
+		dPlan, handled, err := ComputeDisseminationPlan(channelID, ns1, rwSet, colAP, nil, gossip)
+		require.NoError(t, err)
+		require.True(t, handled)
+		require.Equal(t, 1, len(dPlan))
+
+		criteria := dPlan[0].Criteria
+
+		assert.Equal(t, maxPeers, criteria.MaxPeers)
+
+		// The transient data for:
+		// - key1: p2Org1, p3Org3
+		// - key2: p1Org2, p1Org3
+		// Since p1Org1 is a local peer, it's not included in the dissemination plan.
+		// So the data should be disseminated to p2Org1, p3Org3, p1Org2, and p1Org3
+		assert.False(t, criteria.IsEligible(p1Org1))
+		assert.True(t, criteria.IsEligible(p2Org1))
+		assert.False(t, criteria.IsEligible(p3Org1))
+		assert.True(t, criteria.IsEligible(p1Org2))
+		assert.False(t, criteria.IsEligible(p2Org2))
+		assert.False(t, criteria.IsEligible(p3Org2))
+		assert.True(t, criteria.IsEligible(p1Org3))
+		assert.False(t, criteria.IsEligible(p2Org3))
+		assert.True(t, criteria.IsEligible(p3Org3))
+	})
+}
+
+func TestMain(m *testing.M) {
+	viper.SetDefault("ledger.roles", "committer,endorser")
+
+	os.Exit(m.Run())
+}

--- a/pkg/common/discovery/discovery.go
+++ b/pkg/common/discovery/discovery.go
@@ -1,0 +1,123 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"sync"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/gossip/api"
+	"github.com/hyperledger/fabric/gossip/common"
+	"github.com/hyperledger/fabric/gossip/discovery"
+	proto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+var logger = flogging.MustGetLogger("discovery")
+
+// Discovery provides functions to retrieve info about the local peer and other peers in a given channel
+type Discovery struct {
+	channelID string
+	gossip    gossipAdapter
+	self      *Member
+	selfInit  sync.Once
+}
+
+// New returns a new Discovery
+func New(channelID string, gossip gossipAdapter) *Discovery {
+	return &Discovery{
+		channelID: channelID,
+		gossip:    gossip,
+	}
+}
+
+type filter func(m *Member) bool
+
+type gossipAdapter interface {
+	PeersOfChannel(common.ChainID) []discovery.NetworkMember
+	SelfMembershipInfo() discovery.NetworkMember
+	IdentityInfo() api.PeerIdentitySet
+}
+
+// Self returns the local peer
+func (r *Discovery) Self() *Member {
+	r.selfInit.Do(func() {
+		r.self = getSelf(r.channelID, r.gossip)
+	})
+	return r.self
+}
+
+// ChannelID returns the channel ID
+func (r *Discovery) ChannelID() string {
+	return r.channelID
+}
+
+// GetMembers returns members filtered by the given filter
+func (r *Discovery) GetMembers(accept filter) []*Member {
+	identityInfo := r.gossip.IdentityInfo()
+	mapByID := identityInfo.ByID()
+
+	var peers []*Member
+	for _, m := range r.gossip.PeersOfChannel(common.ChainID(r.channelID)) {
+		identity, ok := mapByID[string(m.PKIid)]
+		if !ok {
+			logger.Warningf("[%s] Not adding peer [%s] as a validator since unable to determine MSP ID from PKIID for [%s]", r.channelID, m.Endpoint)
+			continue
+		}
+
+		m := &Member{
+			NetworkMember: m,
+			MSPID:         string(identity.Organization),
+		}
+
+		if accept(m) {
+			peers = append(peers, m)
+		}
+	}
+
+	if accept(r.Self()) {
+		peers = append(peers, r.Self())
+	}
+
+	return peers
+}
+
+// GetMSPID gets the MSP id
+func (r *Discovery) GetMSPID(pkiID common.PKIidType) (string, bool) {
+	identityInfo := r.gossip.IdentityInfo()
+	mapByID := identityInfo.ByID()
+
+	identity, ok := mapByID[string(pkiID)]
+	if !ok {
+		return "", false
+	}
+	return string(identity.Organization), true
+}
+
+func getSelf(channelID string, gossip gossipAdapter) *Member {
+	self := gossip.SelfMembershipInfo()
+	self.Properties = &proto.Properties{
+		Roles: roles.AsString(),
+	}
+
+	identityInfo := gossip.IdentityInfo()
+	mapByID := identityInfo.ByID()
+
+	var mspID string
+	selfIdentity, ok := mapByID[string(self.PKIid)]
+	if ok {
+		mspID = string(selfIdentity.Organization)
+	} else {
+		logger.Warningf("[%s] Unable to determine MSP ID from PKIID for self", channelID)
+	}
+
+	return &Member{
+		NetworkMember: self,
+		MSPID:         mspID,
+		Local:         true,
+	}
+}

--- a/pkg/common/discovery/discovery_test.go
+++ b/pkg/common/discovery/discovery_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"testing"
+
+	gcommon "github.com/hyperledger/fabric/gossip/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+const (
+	channelID = "testchannel"
+
+	ns1   = "chaincode1"
+	ns2   = "chaincode2"
+	coll1 = "collection1"
+	coll2 = "collection2"
+	key1  = "key1"
+	key2  = "key2"
+)
+
+var (
+	org1MSPID      = "Org1MSP"
+	p1Org1Endpoint = "p1.org1.com"
+	p1Org1PKIID    = gcommon.PKIidType("pkiid_P1O1")
+	p2Org1Endpoint = "p2.org1.com"
+	p2Org1PKIID    = gcommon.PKIidType("pkiid_P2O1")
+	p3Org1Endpoint = "p3.org1.com"
+	p3Org1PKIID    = gcommon.PKIidType("pkiid_P3O1")
+
+	org2MSPID      = "Org2MSP"
+	p1Org2Endpoint = "p1.org2.com"
+	p1Org2PKIID    = gcommon.PKIidType("pkiid_P1O2")
+	p2Org2Endpoint = "p2.org2.com"
+	p2Org2PKIID    = gcommon.PKIidType("pkiid_P2O2")
+	p3Org2Endpoint = "p3.org2.com"
+	p3Org2PKIID    = gcommon.PKIidType("pkiid_P3O2")
+
+	org3MSPID      = "Org3MSP"
+	p1Org3Endpoint = "p1.org3.com"
+	p1Org3PKIID    = gcommon.PKIidType("pkiid_P1O3")
+	p2Org3Endpoint = "p2.org3.com"
+	p2Org3PKIID    = gcommon.PKIidType("pkiid_P2O3")
+	p3Org3Endpoint = "p3.org3.com"
+	p3Org3PKIID    = gcommon.PKIidType("pkiid_P3O3")
+
+	validatorRole = string(roles.ValidatorRole)
+	endorserRole  = string(roles.EndorserRole)
+)
+
+func TestDiscovery(t *testing.T) {
+	p1Org1 := mocks.NewMember(p1Org1Endpoint, p1Org1PKIID, endorserRole)
+	p2Org1 := mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, endorserRole)
+	p3Org1 := mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, validatorRole)
+	p1Org2 := mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)
+	p2Org2 := mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, validatorRole)
+	p3Org2 := mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole)
+	p1Org3 := mocks.NewMember(p1Org3Endpoint, p1Org3PKIID, endorserRole)
+	p2Org3 := mocks.NewMember(p2Org3Endpoint, p2Org3PKIID, validatorRole)
+	p3Org3 := mocks.NewMember(p3Org3Endpoint, p3Org3PKIID, endorserRole)
+	pInvalid := mocks.NewMember("invalid", gcommon.PKIidType("invalid"), endorserRole)
+
+	gossip := mocks.NewMockGossipAdapter().
+		Self(org1MSPID, p1Org1).
+		Member(org1MSPID, p2Org1).
+		Member(org1MSPID, p3Org1).
+		Member(org2MSPID, p1Org2).
+		Member(org2MSPID, p2Org2).
+		Member(org2MSPID, p3Org2).
+		Member(org3MSPID, p1Org3).
+		Member(org3MSPID, p2Org3).
+		Member(org3MSPID, p3Org3).
+		MemberWithNoPKIID(org3MSPID, pInvalid) // Should be ignored
+
+	d := New(channelID, gossip)
+
+	t.Run("ChannelID", func(t *testing.T) {
+		assert.Equal(t, channelID, d.ChannelID())
+	})
+
+	t.Run("Self", func(t *testing.T) {
+		s := d.Self()
+		assert.NotNil(t, s)
+		assert.Equal(t, p1Org1.Endpoint, s.Endpoint)
+	})
+
+	t.Run("GetMSPID", func(t *testing.T) {
+		mspID, ok := d.GetMSPID(p1Org1PKIID)
+		assert.True(t, ok)
+		assert.Equal(t, org1MSPID, mspID)
+
+		mspID, ok = d.GetMSPID(gcommon.PKIidType("pkiid_UNKNOWN"))
+		assert.False(t, ok)
+	})
+
+	t.Run("GetMembers", func(t *testing.T) {
+		f := func(m *Member) bool {
+			return m.HasRole(roles.EndorserRole)
+		}
+		members := d.GetMembers(f)
+		assert.Equal(t, 6, len(members))
+
+		expectedEndpoints := []string{p1Org1Endpoint, p2Org1Endpoint, p1Org2Endpoint, p3Org2Endpoint, p1Org3Endpoint, p3Org3Endpoint}
+
+		for _, m := range members {
+			assert.True(t, contains(expectedEndpoints, m.Endpoint))
+		}
+
+		memberEndpoints := asEndpoints(members...)
+		for _, e := range expectedEndpoints {
+			assert.True(t, contains(memberEndpoints, e))
+		}
+	})
+}
+
+func contains(endpoints []string, endpoint string) bool {
+	for _, e := range endpoints {
+		if endpoint == e {
+			return true
+		}
+	}
+	return false
+}
+
+func asEndpoints(members ...*Member) []string {
+	endpoints := make([]string, len(members))
+	for i, m := range members {
+		endpoints[i] = m.Endpoint
+	}
+	return endpoints
+}

--- a/pkg/common/discovery/member.go
+++ b/pkg/common/discovery/member.go
@@ -1,0 +1,38 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+// Member wraps a NetworkMember and provides additional info
+type Member struct {
+	discovery.NetworkMember
+	ChannelID string
+	MSPID     string
+	Local     bool // Indicates whether this member is the local peer
+}
+
+func (m *Member) String() string {
+	return m.Endpoint
+}
+
+// Roles returns the roles of the peer
+func (m *Member) Roles() roles.Roles {
+	if m.Properties == nil {
+		logger.Debugf("[%s] Peer [%s] does not have any properties", m.ChannelID, m.Endpoint)
+		return nil
+	}
+	return roles.FromStrings(m.Properties.Roles...)
+}
+
+// HasRole returns true if the member has the given role
+func (m *Member) HasRole(role roles.Role) bool {
+	return m.Roles().Contains(role)
+}

--- a/pkg/common/discovery/member_test.go
+++ b/pkg/common/discovery/member_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/gossip/discovery"
+	proto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/stretchr/testify/assert"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+const (
+	org1MSP = "org1MSP"
+
+	p0Endpoint = "p0.org1.com"
+	p1Endpoint = "p1.org1.com"
+	p2Endpoint = "p2.org1.com"
+	p3Endpoint = "p3.org1.com"
+	p4Endpoint = "p4.org1.com"
+	p5Endpoint = "p5.org1.com"
+	p6Endpoint = "p6.org1.com"
+	p7Endpoint = "p7.org1.com"
+
+	r1 = "role1"
+	r2 = "role2"
+	r3 = "role3"
+	r4 = "role4"
+
+	role1 = roles.Role(r1)
+	role2 = roles.Role(r2)
+	role3 = roles.Role(r3)
+	role4 = roles.Role(r4)
+)
+
+var (
+	p1 = newMember(org1MSP, p1Endpoint, false)
+	p2 = newMember(org1MSP, p2Endpoint, false, r2, r3, r4)
+	p3 = newMember(org1MSP, p3Endpoint, false)
+	p4 = newMember(org1MSP, p4Endpoint, false)
+	p5 = newMember(org1MSP, p5Endpoint, true)
+	p6 = newMember(org1MSP, p6Endpoint, false)
+	p7 = newMember(org1MSP, p7Endpoint, false)
+)
+
+func TestMember_HasRole(t *testing.T) {
+	assert.True(t, p1.HasRole(role1))
+	assert.False(t, p2.HasRole(role1))
+	assert.True(t, p2.HasRole(role2))
+}
+
+func TestMember_Roles(t *testing.T) {
+	assert.Empty(t, p1.Roles())
+
+	roles := p2.Roles()
+	assert.Equal(t, role2, roles[0])
+	assert.Equal(t, role3, roles[1])
+	assert.Equal(t, role4, roles[2])
+}
+
+func TestMember_String(t *testing.T) {
+	assert.Equal(t, p1.Endpoint, p1.String())
+}
+func newMember(mspID, endpoint string, local bool, roles ...string) *Member {
+	m := &Member{
+		NetworkMember: discovery.NetworkMember{
+			Endpoint: endpoint,
+		},
+		MSPID: mspID,
+		Local: local,
+	}
+	if roles != nil {
+		m.Properties = &proto.Properties{
+			Roles: roles,
+		}
+	}
+	return m
+}

--- a/pkg/common/discovery/peergroup.go
+++ b/pkg/common/discovery/peergroup.go
@@ -1,0 +1,136 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"math/rand"
+	"sort"
+)
+
+// PeerGroup is a group of peers
+type PeerGroup []*Member
+
+// ContainsLocal return true if one of the peers in the group is the local peer
+func (g PeerGroup) ContainsLocal() bool {
+	for _, p := range g {
+		if p.Local {
+			return true
+		}
+	}
+	return false
+}
+
+func (g PeerGroup) String() string {
+	s := "["
+	for i, p := range g {
+		s += p.String()
+		if i+1 < len(g) {
+			s += ", "
+		}
+	}
+	s += "]"
+	return s
+}
+
+// Sort sorts the peer group by endpoint
+func (g PeerGroup) Sort() PeerGroup {
+	sort.Sort(g)
+	return g
+}
+
+// ContainsAll returns true if ALL of the peers within the given peer group are contained within this peer group
+func (g PeerGroup) ContainsAll(peerGroup PeerGroup) bool {
+	for _, p := range peerGroup {
+		if !g.Contains(p) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainsAny returns true if ANY of the peers within the given peer group are contained within this peer group
+func (g PeerGroup) ContainsAny(peerGroup PeerGroup) bool {
+	for _, p := range peerGroup {
+		if g.Contains(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// Contains returns true if the given peer is contained within this peer group
+func (g PeerGroup) Contains(peer *Member) bool {
+	for _, p := range g {
+		if p.Endpoint == peer.Endpoint {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsPeer returns true if the given peer is contained within this peer group
+func (g PeerGroup) ContainsPeer(endpoint string) bool {
+	for _, p := range g {
+		if p.Endpoint == endpoint {
+			return true
+		}
+	}
+	return false
+}
+
+func (g PeerGroup) Len() int {
+	return len(g)
+}
+
+func (g PeerGroup) Less(i, j int) bool {
+	return g[i].Endpoint < g[j].Endpoint
+}
+
+func (g PeerGroup) Swap(i, j int) {
+	g[i], g[j] = g[j], g[i]
+}
+
+// Local returns the local peer from the group
+func (g PeerGroup) Local() (*Member, bool) {
+	for _, p := range g {
+		if p.Local {
+			return p, true
+		}
+	}
+	return nil, false
+}
+
+// Remote returns a PeerGroup subset that only includes remote peers
+func (g PeerGroup) Remote() PeerGroup {
+	var pg PeerGroup
+	for _, p := range g {
+		if !p.Local {
+			pg = append(pg, p)
+		}
+	}
+	return pg
+}
+
+// Shuffle returns a randomly shuffled PeerGroup
+func (g PeerGroup) Shuffle() PeerGroup {
+	var pg PeerGroup
+	for _, i := range rand.Perm(len(g)) {
+		pg = append(pg, g[i])
+	}
+
+	return pg
+}
+
+// Merge adds the given peers to the group if they don't already exist
+func Merge(g PeerGroup, peers ...*Member) PeerGroup {
+	for _, p := range peers {
+		if !g.Contains(p) {
+			g = append(g, p)
+		}
+	}
+	return g
+}

--- a/pkg/common/discovery/peergroup_test.go
+++ b/pkg/common/discovery/peergroup_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeerGroup_String(t *testing.T) {
+	pg := PeerGroup{p3, p1, p6, p5}
+	assert.Equal(t, "[p3.org1.com, p1.org1.com, p6.org1.com, p5.org1.com]", pg.String())
+}
+
+func TestPeerGroup_Sort(t *testing.T) {
+	pg := PeerGroup{p3, p1, p6, p5}
+	pg.Sort()
+
+	assert.Equal(t, p1, pg[0])
+	assert.Equal(t, p3, pg[1])
+	assert.Equal(t, p5, pg[2])
+	assert.Equal(t, p6, pg[3])
+}
+
+func TestPeerGroup_Contains(t *testing.T) {
+	pg1 := PeerGroup{p1, p2, p3}
+	pg2 := PeerGroup{p2, p3}
+	pg3 := PeerGroup{p2, p3, p4}
+	pg4 := PeerGroup{p4, p5}
+
+	assert.True(t, pg1.Contains(p1))
+	assert.True(t, pg1.Contains(p2))
+	assert.False(t, pg1.Contains(p4))
+	assert.True(t, pg1.ContainsAll(pg2))
+	assert.False(t, pg1.ContainsAll(pg3))
+	assert.True(t, pg1.ContainsAny(pg3))
+	assert.False(t, pg1.ContainsAny(pg4))
+}
+
+func TestPeerGroup_ContainsLocal(t *testing.T) {
+	pLocal := newMember(org1MSP, p0Endpoint, true)
+
+	pg1 := PeerGroup{p1, p2, p3, pLocal}
+	pg2 := PeerGroup{p2, p3, p4}
+
+	assert.True(t, pg1.ContainsLocal())
+	assert.False(t, pg2.ContainsLocal())
+}
+
+func TestPeerGroup_ContainsPeer(t *testing.T) {
+	pg := PeerGroup{p1, p2, p3}
+	assert.False(t, pg.ContainsPeer(p0Endpoint))
+	assert.True(t, pg.ContainsPeer(p1Endpoint))
+	assert.True(t, pg.ContainsPeer(p2Endpoint))
+	assert.True(t, pg.ContainsPeer(p3Endpoint))
+}
+
+func TestPeerGroup_Local(t *testing.T) {
+	pg := PeerGroup{p1, p2, p3, p4, p5, p6}
+	p, ok := pg.Local()
+	assert.True(t, ok)
+	assert.Equal(t, p5, p)
+
+	pg = PeerGroup{p1, p2, p3, p4, p6}
+	p, ok = pg.Local()
+	assert.False(t, ok)
+	assert.Nil(t, p)
+}
+
+func TestPeerGroup_Remote(t *testing.T) {
+	pg := PeerGroup{p1, p2, p3, p4, p5, p6}
+	for _, pg := range pg.Remote() {
+		assert.False(t, pg.Local)
+	}
+}
+
+func TestMerge(t *testing.T) {
+	pg1 := PeerGroup{p1, p2, p3}
+	pg := Merge(pg1, p2, p3, p4)
+	assert.Equal(t, p1, pg[0])
+	assert.Equal(t, p2, pg[1])
+	assert.Equal(t, p3, pg[2])
+	assert.Equal(t, p4, pg[3])
+}
+
+func TestPeerGroup_Shuffle(t *testing.T) {
+	pg := PeerGroup{p1, p2, p3, p4, p5, p6}
+
+	chosen := make(map[string]struct{})
+
+	for i := 0; i < 10; i++ {
+		pgShuffled := pg.Shuffle()
+		assert.True(t, pgShuffled.ContainsAll(pg))
+		chosen[pgShuffled[0].Endpoint] = struct{}{}
+	}
+
+	assert.Truef(t, len(chosen) > 1, "Expecting that the first peer is not always the same one.")
+}

--- a/pkg/mocks/mockaccesspolicy.go
+++ b/pkg/mocks/mockaccesspolicy.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/protoutil"
+)
+
+// MockAccessPolicy implements a mock CollectionAccessPolicy
+type MockAccessPolicy struct {
+	ReqPeerCount int
+	MaxPeerCount int
+	Orgs         []string
+	OnlyRead     bool
+	OnlyWrite    bool
+	Filter       privdata.Filter
+}
+
+// AccessFilter returns a member filter function for a collection
+func (m *MockAccessPolicy) AccessFilter() privdata.Filter {
+	if m.Filter == nil {
+		return func(protoutil.SignedData) bool { return true }
+	}
+	return m.Filter
+}
+
+// RequiredPeerCount The minimum number of peers private data will be sent to upon
+// endorsement. The endorsement would fail if dissemination to at least
+// this number of peers is not achieved.
+func (m *MockAccessPolicy) RequiredPeerCount() int {
+	return m.ReqPeerCount
+}
+
+// MaximumPeerCount The maximum number of peers that private data will be sent to
+// upon endorsement. This number has to be bigger than RequiredPeerCount().
+func (m *MockAccessPolicy) MaximumPeerCount() int {
+	return m.MaxPeerCount
+}
+
+// MemberOrgs returns the collection's members as MSP IDs. This serves as
+// a human-readable way of quickly identifying who is part of a collection.
+func (m *MockAccessPolicy) MemberOrgs() []string {
+	return m.Orgs
+}
+
+// IsMemberOnlyRead returns a true if only collection members can read
+// the private data
+func (m *MockAccessPolicy) IsMemberOnlyRead() bool {
+	return m.OnlyRead
+}
+
+// IsMemberOnlyWrite returns a true if only collection members can write
+// the private data
+func (m *MockAccessPolicy) IsMemberOnlyWrite() bool {
+	return m.OnlyWrite
+}

--- a/pkg/mocks/mockgossipadapter.go
+++ b/pkg/mocks/mockgossipadapter.go
@@ -1,0 +1,96 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	gossipapi "github.com/hyperledger/fabric/gossip/api"
+	"github.com/hyperledger/fabric/gossip/comm"
+	"github.com/hyperledger/fabric/gossip/common"
+	"github.com/hyperledger/fabric/gossip/discovery"
+	gossipproto "github.com/hyperledger/fabric/protos/gossip"
+)
+
+// MessageHandler defines a function that handles a gossip message.
+type MessageHandler func(msg *gossipproto.GossipMessage)
+
+// MockGossipAdapter is the gossip adapter
+type MockGossipAdapter struct {
+	self        discovery.NetworkMember
+	members     []discovery.NetworkMember
+	identitySet gossipapi.PeerIdentitySet
+	handler     MessageHandler
+}
+
+// NewMockGossipAdapter returns the adapter
+func NewMockGossipAdapter() *MockGossipAdapter {
+	return &MockGossipAdapter{}
+}
+
+// Self discovers a network member
+func (m *MockGossipAdapter) Self(mspID string, self discovery.NetworkMember) *MockGossipAdapter {
+	m.self = self
+	m.identitySet = append(m.identitySet, gossipapi.PeerIdentityInfo{
+		PKIId:        self.PKIid,
+		Organization: []byte(mspID),
+	})
+	return m
+}
+
+// Member adds the network member
+func (m *MockGossipAdapter) Member(mspID string, member discovery.NetworkMember) *MockGossipAdapter {
+	m.members = append(m.members, member)
+	m.identitySet = append(m.identitySet, gossipapi.PeerIdentityInfo{
+		PKIId:        member.PKIid,
+		Organization: []byte(mspID),
+	})
+	return m
+}
+
+// MemberWithNoPKIID appends the member
+func (m *MockGossipAdapter) MemberWithNoPKIID(mspID string, member discovery.NetworkMember) *MockGossipAdapter {
+	m.members = append(m.members, member)
+	return m
+}
+
+// MessageHandler sets the handler
+func (m *MockGossipAdapter) MessageHandler(handler MessageHandler) *MockGossipAdapter {
+	m.handler = handler
+	return m
+}
+
+// PeersOfChannel returns the members
+func (m *MockGossipAdapter) PeersOfChannel(common.ChainID) []discovery.NetworkMember {
+	return m.members
+}
+
+// SelfMembershipInfo returns self
+func (m *MockGossipAdapter) SelfMembershipInfo() discovery.NetworkMember {
+	return m.self
+}
+
+// IdentityInfo returns the identitySet of this adapter
+func (m *MockGossipAdapter) IdentityInfo() gossipapi.PeerIdentitySet {
+	return m.identitySet
+}
+
+// Send sends a message to remote peers
+func (m *MockGossipAdapter) Send(msg *gossipproto.GossipMessage, peers ...*comm.RemotePeer) {
+	if m.handler != nil {
+		go m.handler(msg)
+	}
+}
+
+// NewMember creates a new network member
+func NewMember(endpoint string, pkiID []byte, roles ...string) discovery.NetworkMember {
+	return discovery.NetworkMember{
+		Endpoint: endpoint,
+		PKIid:    pkiID,
+		Properties: &gossipproto.Properties{
+			Roles: roles,
+		},
+	}
+}


### PR DESCRIPTION
Implemented a dissemination plan for transient data that is based on a deterministic algorithm.
The hash of the key is used first to determine the org to which to disseminate and then the
same hash is used to select the peer within the org. The number of peers to which to disseminate
is specific in the collection policy by 'maxPeers'.

closes #54

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>