### PR TITLE
[ON-HOLD] feat: State DB Cache

### DIFF
--- a/mod/peer/statedb/store.go
+++ b/mod/peer/statedb/store.go
@@ -8,9 +8,10 @@ package privacyenabledstate
 
 import (
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	statedbext "github.com/trustbloc/fabric-peer-ext/pkg/statedb"
 )
 
 // NewVersionedDBProvider instantiates VersionedDBProvider
 func NewVersionedDBProvider(vdbProvider statedb.VersionedDBProvider) statedb.VersionedDBProvider {
-	return vdbProvider
+	return statedbext.NewVersionedDBProvider(vdbProvider)
 }

--- a/mod/peer/testutil/ext_test_env.go
+++ b/mod/peer/testutil/ext_test_env.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	statedbext "github.com/trustbloc/fabric-peer-ext/pkg/statedb"
 	"github.com/trustbloc/fabric-peer-ext/pkg/testutil"
 )
 
@@ -21,5 +22,5 @@ func SetupExtTestEnv() (addr string, cleanup func(string), stop func()) {
 
 // GetExtStateDBProvider returns the implementation of the versionedDBProvider
 func GetExtStateDBProvider(t testing.TB, dbProvider statedb.VersionedDBProvider) statedb.VersionedDBProvider {
-	return nil
+	return statedbext.GetExtStateDBProvider(t, dbProvider)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,10 @@ const (
 	defaultTransientDataCleanupIntervalTime = 5 * time.Second
 	defaultTransientDataCacheSize           = 100000
 	defaultOLCollCleanupIntervalTime        = 5 * time.Second
+
+	// state cache
+	stateDataCacheSize        = "ledger.state.cache.size"
+	defaultStateDataCacheSize = 100
 )
 
 // GetRoles returns the roles of the peer. Empty return value indicates that the peer has all roles.
@@ -79,4 +83,13 @@ func GetOLCollExpirationCheckInterval() time.Duration {
 		return defaultOLCollCleanupIntervalTime
 	}
 	return timeout
+}
+
+// GetStateDataCacheSize returns the state data cache size value. If not set, the default value is 100.
+func GetStateDataCacheSize() int {
+	cap := viper.GetInt(stateDataCacheSize)
+	if cap <= 0 {
+		cap = defaultStateDataCacheSize
+	}
+	return cap
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -85,4 +87,13 @@ func TestGetOLCollExpiredIntervalTime(t *testing.T) {
 
 	viper.Set(confOLCollCleanupIntervalTime, 111*time.Second)
 	assert.Equal(t, 111*time.Second, GetOLCollExpirationCheckInterval())
+}
+
+func TestStateCacheConfig(t *testing.T) {
+	// test for default value
+	require.Equal(t, 100, GetStateDataCacheSize())
+
+	// set value and verify
+	viper.Set("ledger.state.cache.size", 200)
+	require.Equal(t, 200, GetStateDataCacheSize())
 }

--- a/pkg/statedb/api/cache/statecahe.go
+++ b/pkg/statedb/api/cache/statecahe.go
@@ -1,0 +1,26 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statecahe
+
+import (
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+)
+
+// StateCache state cache interface
+type StateCache interface {
+	// Get gets state data
+	Get(ns, key string) *statedb.VersionedValue
+
+	// Add adds state data
+	Add(ns, key string, vval *statedb.VersionedValue)
+
+	// Remove removes state data
+	Remove(ns string, key string) bool
+
+	// GetVersion version of state data
+	GetVersion(ns, key string) *version.Height
+}

--- a/pkg/statedb/cachestore/statecahestore.go
+++ b/pkg/statedb/cachestore/statecahestore.go
@@ -1,0 +1,72 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cachestore
+
+import (
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	statecahe "github.com/trustbloc/fabric-peer-ext/pkg/statedb/api/cache"
+)
+
+var logger = flogging.MustGetLogger("statecache")
+
+// StateCacheStore state cache store
+type StateCacheStore struct {
+	cache gcache.Cache
+	name  string
+}
+
+// NewStateCacheStore constructs an instance of State Cache store
+func NewStateCacheStore(cacheName string, size int) statecahe.StateCache {
+	cache := gcache.New(size).ARC().Build()
+
+	return &StateCacheStore{cache: cache, name: cacheName}
+}
+
+// Get implements method in StateCache interface
+func (store *StateCacheStore) Get(ns string, key string) *statedb.VersionedValue {
+	val, err := store.cache.Get(ConstructCompositeKey(ns, key))
+	if err != nil {
+		if err != gcache.KeyNotFoundError {
+			logger.Errorf("Retrieving State from Cache failed : %s", err)
+		}
+		return nil
+	}
+
+	if val == nil {
+		return nil
+	}
+
+	logger.Debugf("Successfully retrieved state data from Cache :: ns=%s key=%s", ns, key)
+	return val.(*statedb.VersionedValue)
+}
+
+// Add implements method in StateCache interface
+func (store *StateCacheStore) Add(ns, key string, vval *statedb.VersionedValue) {
+	err := store.cache.Set(ConstructCompositeKey(ns, key), vval)
+	if err != nil {
+		logger.Errorf("Adding State to Cache failed : %s", err)
+	}
+	logger.Debugf("Successfully added state data to Cache :: ns=%s key=%s", ns, key)
+}
+
+// Remove implements method in StateCache interface
+func (store *StateCacheStore) Remove(ns string, key string) bool {
+	logger.Debugf("Remove state data from Cache :: ns=%s key=%s", ns, key)
+	return store.cache.Remove(ConstructCompositeKey(ns, key))
+}
+
+// GetVersion implements method in StateCache interface
+func (store *StateCacheStore) GetVersion(namespace string, key string) *version.Height {
+	versionedValue := store.Get(namespace, key)
+	if versionedValue == nil {
+		return nil
+	}
+
+	return versionedValue.Version
+}

--- a/pkg/statedb/cachestore/statecahestore_test.go
+++ b/pkg/statedb/cachestore/statecahestore_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cachestore
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+)
+
+func TestStateCacheStore(t *testing.T) {
+	stateCache := NewStateCacheStore("test", config.GetStateDataCacheSize())
+
+	val1 := "ns1+key1+val"
+	blockNum1 := uint64(101)
+	txNum1 := uint64(53129426795)
+
+	// add state cache data
+	stateCache.Add("ns1", "key1", &statedb.VersionedValue{Value: []byte("ns1+key1+val"), Version: &version.Height{
+		blockNum1,
+		txNum1,
+	}})
+
+	// validate state cache store functions
+	require.Equal(t, val1, string(stateCache.Get("ns1", "key1").Value))
+	require.Equal(t, blockNum1, stateCache.GetVersion("ns1", "key1").BlockNum)
+	require.Equal(t, txNum1, stateCache.GetVersion("ns1", "key1").TxNum)
+
+	// remove state cache
+	stateCache.Remove("ns1", "key1")
+
+	// validate state cache store after removing the key
+	require.Empty(t, stateCache.Get("ns1", "key1"))
+	require.Empty(t, stateCache.GetVersion("ns1", "key1"))
+
+}

--- a/pkg/statedb/cachestore/utils.go
+++ b/pkg/statedb/cachestore/utils.go
@@ -1,0 +1,11 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cachestore
+
+// ConstructCompositeKey constructs a string composite key
+func ConstructCompositeKey(ns string, key string) string {
+	return ns + key
+}

--- a/pkg/statedb/cachestore/utils_test.go
+++ b/pkg/statedb/cachestore/utils_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cachestore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateCacheCompositeKey(t *testing.T) {
+	require.Equal(t, "ab", ConstructCompositeKey("a", "b"))
+
+	require.Equal(t, "b", ConstructCompositeKey("", "b"))
+}

--- a/pkg/statedb/store_impl.go
+++ b/pkg/statedb/store_impl.go
@@ -1,0 +1,192 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statedb
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/ccprovider"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+	statecahe "github.com/trustbloc/fabric-peer-ext/pkg/statedb/api/cache"
+	"github.com/trustbloc/fabric-peer-ext/pkg/statedb/cachestore"
+)
+
+var logger = flogging.MustGetLogger("statedb")
+
+// VersionedDBProvider implements interface VersionedDBProvider
+type VersionedDBProvider struct {
+	statedbProvider statedb.VersionedDBProvider
+}
+
+// NewVersionedDBProvider instantiates VersionedDBProvider
+func NewVersionedDBProvider(vdbProvider statedb.VersionedDBProvider) statedb.VersionedDBProvider {
+	return &VersionedDBProvider{statedbProvider: vdbProvider}
+}
+
+// GetDBHandle gets the handle to a named database
+func (provider *VersionedDBProvider) GetDBHandle(dbName string) (statedb.VersionedDB, error) {
+	return newVersionedDB(provider, dbName), nil
+}
+
+// Close closes the underlying db
+func (provider *VersionedDBProvider) Close() {
+	provider.statedbProvider.Close()
+}
+
+// VersionedDB implements VersionedDB interface
+type versionedDB struct {
+	statedb         statedb.VersionedDB
+	statecachestore statecahe.StateCache
+}
+
+// newVersionedDB constructs an instance of VersionedDB
+func newVersionedDB(provider *VersionedDBProvider, dbName string) *versionedDB {
+	statedbHandle, _ := provider.statedbProvider.GetDBHandle(dbName)
+	statecachestore := cachestore.NewStateCacheStore(dbName, config.GetStateDataCacheSize())
+
+	return &versionedDB{statedb: statedbHandle, statecachestore: statecachestore}
+}
+
+// Open implements method in VersionedDB interface
+func (vdb *versionedDB) Open() error {
+	return vdb.statedb.Open()
+}
+
+// Close implements method in VersionedDB interface
+func (vdb *versionedDB) Close() {
+	vdb.statedb.Close()
+}
+
+// ValidateKeyValue implements method in VersionedDB interface
+func (vdb *versionedDB) ValidateKeyValue(key string, value []byte) error {
+	return vdb.statedb.ValidateKeyValue(key, value)
+}
+
+// BytesKeySupported implements method in VersionedDB interface
+func (vdb *versionedDB) BytesKeySupported() bool {
+	return vdb.statedb.BytesKeySupported()
+}
+
+// GetState implements method in VersionedDB interface
+func (vdb *versionedDB) GetState(namespace string, key string) (*statedb.VersionedValue, error) {
+
+	val := vdb.statecachestore.Get(namespace, key)
+
+	if val != nil {
+		return val, nil
+	}
+
+	val, err := vdb.statedb.GetState(namespace, key)
+
+	if err == nil && val != nil {
+		go func() {
+			vdb.statecachestore.Add(namespace, key, val)
+		}()
+	}
+
+	return val, err
+}
+
+// GetVersion implements method in VersionedDB interface
+func (vdb *versionedDB) GetVersion(namespace string, key string) (*version.Height, error) {
+	versionedValue, err := vdb.GetState(namespace, key)
+	if err != nil {
+		return nil, err
+	}
+	if versionedValue == nil {
+		return nil, nil
+	}
+
+	return versionedValue.Version, nil
+}
+
+// GetStateMultipleKeys implements method in VersionedDB interface
+func (vdb *versionedDB) GetStateMultipleKeys(namespace string, keys []string) ([]*statedb.VersionedValue, error) {
+	vals := make([]*statedb.VersionedValue, len(keys))
+	for i, key := range keys {
+		val, err := vdb.GetState(namespace, key)
+		if err != nil {
+			return nil, err
+		}
+		vals[i] = val
+	}
+	return vals, nil
+}
+
+// GetStateRangeScanIterator implements method in VersionedDB interface
+// startKey is inclusive
+// endKey is exclusive
+func (vdb *versionedDB) GetStateRangeScanIterator(namespace string, startKey string, endKey string) (statedb.ResultsIterator, error) {
+	return vdb.GetStateRangeScanIteratorWithMetadata(namespace, startKey, endKey, nil)
+}
+
+// GetStateRangeScanIteratorWithMetadata implements method in VersionedDB interface
+func (vdb *versionedDB) GetStateRangeScanIteratorWithMetadata(namespace string, startKey string, endKey string, metadata map[string]interface{}) (statedb.QueryResultsIterator, error) {
+	return vdb.statedb.GetStateRangeScanIteratorWithMetadata(namespace, startKey, endKey, metadata)
+}
+
+// ExecuteQuery implements method in VersionedDB interface
+func (vdb *versionedDB) ExecuteQuery(namespace, query string) (statedb.ResultsIterator, error) {
+	return vdb.statedb.ExecuteQuery(namespace, query)
+}
+
+// ExecuteQueryWithMetadata implements method in VersionedDB interface
+func (vdb *versionedDB) ExecuteQueryWithMetadata(namespace, query string, metadata map[string]interface{}) (statedb.QueryResultsIterator, error) {
+	return vdb.statedb.ExecuteQueryWithMetadata(namespace, query, metadata)
+}
+
+// ApplyUpdates implements method in VersionedDB interface
+func (vdb *versionedDB) ApplyUpdates(batch *statedb.UpdateBatch, height *version.Height) error {
+	vdb.applyUpdatesToCache(batch)
+
+	return vdb.statedb.ApplyUpdates(batch, height)
+}
+
+// GetLatestSavePoint implements method in VersionedDB interface
+func (vdb *versionedDB) GetLatestSavePoint() (*version.Height, error) {
+	return vdb.statedb.GetLatestSavePoint()
+}
+
+// ProcessIndexesForChaincodeDeploy creates indexes for a specified namespace
+func (vdb *versionedDB) ProcessIndexesForChaincodeDeploy(namespace string, fileEntries []*ccprovider.TarFileEntry) error {
+	//Check to see if the interface for IndexCapable is implemented
+	indexCapable, ok := vdb.statedb.(statedb.IndexCapable)
+	if !ok {
+		return nil
+	}
+
+	return indexCapable.ProcessIndexesForChaincodeDeploy(namespace, fileEntries)
+}
+
+// GetDBType returns the hosted stateDB
+func (vdb *versionedDB) GetDBType() string {
+	//Check to see if the interface for IndexCapable is implemented
+	indexCapable, ok := vdb.statedb.(statedb.IndexCapable)
+	if !ok {
+		return ""
+	}
+
+	return indexCapable.GetDBType()
+}
+
+// ApplyUpdates applies state data batch updates to cache store
+func (vdb *versionedDB) applyUpdatesToCache(batch *statedb.UpdateBatch) {
+	namespaces := batch.GetUpdatedNamespaces()
+	for _, ns := range namespaces {
+		updates := batch.GetUpdates(ns)
+		for key, vv := range updates {
+			compositeKey := cachestore.ConstructCompositeKey(ns, key)
+			logger.Debugf("statecachestore : Applying key(string)=[%s]", compositeKey)
+
+			if vv.Value == nil {
+				vdb.statecachestore.Remove(ns, key)
+			} else {
+				vdb.statecachestore.Add(ns, key, vv)
+			}
+		}
+	}
+}

