### PR TITLE
feat: Transient Data Cache

### DIFF
--- a/pkg/collections/transientdata/storeprovider/store/cache/cache.go
+++ b/pkg/collections/transientdata/storeprovider/store/cache/cache.go
@@ -1,0 +1,151 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/storeprovider/store/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+)
+
+var logger = flogging.MustGetLogger("memtransientdatastore")
+
+// Cache is an in-memory key-value cache
+type Cache struct {
+	cache   gcache.Cache
+	ticker  *time.Ticker
+	dbstore transientDB
+}
+
+// transientDB - an interface for persisting and retrieving keys
+type transientDB interface {
+	AddKey(api.Key, *api.Value) error
+	DeleteExpiredKeys() error
+	GetKey(key api.Key) (*api.Value, error)
+	Close()
+}
+
+// New return a new in-memory key-value cache
+func New(size int, dbstore transientDB) *Cache {
+	c := &Cache{
+		ticker:  time.NewTicker(config.GetTransientDataExpiredIntervalTime()),
+		dbstore: dbstore,
+	}
+
+	c.cache = gcache.New(size).
+		LoaderExpireFunc(c.loadFromDB).
+		EvictedFunc(c.storeToDB).
+		ARC().Build()
+
+	// cleanup expired data in db
+	go c.periodicPurge()
+
+	return c
+}
+
+// Close closes the cache
+func (c *Cache) Close() {
+	c.cache.Purge()
+	c.ticker.Stop()
+}
+
+// Put adds the transient value for the given key.
+func (c *Cache) Put(key api.Key, value []byte, txID string) {
+	if err := c.cache.Set(key,
+		&api.Value{
+			Value: value,
+			TxID:  txID,
+		}); err != nil {
+		panic("Set must never return an error")
+	}
+}
+
+// PutWithExpire adds the transient value for the given key.
+func (c *Cache) PutWithExpire(key api.Key, value []byte, txID string, expiry time.Duration) {
+	if err := c.cache.SetWithExpire(key,
+		&api.Value{
+			Value:      value,
+			TxID:       txID,
+			ExpiryTime: time.Now().UTC().Add(expiry),
+		}, expiry); err != nil {
+		panic("Set must never return an error")
+	}
+}
+
+// Get returns the transient value for the given key
+func (c *Cache) Get(key api.Key) *api.Value {
+	value, err := c.cache.Get(key)
+	if err != nil {
+		if err != gcache.KeyNotFoundError {
+			panic(fmt.Sprintf("Get must never return an error other than KeyNotFoundError err:%s", err))
+		}
+		return nil
+	}
+
+	return value.(*api.Value)
+}
+
+func (c *Cache) loadFromDB(key interface{}) (interface{}, *time.Duration, error) {
+	logger.Debugf("LoaderExpireFunc for key %s", key)
+	value, err := c.dbstore.GetKey(key.(api.Key))
+	if value == nil || err != nil {
+		if err != nil {
+			logger.Error(err.Error())
+		}
+		logger.Debugf("Key [%s] not found in DB", key)
+		return nil, nil, gcache.KeyNotFoundError
+	}
+	isExpired, diff := checkExpiryTime(value.ExpiryTime)
+	if isExpired {
+		logger.Debugf("Key [%s] from DB has expired", key)
+		return nil, nil, gcache.KeyNotFoundError
+	}
+	logger.Debugf("Loaded key [%s] from DB", key)
+	return value, &diff, nil
+}
+
+func (c *Cache) storeToDB(key, value interface{}) {
+	logger.Debugf("EvictedFunc for key %s", key)
+	if value != nil {
+		k := key.(api.Key)
+		v := value.(*api.Value)
+		isExpired, _ := checkExpiryTime(v.ExpiryTime)
+		if !isExpired {
+			dbstoreErr := c.dbstore.AddKey(k, v)
+			if dbstoreErr != nil {
+				logger.Error(dbstoreErr.Error())
+			} else {
+				logger.Debugf("Key [%s] offloaded to DB", key)
+			}
+		}
+	}
+}
+
+func (c *Cache) periodicPurge() {
+	for range c.ticker.C {
+		dbstoreErr := c.dbstore.DeleteExpiredKeys()
+		if dbstoreErr != nil {
+			logger.Error(dbstoreErr.Error())
+		}
+	}
+}
+
+func checkExpiryTime(expiryTime time.Time) (bool, time.Duration) {
+	if expiryTime.IsZero() {
+		return false, 0
+	}
+
+	timeNow := time.Now().UTC()
+	logger.Debugf("Checking expiration - Current time: %s, Expiry time: %s", timeNow, expiryTime)
+
+	diff := expiryTime.Sub(timeNow)
+	return diff <= 0, diff
+}

--- a/pkg/collections/transientdata/storeprovider/store/cache/cache_test.go
+++ b/pkg/collections/transientdata/storeprovider/store/cache/cache_test.go
@@ -1,0 +1,320 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/storeprovider/store/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/storeprovider/store/dbstore"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+)
+
+const (
+	txID1 = "txid1"
+	txID2 = "txid2"
+
+	ns1 = "namespace1"
+	ns2 = "namespace2"
+
+	coll1 = "coll1"
+	coll2 = "coll2"
+
+	key1 = "key1"
+	key2 = "key2"
+	key3 = "key3"
+)
+
+var (
+	k1 = api.Key{
+		Namespace:  ns1,
+		Collection: coll1,
+		Key:        key1,
+	}
+	k2 = api.Key{
+		Namespace:  ns2,
+		Collection: coll2,
+		Key:        key2,
+	}
+	k3 = api.Key{
+		Namespace:  ns1,
+		Collection: coll2,
+		Key:        key2,
+	}
+	k4 = api.Key{
+		Namespace:  ns1,
+		Collection: coll2,
+		Key:        key3,
+	}
+	v1 = []byte("v1")
+	v2 = []byte("v2")
+)
+
+func TestCleanupExpiredTransientDataFromDB(t *testing.T) {
+	defer removeDBPath(t)
+
+	p := dbstore.NewDBProvider()
+	require.NotNil(t, p)
+	defer p.Close()
+
+	db, err := p.OpenDBStore("testchannel")
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	cache := New(1, db)
+	require.NotNil(t, cache)
+
+	cache.PutWithExpire(k1, v1, txID1, 2*time.Second)
+	cache.PutWithExpire(k2, v1, txID1, 1*time.Second)
+	cache.Put(k3, v1, txID1)
+	cache.Put(k4, v1, txID1)
+
+	// wait one second and half to confirm cleanup remove k2
+	time.Sleep(1500 * time.Millisecond)
+
+	// check data exist
+	v, err := cache.dbstore.GetKey(k1)
+	require.Nil(t, err)
+	require.NotNil(t, v)
+	// check data not exist because it's expired
+	v, err = cache.dbstore.GetKey(k2)
+	require.Nil(t, err)
+	require.Nil(t, v)
+	// check data exist
+	v, err = cache.dbstore.GetKey(k3)
+	require.Nil(t, err)
+	require.NotNil(t, v)
+
+	// wait one more second and half to confirm cleanup remove k1
+	time.Sleep(1500 * time.Millisecond)
+	// check data not exist because it's expired
+	v, err = cache.dbstore.GetKey(k1)
+	require.Nil(t, err)
+	require.Nil(t, v)
+	// check data exist
+	v, err = cache.dbstore.GetKey(k3)
+	require.Nil(t, err)
+	require.NotNil(t, v)
+
+}
+
+func TestRetrieveTransientDataFromDB(t *testing.T) {
+	t.Run("getAfterPurgeFromCache", func(t *testing.T) {
+		defer removeDBPath(t)
+		p := dbstore.NewDBProvider()
+		require.NotNil(t, p)
+		defer p.Close()
+
+		db, err := p.OpenDBStore("testchannel")
+		require.NoError(t, err)
+		require.NotNil(t, db)
+
+		cache := New(1, db)
+		require.NotNil(t, cache)
+		v := cache.Get(k1)
+		require.Nil(t, v)
+
+		cache.Put(k1, v1, txID1)
+		// Get k1 from cache
+		v = cache.Get(k1)
+		require.NotNil(t, v)
+		require.Equal(t, txID1, v.TxID)
+		require.Equal(t, v1, v.Value)
+
+		// After put the k2 the k1 will be purged from cache
+		cache.Put(k2, v2, txID2)
+
+		// k1 will not be found in cache so will get it from db
+		v = cache.Get(k1)
+		require.NotNil(t, v)
+		require.Equal(t, txID1, v.TxID)
+		require.Equal(t, v1, v.Value)
+
+	})
+
+	t.Run("getAfterPurgeFromCacheForNotExpiredData", func(t *testing.T) {
+		defer removeDBPath(t)
+		p := dbstore.NewDBProvider()
+		require.NotNil(t, p)
+		defer p.Close()
+
+		db, err := p.OpenDBStore("testchannel")
+		require.NoError(t, err)
+		require.NotNil(t, db)
+
+		cache := New(1, db)
+		require.NotNil(t, cache)
+		v := cache.Get(k1)
+		require.Nil(t, v)
+
+		cache.PutWithExpire(k1, v1, txID1, 5*time.Second)
+		// Get k1 from cache
+		v = cache.Get(k1)
+		require.NotNil(t, v)
+
+		// After put the k2 the k1 will be purged from cache
+		cache.PutWithExpire(k2, v2, txID2, 5*time.Second)
+
+		// k1 will not be found in cache so will get it from db
+		v = cache.Get(k1)
+		require.NotNil(t, v)
+
+	})
+
+	t.Run("getAfterPurgeFromCacheForExpiredData", func(t *testing.T) {
+		defer removeDBPath(t)
+		p := dbstore.NewDBProvider()
+		require.NotNil(t, p)
+		defer p.Close()
+
+		db, err := p.OpenDBStore("testchannel")
+		require.NoError(t, err)
+		require.NotNil(t, db)
+
+		cache := New(1, db)
+		require.NotNil(t, cache)
+		v := cache.Get(k1)
+		require.Nil(t, v)
+
+		cache.PutWithExpire(k1, v1, txID1, 2*time.Second)
+		// Get k1 from cache
+		v = cache.Get(k1)
+		require.NotNil(t, v)
+
+		// After put the k2 the k1 will be purged from cache
+		cache.PutWithExpire(k2, v2, txID2, 5*time.Second)
+
+		// k1 will not be found in cache so will get it from db
+		time.Sleep(1 * time.Second)
+		v = cache.Get(k1)
+		require.NotNil(t, v)
+
+		// k1 will not be found in db because it's already expired
+		time.Sleep(1 * time.Second)
+		v = cache.Get(k1)
+		require.Nil(t, v)
+
+	})
+
+}
+
+func TestTransientDataCache(t *testing.T) {
+	defer removeDBPath(t)
+	p := dbstore.NewDBProvider()
+	require.NotNil(t, p)
+	defer p.Close()
+
+	db, err := p.OpenDBStore("testchannel")
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	cache := New(1, db)
+	require.NotNil(t, cache)
+	defer cache.Close()
+
+	t.Run("Key", func(t *testing.T) {
+		require.Equal(t, "namespace1:coll1:key1", k1.String())
+	})
+
+	t.Run("GetAndPut", func(t *testing.T) {
+		v := cache.Get(k1)
+		require.Nil(t, v)
+
+		cache.Put(k1, v1, txID1)
+		cache.Put(k2, v2, txID2)
+
+		v = cache.Get(k1)
+		require.NotNil(t, v)
+		require.Equal(t, txID1, v.TxID)
+		require.Equal(t, v1, v.Value)
+
+		v = cache.Get(k2)
+		require.NotNil(t, v)
+		require.Equal(t, txID2, v.TxID)
+		require.Equal(t, v2, v.Value)
+	})
+
+	t.Run("Expire", func(t *testing.T) {
+		expiration := 10 * time.Millisecond
+		cache.PutWithExpire(k3, v1, txID1, expiration)
+
+		v := cache.Get(k3)
+		require.NotNil(t, v)
+
+		time.Sleep(100 * time.Millisecond)
+		v = cache.Get(k3)
+		require.Nil(t, v)
+	})
+}
+
+func TestTransientDataCacheConcurrency(t *testing.T) {
+	defer removeDBPath(t)
+	p := dbstore.NewDBProvider()
+	require.NotNil(t, p)
+	defer p.Close()
+
+	db, err := p.OpenDBStore("testchannel")
+	require.NoError(t, err)
+	require.NotNil(t, db)
+
+	cache := New(1, db)
+	require.NotNil(t, cache)
+	defer cache.Close()
+
+	n := 100
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i := 0; i < n; i++ {
+		k := api.Key{
+			Namespace:  ns1,
+			Collection: coll1,
+			Key:        fmt.Sprintf("k_%d", i),
+		}
+		v := []byte(fmt.Sprintf("v_%d", i))
+
+		go func() {
+			defer wg.Done()
+
+			cache.Put(k, v, txID1)
+			val := cache.Get(k)
+			if val == nil {
+				panic("Unable to get value for key")
+			}
+			if string(val.Value) != string(v) {
+				panic("Unable to get value for key")
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestMain(m *testing.M) {
+	removeDBPath(nil)
+	viper.Set("peer.fileSystemPath", "/tmp/fabric/ledgertests/transientdatadb")
+	viper.Set("coll.transientdata.cleanupExpired.Interval", "50ms")
+
+	os.Exit(m.Run())
+}
+
+func removeDBPath(t testing.TB) {
+	removePath(t, config.GetTransientDataLevelDBPath())
+}
+
+func removePath(t testing.TB, path string) {
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf("Err: %s", err)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,15 +8,20 @@ package config
 
 import (
 	"path/filepath"
+	"time"
 
 	"github.com/hyperledger/fabric/core/ledger/ledgerconfig"
 	"github.com/spf13/viper"
 )
 
 const (
-	confRoles                = "ledger.roles"
-	confPvtDataCacheSize     = "ledger.blockchain.pvtDataStorage.cacheSize"
-	confTransientDataLeveldb = "transientDataLeveldb"
+	confRoles            = "ledger.roles"
+	confPvtDataCacheSize = "ledger.blockchain.pvtDataStorage.cacheSize"
+
+	confTransientDataLeveldb             = "transientDataLeveldb"
+	confTransientDataCleanupIntervalTime = "coll.transientdata.cleanupExpired.Interval"
+
+	defaultTransientDataCleanupIntervalTime = 5 * time.Second
 )
 
 // GetRoles returns the roles of the peer. Empty return value indicates that the peer has all roles.
@@ -36,4 +41,13 @@ func GetPvtDataCacheSize() int {
 // GetTransientDataLevelDBPath returns the filesystem path that is used to maintain the transient data level db
 func GetTransientDataLevelDBPath() string {
 	return filepath.Join(ledgerconfig.GetRootPath(), confTransientDataLeveldb)
+}
+
+// GetTransientDataExpiredIntervalTime is time when background routine check expired transient data in db to cleanup.
+func GetTransientDataExpiredIntervalTime() time.Duration {
+	timeout := viper.GetDuration(confTransientDataCleanupIntervalTime)
+	if timeout == 0 {
+		return defaultTransientDataCleanupIntervalTime
+	}
+	return timeout
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -33,4 +34,24 @@ func TestGetPvtDataCacheSize(t *testing.T) {
 	val = GetPvtDataCacheSize()
 	assert.Equal(t, val, 99)
 
+}
+
+func TestGetTransientDataLevelDBPath(t *testing.T) {
+	oldVal := viper.Get("peer.fileSystemPath")
+	defer viper.Set("peer.fileSystemPath", oldVal)
+
+	viper.Set("peer.fileSystemPath", "/tmp123")
+
+	assert.Equal(t, "/tmp123/ledgersData/transientDataLeveldb", GetTransientDataLevelDBPath())
+}
+
+func TestGetTransientDataExpiredIntervalTime(t *testing.T) {
+	oldVal := viper.Get(confTransientDataCleanupIntervalTime)
+	defer viper.Set(confTransientDataCleanupIntervalTime, oldVal)
+
+	viper.Set(confTransientDataCleanupIntervalTime, "")
+	assert.Equal(t, defaultTransientDataCleanupIntervalTime, GetTransientDataExpiredIntervalTime())
+
+	viper.Set(confTransientDataCleanupIntervalTime, 111*time.Second)
+	assert.Equal(t, 111*time.Second, GetTransientDataExpiredIntervalTime())
 }


### PR DESCRIPTION
Implemented an LRU cache for transient data. Transient data
is cached in memory and expired according to the provided
expiration time. If the cache reaches capacity, evicted items
are transferred to persistent store. If the evicted item is
later requested, it is loaded from persistent store.

closes #51

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>