--- a/pkg/statedb/store_impl_test.go
+++ b/pkg/statedb/store_impl_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statedb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/commontests"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/version"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	viper.Set("peer.fileSystemPath", "/tmp/fabric/ledgertests/kvledger/txmgmt/statedb/stateleveldb")
+	os.Exit(m.Run())
+}
+
+func TestBasicRW(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestBasicRW(t, env.DBProvider)
+}
+
+func TestMultiDBBasicRW(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestMultiDBBasicRW(t, env.DBProvider)
+}
+
+func TestDeletes(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestDeletes(t, env.DBProvider)
+}
+
+func TestIterator(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestIterator(t, env.DBProvider)
+}
+
+// TestQueryOnLevelDB tests queries on levelDB.
+func TestQueryOnLevelDB(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	db, err := env.DBProvider.GetDBHandle("testquery")
+	assert.NoError(t, err)
+	db.Open()
+	defer db.Close()
+	batch := statedb.NewUpdateBatch()
+	jsonValue1 := `{"asset_name": "marble1","color": "blue","size": 1,"owner": "tom"}`
+	batch.Put("ns1", "key1", []byte(jsonValue1), version.NewHeight(1, 1))
+
+	savePoint := version.NewHeight(2, 22)
+	db.ApplyUpdates(batch, savePoint)
+
+	// query for owner=jerry, use namespace "ns1"
+	// As queries are not supported in levelDB, call to ExecuteQuery()
+	// should return a error message
+	itr, err := db.ExecuteQuery("ns1", `{"selector":{"owner":"jerry"}}`)
+	assert.Error(t, err, "ExecuteQuery not supported for leveldb")
+	assert.Nil(t, itr)
+}
+
+func TestGetStateMultipleKeys(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestGetStateMultipleKeys(t, env.DBProvider)
+}
+
+func TestGetVersion(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestGetVersion(t, env.DBProvider)
+}
+
+func TestUtilityFunctions(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+
+	db, err := env.DBProvider.GetDBHandle("testutilityfunctions")
+	assert.NoError(t, err)
+
+	// BytesKeySupported should be true for goleveldb
+	byteKeySupported := db.BytesKeySupported()
+	assert.True(t, byteKeySupported)
+
+	// ValidateKeyValue should return nil for a valid key and value
+	assert.NoError(t, db.ValidateKeyValue("testKey", []byte("testValue")), "leveldb should accept all key-values")
+}
+
+func TestValueAndMetadataWrites(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestValueAndMetadataWrites(t, env.DBProvider)
+}
+
+func TestPaginatedRangeQuery(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestPaginatedRangeQuery(t, env.DBProvider)
+}
+
+func TestApplyUpdatesWithNilHeight(t *testing.T) {
+	env := NewTestVDBEnv(t)
+	defer env.Cleanup()
+	commontests.TestApplyUpdatesWithNilHeight(t, env.DBProvider)
+}

--- a/pkg/statedb/store_impl_test_export.go
+++ b/pkg/statedb/store_impl_test_export.go
@@ -1,0 +1,66 @@
+/*
+Copyright IBM Corp. 2016 All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		 http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statedb
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/stateleveldb"
+	"github.com/hyperledger/fabric/core/ledger/ledgerconfig"
+)
+
+// TestVDBEnv provides a level db backed versioned db for testing
+type TestVDBEnv struct {
+	t          testing.TB
+	DBProvider statedb.VersionedDBProvider
+}
+
+// NewTestVDBEnv instantiates and new level db backed TestVDB
+func NewTestVDBEnv(t testing.TB) *TestVDBEnv {
+	t.Logf("Creating new TestVDBEnv")
+	removeDBPath(t, "NewTestVDBEnv")
+	dbProvider := NewVersionedDBProvider(stateleveldb.NewVersionedDBProvider())
+	return &TestVDBEnv{t, dbProvider}
+}
+
+// Cleanup closes the db and removes the db folder
+func (env *TestVDBEnv) Cleanup() {
+	env.t.Logf("Cleaningup TestVDBEnv")
+	env.DBProvider.Close()
+	removeDBPath(env.t, "Cleanup")
+}
+
+func removeDBPath(t testing.TB, caller string) {
+	dbPath := ledgerconfig.GetStateLevelDBPath()
+	if err := os.RemoveAll(dbPath); err != nil {
+		t.Fatalf("Err: %s", err)
+		t.FailNow()
+	}
+	logger.Debugf("Removed folder [%s] for test environment for %s", dbPath, caller)
+}
+
+// GetExtStateDBProvider returns the implementation of the versionedDBProvider
+func GetExtStateDBProvider(t testing.TB, dbProvider statedb.VersionedDBProvider) statedb.VersionedDBProvider {
+	dbProv, ok := dbProvider.(*VersionedDBProvider)
+	if !ok {
+		return nil
+	}
+
+	return dbProv.statedbProvider
+}


### PR DESCRIPTION
- Add a new implementation of VersionedDBProvider and VersionedDB to wrap existing db implementations(leveldb/couchdb) and to support caching of the data.
- Add state db cache store using gCache library.

Closes #87

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>