### PR TITLE
feat: Retrieve Transient Data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
 	github.com/stretchr/testify v1.3.0
 	github.com/willf/bitset v1.1.9
+	go.uber.org/zap v1.9.1
 
 )
 

--- a/mod/peer/collections/api/store/provider.go
+++ b/mod/peer/collections/api/store/provider.go
@@ -7,9 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package store
 
 import (
+	"context"
 	"time"
 
 	proto "github.com/hyperledger/fabric/protos/transientstore"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common"
 )
 
 // ExpiringValue is holds the value and expiration time.
@@ -38,9 +40,23 @@ type Store interface {
 
 // Retriever retrieves private data
 type Retriever interface {
+	// GetTransientData gets the value for the given transient data item
+	GetTransientData(ctxt context.Context, key *Key) (*ExpiringValue, error)
+
+	// GetTransientDataMultipleKeys gets the values for the multiple transient data items in a single call
+	GetTransientDataMultipleKeys(ctxt context.Context, key *MultiKey) (ExpiringValues, error)
 }
 
 // Provider provides private data retrievers
 type Provider interface {
 	RetrieverForChannel(channel string) Retriever
+}
+
+// Values returns the ExpiringValues as Values
+func (ev ExpiringValues) Values() common.Values {
+	vals := make(common.Values, len(ev))
+	for i, v := range ev {
+		vals[i] = v
+	}
+	return vals
 }

--- a/mod/peer/collections/retriever/retriever.go
+++ b/mod/peer/collections/retriever/retriever.go
@@ -11,23 +11,15 @@ import (
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	extretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/retriever"
 )
 
-// Provider is a private data provider.
-type Provider struct {
-}
-
-// NewProvider returns a new private data provider
+// NewProvider returns a new private data Retriever provider
 func NewProvider(
 	storeProvider func(channelID string) storeapi.Store,
 	ledgerProvider func(channelID string) ledger.PeerLedger,
 	gossipProvider func() supportapi.GossipAdapter,
-	blockPublisherProvider func(channelID string) gossipapi.BlockPublisher) storeapi.Provider {
+	_ func(channelID string) gossipapi.BlockPublisher) storeapi.Provider {
 
-	return &Provider{}
-}
-
-// RetrieverForChannel returns the private data dataRetriever for the given channel
-func (p *Provider) RetrieverForChannel(channelID string) storeapi.Retriever {
-	panic("not implemented")
+	return extretriever.NewProvider(storeProvider, ledgerProvider, gossipProvider)
 }

--- a/mod/peer/collections/retriever/retriever_test.go
+++ b/mod/peer/collections/retriever/retriever_test.go
@@ -9,15 +9,19 @@ package retriever
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
 	"github.com/stretchr/testify/require"
+	extretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/retriever"
+	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
+	tdatamocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/mocks"
 )
 
 func TestNewProvider(t *testing.T) {
+	extretriever.SetTransientDataProvider(func(storeProvider func(channelID string) tdataapi.Store, support extretriever.Support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider {
+		return &tdatamocks.TransientDataProvider{}
+	})
+
 	p := NewProvider(nil, nil, nil, nil)
 	require.NotNil(t, p)
-
-	assert.PanicsWithValue(t, "not implemented", func() {
-		p.RetrieverForChannel("testchannel")
-	})
+	require.NotNil(t, p.RetrieverForChannel("testchannel"))
 }

--- a/mod/peer/gossip/dispatcher/dispatcher.go
+++ b/mod/peer/gossip/dispatcher/dispatcher.go
@@ -13,7 +13,7 @@ import (
 	gossip "github.com/hyperledger/fabric/gossip/api"
 	"github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/gossip/discovery"
-	"github.com/hyperledger/fabric/gossip/protoext"
+	extdispatcher "github.com/trustbloc/fabric-peer-ext/pkg/gossip/dispatcher"
 )
 
 type gossipAdapter interface {
@@ -32,16 +32,6 @@ func New(
 	dataStore storeapi.Store,
 	gossipAdapter gossipAdapter,
 	ledger ledger.PeerLedger,
-	blockPublisher blockPublisher) *Dispatcher {
-	return &Dispatcher{}
-}
-
-// Dispatcher is a extensions Gossip message dispatcher
-type Dispatcher struct {
-}
-
-// Dispatch is a noop implementation
-func (s *Dispatcher) Dispatch(msg protoext.ReceivedMessage) bool {
-	// Nothing to handle
-	return false
+	_ blockPublisher) *extdispatcher.Dispatcher {
+	return extdispatcher.New(channelID, dataStore, gossipAdapter, ledger)
 }

--- a/mod/peer/mocks/mockprovider.go
+++ b/mod/peer/mocks/mockprovider.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package mocks
 
 import (
+	"context"
+
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 )
 
@@ -20,4 +22,18 @@ func (p *DataProvider) RetrieverForChannel(channel string) storeapi.Retriever {
 }
 
 type dataRetriever struct {
+}
+
+// GetTransientData returns the transient data for the given context and key
+func (m *dataRetriever) GetTransientData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+}
+
+// GetTransientDataMultipleKeys returns the transient data with multiple keys for the given context and key
+func (m *dataRetriever) GetTransientDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	values := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+	}
+	return values, nil
 }

--- a/pkg/collections/retriever/retriever.go
+++ b/pkg/collections/retriever/retriever.go
@@ -1,0 +1,96 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package retriever
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/core/ledger"
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	cb "github.com/hyperledger/fabric/protos/common"
+	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
+	tretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/retriever"
+	supp "github.com/trustbloc/fabric-peer-ext/pkg/common/support"
+)
+
+// Provider is a transient data provider.
+type Provider struct {
+	transientDataProvider tdataapi.Provider
+	retrievers            map[string]*retriever
+	mutex                 sync.RWMutex
+}
+
+// NewProvider returns a new transient data Retriever provider
+func NewProvider(
+	storeProvider func(channelID string) storeapi.Store,
+	ledgerProvider func(channelID string) ledger.PeerLedger,
+	gossipProvider func() supportapi.GossipAdapter) storeapi.Provider {
+
+	support := supp.New(ledgerProvider)
+
+	tdataStoreProvider := func(channelID string) tdataapi.Store { return storeProvider(channelID) }
+
+	return &Provider{
+		transientDataProvider: getTransientDataProvider(tdataStoreProvider, support, gossipProvider),
+		retrievers:            make(map[string]*retriever),
+	}
+}
+
+// RetrieverForChannel returns the collection retriever for the given channel
+func (p *Provider) RetrieverForChannel(channelID string) storeapi.Retriever {
+	p.mutex.RLock()
+	r, ok := p.retrievers[channelID]
+	p.mutex.RUnlock()
+
+	if ok {
+		return r
+	}
+
+	return p.getOrCreateRetriever(channelID)
+}
+
+func (p *Provider) getOrCreateRetriever(channelID string) storeapi.Retriever {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	r, ok := p.retrievers[channelID]
+	if !ok {
+		r = &retriever{
+			transientDataRetriever: p.transientDataProvider.RetrieverForChannel(channelID),
+		}
+		p.retrievers[channelID] = r
+	}
+
+	return r
+}
+
+type retriever struct {
+	transientDataRetriever tdataapi.Retriever
+}
+
+// GetTransientData returns the transient data for the given key
+func (r *retriever) GetTransientData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return r.transientDataRetriever.GetTransientData(ctxt, key)
+}
+
+// GetTransientDataMultipleKeys gets the values for the multiple transient data items in a single call
+func (r *retriever) GetTransientDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	return r.transientDataRetriever.GetTransientDataMultipleKeys(ctxt, key)
+}
+
+// Support defines the supporting functions required by the transient data provider
+type Support interface {
+	Config(channelID, ns, coll string) (*cb.StaticCollectionConfig, error)
+	Policy(channel, ns, collection string) (privdata.CollectionAccessPolicy, error)
+}
+
+var getTransientDataProvider = func(storeProvider func(channelID string) tdataapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider {
+	return tretriever.NewProvider(storeProvider, support, gossipProvider)
+}

--- a/pkg/collections/retriever/retriever_test.go
+++ b/pkg/collections/retriever/retriever_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package retriever
+
+import (
+	"context"
+	"testing"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
+	tdatamocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/mocks"
+)
+
+const (
+	channelID = "testchannel"
+)
+
+func TestRetriever(t *testing.T) {
+	getTransientDataProvider = func(storeProvider func(channelID string) tdataapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider {
+		return &tdatamocks.TransientDataProvider{}
+	}
+
+	p := NewProvider(nil, nil, nil)
+	require.NotNil(t, p)
+
+	retriever := p.RetrieverForChannel(channelID)
+	require.NotNil(t, retriever)
+
+	const key1 = "key1"
+
+	v, err := retriever.GetTransientData(context.Background(), &storeapi.Key{Key: key1})
+	assert.NoError(t, err)
+	require.NotNil(t, v)
+	assert.Equal(t, []byte(key1), v.Value)
+
+	vals, err := retriever.GetTransientDataMultipleKeys(context.Background(), &storeapi.MultiKey{Keys: []string{key1}})
+	assert.NoError(t, err)
+	require.Equal(t, 1, len(vals))
+	assert.Equal(t, []byte(key1), vals[0].Value)
+}

--- a/pkg/collections/retriever/test_exports.go
+++ b/pkg/collections/retriever/test_exports.go
@@ -1,0 +1,19 @@
+// +build testing
+
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package retriever
+
+import (
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
+)
+
+// SetTransientDataProvider sets the transient data Retriever provider for unit tests
+func SetTransientDataProvider(provider func(storeProvider func(channelID string) tdataapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider) {
+	getTransientDataProvider = provider
+}

--- a/pkg/collections/transientdata/api/transientdata.go
+++ b/pkg/collections/transientdata/api/transientdata.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
+	"context"
+
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	proto "github.com/hyperledger/fabric/protos/transientstore"
 )
@@ -33,4 +35,18 @@ type StoreProvider interface {
 
 	// Close cleans up the provider
 	Close()
+}
+
+// Retriever retrieves transient data
+type Retriever interface {
+	// GetTransientData gets the value for the given transient data item
+	GetTransientData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error)
+
+	// GetTransientDataMultipleKeys gets the values for the multiple transient data items in a single call
+	GetTransientDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error)
+}
+
+// Provider provides transient data retrievers
+type Provider interface {
+	RetrieverForChannel(channel string) Retriever
 }

--- a/pkg/collections/transientdata/mocks/mockprovider.go
+++ b/pkg/collections/transientdata/mocks/mockprovider.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"context"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
+)
+
+// TransientDataProvider is a mock transient data provider
+type TransientDataProvider struct {
+}
+
+// RetrieverForChannel returns a provider for the given channel
+func (p *TransientDataProvider) RetrieverForChannel(channel string) tdataapi.Retriever {
+	return &transientDataRetriever{}
+}
+
+type transientDataRetriever struct {
+}
+
+// GetTransientData returns the transientData
+func (m *transientDataRetriever) GetTransientData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+}
+
+// GetTransientDataMultipleKeys returns the data with multiple keys
+func (m *transientDataRetriever) GetTransientDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	values := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+	}
+	return values, nil
+}

--- a/pkg/collections/transientdata/retriever/transientdataretriever.go
+++ b/pkg/collections/transientdata/retriever/transientdataretriever.go
@@ -1,0 +1,373 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package retriever
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	"github.com/hyperledger/fabric/gossip/comm"
+	mspmgmt "github.com/hyperledger/fabric/msp/mgmt"
+	gproto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/pkg/errors"
+	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/dissemination"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/multirequest"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/requestmgr"
+)
+
+var logger = flogging.MustGetLogger("transientdata")
+
+type support interface {
+	Policy(channel, ns, collection string) (privdata.CollectionAccessPolicy, error)
+}
+
+// Provider is a transient data provider.
+type Provider struct {
+	support
+	storeForChannel func(channelID string) tdataapi.Store
+	gossipAdapter   func() supportapi.GossipAdapter
+}
+
+// NewProvider returns a new transient data provider
+func NewProvider(storeProvider func(channelID string) tdataapi.Store, support support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider {
+	return &Provider{
+		support:         support,
+		storeForChannel: storeProvider,
+		gossipAdapter:   gossipProvider,
+	}
+}
+
+// RetrieverForChannel returns the transient data dataRetriever for the given channel
+func (p *Provider) RetrieverForChannel(channelID string) tdataapi.Retriever {
+	return &retriever{
+		support:       p.support,
+		gossipAdapter: p.gossipAdapter(),
+		store:         p.storeForChannel(channelID),
+		channelID:     channelID,
+		reqMgr:        requestmgr.Get(channelID),
+		resolvers:     make(map[collKey]resolver),
+	}
+}
+
+// ResolveEndorsers resolves to a set of endorsers to which transient data should be disseminated
+type resolver interface {
+	ResolveEndorsers(key string) (discovery.PeerGroup, error)
+}
+
+type collKey struct {
+	ns   string
+	coll string
+}
+
+func newCollKey(ns, coll string) collKey {
+	return collKey{ns: ns, coll: coll}
+}
+
+type retriever struct {
+	support
+	channelID     string
+	gossipAdapter supportapi.GossipAdapter
+	store         tdataapi.Store
+	resolvers     map[collKey]resolver
+	lock          sync.RWMutex
+	reqMgr        requestmgr.RequestMgr
+}
+
+func (r *retriever) GetTransientData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	authorized, err := r.isAuthorized(key.Namespace, key.Collection)
+	if err != nil {
+		return nil, err
+	}
+	if !authorized {
+		logger.Infof("[%s] This peer does not have access to the collection [%s:%s]", r.channelID, key.Namespace, key.Collection)
+		return nil, nil
+	}
+
+	endorsers, err := r.resolveEndorsers(key)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unable to get resolve endorsers for channel [%s] and [%s]", r.channelID, key)
+	}
+
+	logger.Debugf("[%s] Endorsers for [%s]: %s", r.channelID, key, endorsers)
+
+	if endorsers.ContainsLocal() {
+		value, ok, err := r.getTransientDataFromLocal(key)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return value, nil
+		}
+	}
+
+	return r.getTransientDataFromRemote(ctxt, key, endorsers.Remote())
+}
+
+type valueResp struct {
+	value *storeapi.ExpiringValue
+	err   error
+}
+
+// GetTransientDataMultipleKeys gets the values for the multiple transient data items in a single call
+func (r *retriever) GetTransientDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	if len(key.Keys) == 0 {
+		return nil, errors.New("at least one key must be specified")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(len(key.Keys))
+	var mutex sync.Mutex
+
+	// TODO: This can be optimized by sending one request to endorsers that have multiple keys, as opposed to one request per key.
+	responses := make(map[string]*valueResp)
+	for _, k := range key.Keys {
+		go func(key *storeapi.Key) {
+			cctxt, cancel := context.WithCancel(ctxt)
+			defer cancel()
+
+			value, err := r.GetTransientData(cctxt, key)
+			mutex.Lock()
+			responses[key.Key] = &valueResp{value: value, err: err}
+			logger.Debugf("Got response for [%s]: %s, Err: %s", key.Key, value, err)
+			mutex.Unlock()
+			wg.Done()
+		}(storeapi.NewKey(key.EndorsedAtTxID, key.Namespace, key.Collection, k))
+	}
+
+	wg.Wait()
+
+	// Return the responses in the order of the requested keys
+	values := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		r, ok := responses[k]
+		if !ok {
+			return nil, errors.Errorf("no response for key [%s:%s:%s]", key.Namespace, key.Collection, k)
+		}
+		if r.err != nil {
+			return nil, r.err
+		}
+		values[i] = r.value
+	}
+
+	return values, nil
+}
+
+// resolveEndorsers returns the endorsers that (should) have the transient data
+func (r *retriever) resolveEndorsers(key *storeapi.Key) (discovery.PeerGroup, error) {
+	res, err := r.getResolver(key.Namespace, key.Collection)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unable to get resolver for channel [%s] and [%s:%s]", r.channelID, key.Namespace, key.Collection)
+	}
+	return res.ResolveEndorsers(key.Key)
+}
+
+func (r *retriever) getTransientDataFromLocal(key *storeapi.Key) (*storeapi.ExpiringValue, bool, error) {
+	value, retrieveErr := r.store.GetTransientData(key)
+	if retrieveErr != nil {
+		logger.Debugf("[%s] Error getting transient data from local store for [%s]: %s", r.channelID, key, retrieveErr)
+		return nil, false, errors.WithMessagef(retrieveErr, "unable to get transient data for channel [%s] and [%s]", r.channelID, key)
+	}
+
+	if value != nil && len(value.Value) > 0 {
+		logger.Debugf("[%s] Got transient data from local store for [%s]", r.channelID, key)
+		return value, true, nil
+	}
+
+	logger.Debugf("[%s] nil transient data in local store for [%s]. Will try to pull from remote peer(s).", r.channelID, key)
+	return nil, false, nil
+}
+
+func (r *retriever) getTransientDataFromRemote(ctxt context.Context, key *storeapi.Key, endorsers discovery.PeerGroup) (*storeapi.ExpiringValue, error) {
+	cReq := multirequest.New()
+	for _, endorser := range endorsers {
+		logger.Debugf("Adding request to get transient data for [%s] from [%s] ...", key, endorser)
+		cReq.Add(endorser.String(), r.getTransientDataRequest(key, endorser))
+	}
+
+	response := cReq.Execute(ctxt)
+
+	if response.Values.IsEmpty() {
+		logger.Debugf("Got empty transient data response for [%s] ...", key)
+		return nil, nil
+	}
+
+	logger.Debugf("Got non-nil transient data response for [%s] ...", key)
+	return response.Values[0].(*storeapi.ExpiringValue), nil
+}
+
+func (r *retriever) getTransientDataRequest(key *storeapi.Key, endorser *discovery.Member) func(ctxt context.Context) (common.Values, error) {
+	return func(ctxt context.Context) (common.Values, error) {
+		return r.getTransientDataFromEndorser(ctxt, key, endorser)
+	}
+}
+
+func (r *retriever) getTransientDataFromEndorser(ctxt context.Context, key *storeapi.Key, endorser *discovery.Member) (common.Values, error) {
+	logger.Debugf("Getting transient data for [%s] from [%s] ...", key, endorser)
+
+	value, err := r.getTransientData(ctxt, key, endorser)
+	if err != nil {
+		if err == context.Canceled {
+			logger.Debugf("[%s] Request to get transient data from [%s] for [%s] was cancelled", r.channelID, endorser, key)
+		} else {
+			logger.Debugf("[%s] Error getting transient data from [%s] for [%s]: %s", r.channelID, endorser, key, err)
+		}
+		return common.Values{nil}, err
+	}
+
+	if value == nil {
+		logger.Debugf("[%s] Transient data not found on [%s] for [%s]", r.channelID, endorser, key)
+	} else {
+		logger.Debugf("[%s] Got transient data from [%s] for [%s]", r.channelID, endorser, key)
+	}
+
+	return common.Values{value}, nil
+}
+
+func (r *retriever) getResolver(ns, coll string) (resolver, error) {
+	key := newCollKey(ns, coll)
+
+	r.lock.RLock()
+	resolver, ok := r.resolvers[key]
+	r.lock.RUnlock()
+
+	if ok {
+		return resolver, nil
+	}
+
+	return r.getOrCreateResolver(key)
+}
+
+func (r *retriever) getOrCreateResolver(key collKey) (resolver, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	resolver, ok := r.resolvers[key]
+	if ok {
+		return resolver, nil
+	}
+
+	policy, err := r.Policy(r.channelID, key.ns, key.coll)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver = dissemination.New(r.channelID, key.ns, key.coll, policy, r.gossipAdapter)
+
+	r.resolvers[key] = resolver
+
+	return resolver, nil
+}
+
+func (r *retriever) removeResolvers(ns string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for key := range r.resolvers {
+		if key.ns == ns {
+			logger.Debugf("[%s] Removing resolver [%s:%s] from cache", r.channelID, key.ns, key.coll)
+			delete(r.resolvers, key)
+		}
+	}
+}
+
+func (r *retriever) getTransientData(ctxt context.Context, key *storeapi.Key, endorsers ...*discovery.Member) (*storeapi.ExpiringValue, error) {
+	logger.Debugf("[%s] Sending Gossip request to %s for transient data for [%s]", r.channelID, endorsers, key)
+
+	req := r.reqMgr.NewRequest()
+
+	logger.Debugf("[%s] Creating Gossip request %d for transient data for [%s]", r.channelID, req.ID(), key)
+	msg := r.createCollDataRequestMsg(req, key)
+
+	logger.Debugf("[%s] Sending Gossip request %d for transient data for [%s]", r.channelID, req.ID(), key)
+	r.gossipAdapter.Send(msg, asRemotePeers(endorsers)...)
+
+	logger.Debugf("[%s] Waiting for response for %d for transient data for [%s]", r.channelID, req.ID(), key)
+	res, err := req.GetResponse(ctxt)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("[%s] Got response for %d for transient data for [%s]", r.channelID, req.ID(), key)
+	return r.findValue(res.Data, key)
+}
+
+func (r *retriever) findValue(data requestmgr.Elements, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	for _, e := range data {
+		if e.Namespace == key.Namespace && e.Collection == key.Collection && e.Key == key.Key {
+			logger.Debugf("[%s] Got response for transient data for [%s]", r.channelID, key)
+			if e.Value == nil {
+				return nil, nil
+			}
+			return &storeapi.ExpiringValue{Value: e.Value, Expiry: e.Expiry}, nil
+		}
+	}
+	return nil, errors.Errorf("expecting a response to a transient data request for [%s] but got a response for another key", key)
+}
+
+func (r *retriever) createCollDataRequestMsg(req requestmgr.Request, key *storeapi.Key) *gproto.GossipMessage {
+	return &gproto.GossipMessage{
+		Tag:     gproto.GossipMessage_CHAN_ONLY,
+		Channel: []byte(r.channelID),
+		Content: &gproto.GossipMessage_CollDataReq{
+			CollDataReq: &gproto.RemoteCollDataRequest{
+				Nonce: req.ID(),
+				Digests: []*gproto.CollDataDigest{
+					{
+						Namespace:      key.Namespace,
+						Collection:     key.Collection,
+						Key:            key.Key,
+						EndorsedAtTxID: key.EndorsedAtTxID,
+					},
+				},
+			},
+		},
+	}
+}
+
+// isAuthorized returns true if the local peer has access to the given collection
+func (r *retriever) isAuthorized(ns, coll string) (bool, error) {
+	policy, err := r.Policy(r.channelID, ns, coll)
+	if err != nil {
+		return false, errors.WithMessagef(err, "unable to get policy for [%s:%s]", ns, coll)
+	}
+
+	localMSPID, err := getLocalMSPID()
+	if err != nil {
+		return false, errors.WithMessagef(err, "unable to get local MSP ID")
+	}
+
+	for _, mspID := range policy.MemberOrgs() {
+		if mspID == localMSPID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func asRemotePeers(members []*discovery.Member) []*comm.RemotePeer {
+	var peers []*comm.RemotePeer
+	for _, m := range members {
+		peers = append(peers, &comm.RemotePeer{
+			Endpoint: m.Endpoint,
+			PKIID:    m.PKIid,
+		})
+	}
+	return peers
+}
+
+// getLocalMSPID returns the MSP ID of the local peer. This variable may be overridden by unit tests.
+var getLocalMSPID = func() (string, error) {
+	return mspmgmt.GetLocalMSP().GetIdentifier()
+}

--- a/pkg/collections/transientdata/retriever/transientdataretriever_test.go
+++ b/pkg/collections/transientdata/retriever/transientdataretriever_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package retriever
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	spmocks "github.com/hyperledger/fabric/extensions/collections/storeprovider/mocks"
+	gcommon "github.com/hyperledger/fabric/gossip/common"
+	gproto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/requestmgr"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+const (
+	channelID = "testchannel"
+	ns1       = "chaincode1"
+	coll1     = "collection1"
+	key1      = "key1"
+	key2      = "key2"
+	key3      = "key3"
+	txID      = "tx1"
+)
+
+var (
+	org1MSPID      = "Org1MSP"
+	p1Org1Endpoint = "p1.org1.com"
+	p1Org1PKIID    = gcommon.PKIidType("pkiid_P1O1")
+	p2Org1Endpoint = "p2.org1.com"
+	p2Org1PKIID    = gcommon.PKIidType("pkiid_P2O1")
+	p3Org1Endpoint = "p3.org1.com"
+	p3Org1PKIID    = gcommon.PKIidType("pkiid_P3O1")
+
+	org2MSPID      = "Org2MSP"
+	p1Org2Endpoint = "p1.org2.com"
+	p1Org2PKIID    = gcommon.PKIidType("pkiid_P1O2")
+	p2Org2Endpoint = "p2.org2.com"
+	p2Org2PKIID    = gcommon.PKIidType("pkiid_P2O2")
+	p3Org2Endpoint = "p3.org2.com"
+	p3Org2PKIID    = gcommon.PKIidType("pkiid_P3O2")
+
+	org3MSPID      = "Org3MSP"
+	p1Org3Endpoint = "p1.org3.com"
+	p1Org3PKIID    = gcommon.PKIidType("pkiid_P1O3")
+	p2Org3Endpoint = "p2.org3.com"
+	p2Org3PKIID    = gcommon.PKIidType("pkiid_P2O3")
+	p3Org3Endpoint = "p3.org3.com"
+	p3Org3PKIID    = gcommon.PKIidType("pkiid_P3O3")
+
+	validatorRole = string(roles.ValidatorRole)
+	endorserRole  = string(roles.EndorserRole)
+
+	respTimeout = 100 * time.Millisecond
+)
+
+func TestTransientDataProvider(t *testing.T) {
+	value1 := &storeapi.ExpiringValue{Value: []byte("value1")}
+	value2 := &storeapi.ExpiringValue{Value: []byte("value2")}
+	value3 := &storeapi.ExpiringValue{Value: []byte("value3")}
+
+	support := mocks.NewMockSupport().
+		CollectionPolicy(&mocks.MockAccessPolicy{
+			MaxPeerCount: 2,
+			Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+		})
+
+	getLocalMSPID = func() (string, error) { return org1MSPID, nil }
+
+	gossip := mocks.NewMockGossipAdapter()
+	gossip.Self(org1MSPID, mocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+		Member(org1MSPID, mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, validatorRole)).
+		Member(org1MSPID, mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, validatorRole)).
+		Member(org2MSPID, mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)).
+		Member(org2MSPID, mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, validatorRole)).
+		Member(org2MSPID, mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p1Org3Endpoint, p1Org3PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p2Org3Endpoint, p2Org3PKIID, validatorRole)).
+		Member(org3MSPID, mocks.NewMember(p3Org3Endpoint, p3Org3PKIID, endorserRole)).IdentityInfo()
+
+	localStore := spmocks.NewTransientDataStore().
+		Data(storeapi.NewKey(txID, ns1, coll1, key1), value1)
+
+	p := &Provider{
+		support:         support,
+		storeForChannel: func(channelID string) tdataapi.Store { return localStore },
+		gossipAdapter:   func() supportapi.GossipAdapter { return gossip },
+	}
+
+	retriever := p.RetrieverForChannel(channelID)
+	require.NotNil(t, retriever)
+
+	t.Run("GetTransientData - From local peer", func(t *testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetTransientData(ctx, storeapi.NewKey(txID, ns1, coll1, key1))
+		require.NoError(t, err)
+		require.NotNil(t, value)
+		require.Equal(t, value1, value)
+	})
+
+	t.Run("GetTransientData - From remote peer", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key2, value2).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetTransientData(ctx, storeapi.NewKey(txID, ns1, coll1, key2))
+		require.NoError(t, err)
+		require.NotNil(t, value)
+		require.Equal(t, value2, value)
+	})
+
+	t.Run("GetTransientData - No response from remote peer", func(t *testing.T) {
+		gossip.MessageHandler(func(msg *gproto.GossipMessage) {})
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetTransientData(ctx, storeapi.NewKey(txID, ns1, coll1, key2))
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetTransientData - Cancel request from remote peer", func(t *testing.T) {
+		gossip.MessageHandler(func(msg *gproto.GossipMessage) {})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		value, err := retriever.GetTransientData(ctx, storeapi.NewKey(txID, ns1, coll1, key2))
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetTransientDataMultipleKeys - 1 key -> success", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key1, value2).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetTransientDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, key1))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(values))
+		assert.Equal(t, value1, values[0])
+	})
+
+	t.Run("GetTransientDataMultipleKeys - 3 keys -> success", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key1, value1).
+				Value(key2, value2).
+				Value(key3, value3).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetTransientDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, key1, key2, key3))
+		require.NoError(t, err)
+		require.Equal(t, 3, len(values))
+		assert.Equal(t, value1, values[0])
+		assert.Equal(t, value2, values[1])
+		assert.Equal(t, value3, values[2])
+	})
+
+	t.Run("GetTransientDataMultipleKeys - Key not found -> success", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key1, value1).
+				Value(key2, value2).
+				Value(key3, value3).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetTransientDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, "xxx", key2, key3))
+		require.NoError(t, err)
+		require.Equal(t, 3, len(values))
+		assert.Nil(t, values[0])
+		assert.Equal(t, value2, values[1])
+		assert.Equal(t, value3, values[2])
+	})
+
+	t.Run("GetTransientDataMultipleKeys - Timeout -> fail", func(t *testing.T) {
+		handler := newMockGossipMsgHandler(channelID).
+			Value(key1, value1).
+			Value(key2, value2).
+			Value(key3, value3)
+		gossip.MessageHandler(
+			func(msg *gproto.GossipMessage) {
+				time.Sleep(10 * time.Millisecond)
+				handler.Handle(msg)
+			},
+		)
+
+		ctx, _ := context.WithTimeout(context.Background(), time.Microsecond)
+		values, err := retriever.GetTransientDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, key2, key3))
+		require.NoError(t, err)
+		assert.True(t, values.Values().IsEmpty())
+	})
+}
+
+func TestTransientDataProvider_AccessDenied(t *testing.T) {
+	value1 := &storeapi.ExpiringValue{Value: []byte("value1")}
+	value2 := &storeapi.ExpiringValue{Value: []byte("value2")}
+
+	getLocalMSPID = func() (string, error) { return org3MSPID, nil }
+
+	gossip := mocks.NewMockGossipAdapter()
+	gossip.Self(org3MSPID, mocks.NewMember(p1Org3Endpoint, p1Org3PKIID)).
+		Member(org1MSPID, mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, validatorRole)).
+		Member(org1MSPID, mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, validatorRole)).
+		Member(org2MSPID, mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)).
+		Member(org2MSPID, mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, validatorRole)).
+		Member(org2MSPID, mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole))
+
+	gossip.MessageHandler(
+		newMockGossipMsgHandler(channelID).
+			Value(key2, value2).
+			Handle)
+
+	localStore := spmocks.NewTransientDataStore().
+		Data(storeapi.NewKey(txID, ns1, coll1, key1), value1)
+
+	support := mocks.NewMockSupport().
+		CollectionPolicy(&mocks.MockAccessPolicy{
+			MaxPeerCount: 2,
+			Orgs:         []string{org1MSPID, org2MSPID},
+		})
+
+	p := &Provider{
+		support:         support,
+		storeForChannel: func(channelID string) tdataapi.Store { return localStore },
+		gossipAdapter:   func() supportapi.GossipAdapter { return gossip },
+	}
+
+	retriever := p.RetrieverForChannel(channelID)
+	require.NotNil(t, retriever)
+
+	t.Run("GetTransientData - From remote peer -> nil (not authorized)", func(t *testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetTransientData(ctx, storeapi.NewKey(txID, ns1, coll1, key2))
+		assert.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetTransientDataMultipleKeys - From remote peer -> nil (not authorized)", func(t *testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetTransientDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, key2))
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(values))
+		assert.Nil(t, values[0])
+	})
+}
+
+type mockGossipMsgHandler struct {
+	channelID string
+	values    map[string]*storeapi.ExpiringValue
+}
+
+func newMockGossipMsgHandler(channelID string) *mockGossipMsgHandler {
+	return &mockGossipMsgHandler{
+		channelID: channelID,
+		values:    make(map[string]*storeapi.ExpiringValue),
+	}
+}
+
+func (m *mockGossipMsgHandler) Value(key string, value *storeapi.ExpiringValue) *mockGossipMsgHandler {
+	m.values[key] = value
+	return m
+}
+
+func (m *mockGossipMsgHandler) Handle(msg *gproto.GossipMessage) {
+	req := msg.GetCollDataReq()
+
+	res := &requestmgr.Response{
+		Endpoint:  "p1.org1",
+		MSPID:     "org1",
+		Identity:  []byte("p1.org1"),
+		Signature: []byte("sig"),
+	}
+
+	for _, d := range req.Digests {
+		e := &requestmgr.Element{
+			Namespace:  d.Namespace,
+			Collection: d.Collection,
+			Key:        d.Key,
+		}
+
+		v := m.values[d.Key]
+		if v != nil {
+			e.Value = v.Value
+			e.Expiry = v.Expiry
+		}
+
+		res.Data = append(res.Data, e)
+	}
+
+	requestmgr.Get(m.channelID).Respond(req.Nonce, res)
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,88 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"reflect"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+)
+
+// Values contains a slice of values
+type Values []interface{}
+
+// IsEmpty returns true if all of the values are nil
+func (v Values) IsEmpty() bool {
+	for _, value := range v {
+		if !IsNil(value) {
+			return false
+		}
+	}
+	return true
+}
+
+// AllSet returns true if all of the values are not nil
+func (v Values) AllSet() bool {
+	for _, value := range v {
+		if IsNil(value) {
+			return false
+		}
+	}
+	return true
+}
+
+// Merge merges this set of values with the given set
+// and returns the new set
+func (v Values) Merge(other Values) Values {
+	var max int
+	if len(other) < len(v) {
+		max = len(v)
+	} else {
+		max = len(other)
+	}
+
+	retVal := make(Values, max)
+	copy(retVal, v)
+
+	for i, o := range other {
+		if IsNil(retVal[i]) {
+			retVal[i] = o
+		}
+	}
+
+	return retVal
+}
+
+// IsNil returns true if the given value is nil
+func IsNil(p interface{}) bool {
+	if p == nil {
+		return true
+	}
+
+	v := reflect.ValueOf(p)
+
+	switch {
+	case v.Kind() == reflect.Ptr:
+		return v.IsNil()
+	case v.Kind() == reflect.Array || v.Kind() == reflect.Slice:
+		return v.Len() == 0
+	default:
+		return false
+	}
+}
+
+// ToTimestamp converts the Time into Timestamp
+func ToTimestamp(t time.Time) *timestamp.Timestamp {
+	now := time.Now().UTC()
+	return &(timestamp.Timestamp{Seconds: now.Unix()})
+}
+
+// FromTimestamp converts the Timestamp into Time
+func FromTimestamp(ts *timestamp.Timestamp) time.Time {
+	return time.Unix(ts.Seconds, 0)
+}

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type iface interface {
+}
+
+type test struct {
+}
+
+func Test_IsNil(t *testing.T) {
+	assert.True(t, IsNil(nil))
+
+	var b []byte
+	assert.True(t, IsNil(b))
+
+	var v iface
+	assert.True(t, IsNil(v))
+	v = &test{}
+	assert.False(t, IsNil(v))
+
+	v = nil
+	v2 := v
+	assert.True(t, IsNil(v2))
+
+	assert.False(t, IsNil(test{}))
+}
+
+func TestValues_IsEmpty(t *testing.T) {
+	v1 := []byte("v1")
+	v2 := []byte("v1")
+	v3 := []byte("v1")
+
+	values := Values{v1, v2, v3}
+	assert.False(t, values.IsEmpty())
+
+	values = Values{v1, nil, v3}
+	assert.False(t, values.IsEmpty())
+
+	values = Values{nil, nil, nil}
+	assert.True(t, values.IsEmpty())
+}
+
+func TestValues_AllSet(t *testing.T) {
+	v1 := []byte("v1")
+	v2 := []byte("v1")
+	v3 := []byte("v1")
+
+	values := Values{v1, v2, v3}
+	assert.True(t, values.AllSet())
+
+	values = Values{v1, nil, v3}
+	assert.False(t, values.AllSet())
+}
+
+func TestValues_Merge(t *testing.T) {
+	v1 := []byte("v1")
+	v2 := []byte("v1")
+	v3 := []byte("v1")
+
+	t.Run("Merge same size", func(t *testing.T) {
+		values1 := Values{v1, nil, v3}
+		values2 := Values{v3, v2, v1}
+
+		values := values1.Merge(values2)
+		assert.True(t, values.AllSet())
+		assert.Equal(t, v1, values[0])
+		assert.Equal(t, v2, values[1])
+		assert.Equal(t, v3, values[2])
+	})
+
+	t.Run("Merge source size bigger", func(t *testing.T) {
+		values1 := Values{v1, nil, v3}
+		values2 := Values{v3, v2}
+
+		values := values1.Merge(values2)
+		assert.True(t, values.AllSet())
+		assert.Equal(t, v1, values[0])
+		assert.Equal(t, v2, values[1])
+		assert.Equal(t, v3, values[2])
+	})
+
+	t.Run("Merge dest size bigger", func(t *testing.T) {
+		values1 := Values{v1, nil}
+		values2 := Values{v3, v2, v3}
+
+		values := values1.Merge(values2)
+		assert.True(t, values.AllSet())
+		assert.Equal(t, v1, values[0])
+		assert.Equal(t, v2, values[1])
+		assert.Equal(t, v3, values[2])
+	})
+}
+
+func TestTimestamp(t *testing.T) {
+	tim := time.Now()
+	tim2 := FromTimestamp(ToTimestamp(tim))
+	assert.Equal(t, tim.Unix(), tim2.Unix())
+}

--- a/pkg/common/multirequest/multirequest.go
+++ b/pkg/common/multirequest/multirequest.go
@@ -1,0 +1,105 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package multirequest
+
+import (
+	"context"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common"
+)
+
+var logger = flogging.MustGetLogger("kevlar-common")
+
+// Request is the request to execute
+type Request func(ctxt context.Context) (common.Values, error)
+
+type req struct {
+	id      string
+	execute Request
+}
+
+type res struct {
+	id     string
+	values common.Values
+	err    error
+}
+
+// Response contains the response for a given request ID
+type Response struct {
+	RequestID string
+	Values    common.Values
+}
+
+// MultiRequest executes multiple requests and returns the first, non-error response
+type MultiRequest struct {
+	requests []*req
+}
+
+// New returns a new MultiRequest
+func New() *MultiRequest {
+	return &MultiRequest{}
+}
+
+// Add adds a request function
+func (r *MultiRequest) Add(id string, execute Request) {
+	r.requests = append(r.requests, &req{id: id, execute: execute})
+}
+
+// Execute executes the requests concurrently and returns the responses.
+func (r *MultiRequest) Execute(ctxt context.Context) *Response {
+	respChan := make(chan *res, len(r.requests)+1)
+
+	cctxt, cancel := context.WithCancel(ctxt)
+	defer cancel()
+
+	for _, request := range r.requests {
+		go func(r *req) {
+			ccctxt, cancelReq := context.WithCancel(cctxt)
+			defer cancelReq()
+			values, err := r.execute(ccctxt)
+			respChan <- &res{id: r.id, values: values, err: err}
+		}(request)
+	}
+
+	resp := &Response{}
+	done := false
+
+	// Wait for all responses
+	for range r.requests {
+		response := <-respChan
+
+		if done {
+			continue
+		}
+
+		if handleResponse(response, resp) {
+			done = true
+			cancel()
+		}
+	}
+
+	return resp
+}
+
+func handleResponse(response *res, resp *Response) bool {
+	if response.err != nil {
+		logger.Debugf("Error response was received from [%s]: %s", response.id, response.err)
+		return false
+	}
+
+	resp.RequestID = response.id
+	resp.Values = resp.Values.Merge(response.values)
+
+	if response.values.AllSet() {
+		logger.Debugf("All values were received from [%s]", response.id)
+		return true
+	}
+
+	logger.Debugf("One or more values are missing in response from [%s]", response.id)
+	return false
+}

--- a/pkg/common/multirequest/multirequest_test.go
+++ b/pkg/common/multirequest/multirequest_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package multirequest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common"
+)
+
+type requestTest struct {
+	id     string
+	err    error
+	values [][]byte
+}
+
+func TestAllSet(t *testing.T) {
+	t.Parallel()
+
+	re := New()
+
+	value1 := []byte("value1")
+	value2 := []byte("value2")
+	value3 := []byte("value3")
+
+	requests := []requestTest{
+		{id: "Request1", values: [][]byte{value1, value2, value3}},
+		{id: "Request2", values: [][]byte{value1, value2, value3}},
+		{id: "Request3", values: [][]byte{value1, value2, value3}},
+	}
+
+	for _, r := range requests {
+		re.Add(r.id, getRequestFunc(r))
+	}
+
+	result := re.Execute(context.Background())
+	require.NotNil(t, result)
+	require.Equal(t, 3, len(result.Values))
+	assert.Equal(t, value1, result.Values[0])
+	assert.Equal(t, value2, result.Values[1])
+	assert.Equal(t, value3, result.Values[2])
+}
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	re := New()
+
+	value1 := []byte("value1")
+	value2 := []byte("value2")
+	value3 := []byte("value3")
+
+	requests := []requestTest{
+		{id: "Request1", values: [][]byte{nil, value2, value3}},
+		{id: "Request2", values: [][]byte{value1, nil, value3}},
+		{id: "Request3", values: [][]byte{value1, value2, nil}},
+	}
+
+	for _, r := range requests {
+		re.Add(r.id, getRequestFunc(r))
+	}
+
+	result := re.Execute(context.Background())
+	require.NotNil(t, result)
+	require.Equal(t, 3, len(result.Values))
+
+	assert.Equal(t, value1, result.Values[0])
+	assert.Equal(t, value2, result.Values[1])
+	assert.Equal(t, value3, result.Values[2])
+}
+
+func TestTimeoutOrCancel(t *testing.T) {
+	t.Parallel()
+
+	re := New()
+
+	requests := []requestTest{
+		{id: "Request1"},
+		{id: "Request2"},
+		{id: "Request3"},
+	}
+
+	for _, r := range requests {
+		re.Add(r.id, getRequestFunc(r))
+	}
+
+	t.Run("Timeout", func(t *testing.T) {
+		t.Parallel()
+		ctxt, _ := context.WithTimeout(context.Background(), 1*time.Microsecond)
+		result := re.Execute(ctxt)
+		assert.True(t, result.Values.IsEmpty())
+	})
+
+	t.Run("Cancelled", func(t *testing.T) {
+		t.Parallel()
+		ctxt, cancel := context.WithCancel(context.Background())
+		go cancel()
+		result := re.Execute(ctxt)
+		assert.True(t, result.Values.IsEmpty())
+	})
+}
+
+func TestSomeFailed(t *testing.T) {
+	t.Parallel()
+
+	re := New()
+
+	value1 := []byte("value1")
+	value3 := []byte("value3")
+
+	requests := []requestTest{
+		{id: "Request1", err: errors.New("error for request1")},
+		{id: "Request2", values: [][]byte{value1, nil, value3}},
+		{id: "Request3", err: errors.New("error for request3")},
+	}
+
+	for _, r := range requests {
+		re.Add(r.id, getRequestFunc(r))
+	}
+
+	result := re.Execute(context.Background())
+	require.Equal(t, 3, len(result.Values))
+	assert.Equal(t, value1, result.Values[0])
+	assert.Nil(t, result.Values[1])
+	assert.Equal(t, value3, result.Values[2])
+}
+
+func getRequestFunc(r requestTest) Request {
+	return func(ctxt context.Context) (common.Values, error) {
+		select {
+		case <-time.After(5 * time.Millisecond):
+			return asValues(r.values), r.err
+		case <-ctxt.Done():
+			return nil, ctxt.Err()
+		}
+	}
+}
+
+func asValues(bv [][]byte) common.Values {
+	vals := make(common.Values, len(bv))
+	for i, v := range bv {
+		vals[i] = v
+	}
+	return vals
+}

--- a/pkg/common/requestmgr/requestmgr.go
+++ b/pkg/common/requestmgr/requestmgr.go
@@ -1,0 +1,207 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package requestmgr
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/pkg/errors"
+)
+
+var logger = flogging.MustGetLogger("kevlar-common")
+
+// Element contains transient data for a single key
+type Element struct {
+	Namespace  string
+	Collection string
+	Key        string
+	Value      []byte
+	Expiry     time.Time
+}
+
+// Elements is a slice of Element
+type Elements []*Element
+
+// Get returns the Element matching the given namespace, collection, and key.
+func (e Elements) Get(ns, coll, key string) (*Element, bool) {
+	for _, element := range e {
+		if element.Namespace == ns && element.Collection == coll && element.Key == key {
+			return element, true
+		}
+	}
+	return nil, false
+}
+
+// Response is the response from a remote peer for a collection of transient data keys
+type Response struct {
+	Endpoint  string   // The endpoint of the peer that sent the response
+	MSPID     string   // The MSP ID of the peer that sent the response
+	Signature []byte   // The signature of the peer that provided the data
+	Identity  []byte   // The identity of the peer that sent the response
+	Data      Elements // The transient data
+}
+
+// Request is an interface to get the response
+type Request interface {
+	ID() uint64
+	GetResponse(context context.Context) (*Response, error)
+	Cancel()
+}
+
+// RequestMgr is an interface to create a new request and to respond to the request
+type RequestMgr interface {
+	Respond(reqID uint64, response *Response)
+	NewRequest() Request
+}
+
+type requestMgr struct {
+	mutex sync.RWMutex
+	mgrs  map[string]*channelMgr
+}
+
+var mgr = newRequestMgr()
+
+// Get returns the RequestMgr for the given channel
+func Get(channelID string) RequestMgr {
+	return mgr.forChannel(channelID)
+}
+
+func newRequestMgr() *requestMgr {
+	return &requestMgr{
+		mgrs: make(map[string]*channelMgr),
+	}
+}
+
+func (m *requestMgr) forChannel(channelID string) RequestMgr {
+	m.mutex.RLock()
+	cm, ok := m.mgrs[channelID]
+	m.mutex.RUnlock()
+
+	if ok {
+		return cm
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	cm = newChannelMgr(channelID)
+	m.mgrs[channelID] = cm
+	return cm
+}
+
+type channelMgr struct {
+	mutex         sync.RWMutex
+	channelID     string
+	requests      map[uint64]*request
+	nextRequestID uint64
+}
+
+func newChannelMgr(channelID string) *channelMgr {
+	logger.Debugf("[%s] Creating new channel request manager", channelID)
+	return &channelMgr{
+		channelID:     channelID,
+		requests:      make(map[uint64]*request),
+		nextRequestID: 1000000000,
+	}
+}
+
+func (c *channelMgr) NewRequest() Request {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	reqID := c.newRequestID()
+
+	logger.Debugf("[%s] Subscribing to transient data request %d", c.channelID, reqID)
+
+	s := newRequest(reqID, c.channelID, c.remove)
+	c.requests[reqID] = s
+
+	return s
+}
+
+func (c *channelMgr) Respond(reqID uint64, response *Response) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	s, ok := c.requests[reqID]
+	if !ok {
+		logger.Debugf("[%s] No transient data requests for %d", c.channelID, reqID)
+		return
+	}
+
+	logger.Debugf("[%s] Publishing transient data response %d", c.channelID, reqID)
+	s.respond(response)
+}
+
+func (c *channelMgr) remove(reqID uint64) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if _, ok := c.requests[reqID]; !ok {
+		return
+	}
+
+	delete(c.requests, reqID)
+	logger.Debugf("[%s] Unsubscribed from transient data request %d", c.channelID, reqID)
+}
+
+func (c *channelMgr) newRequestID() uint64 {
+	return atomic.AddUint64(&c.nextRequestID, 1)
+}
+
+type request struct {
+	reqID     uint64
+	channelID string
+	remove    func(reqID uint64)
+	respChan  chan *Response
+	done      bool
+}
+
+func newRequest(reqID uint64, channelID string, remove func(reqID uint64)) *request {
+	return &request{
+		reqID:     reqID,
+		channelID: channelID,
+		respChan:  make(chan *Response, 1),
+		remove:    remove,
+	}
+}
+
+func (r *request) ID() uint64 {
+	return r.reqID
+}
+
+func (r *request) GetResponse(ctxt context.Context) (*Response, error) {
+	if r.done {
+		return nil, errors.New("request has already completed")
+	}
+
+	logger.Debugf("[%s] Waiting for response to request %d", r.channelID, r.ID())
+
+	defer r.Cancel()
+
+	select {
+	case <-ctxt.Done():
+		logger.Debugf("[%s] Request %d was timed out or cancelled", r.channelID, r.ID())
+		return nil, ctxt.Err()
+	case item := <-r.respChan:
+		logger.Debugf("[%s] Got response for request %d", r.channelID, r.ID())
+		return item, nil
+	}
+}
+
+func (r *request) Cancel() {
+	r.remove(r.reqID)
+	r.done = true
+}
+
+func (r *request) respond(res *Response) {
+	r.respChan <- res
+}

--- a/pkg/common/requestmgr/requestmgr_test.go
+++ b/pkg/common/requestmgr/requestmgr_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package requestmgr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	channel1 = "channel1"
+	channel2 = "channel2"
+
+	timeout = 200 * time.Millisecond
+)
+
+func TestElements_Get(t *testing.T) {
+	const (
+		ns1   = "ns1"
+		coll1 = "coll1"
+		coll2 = "coll2"
+		key1  = "key1"
+		key2  = "key2"
+		key3  = "key3"
+	)
+
+	e1 := &Element{Namespace: ns1, Collection: coll1, Key: key1, Expiry: time.Now().Add(time.Minute)}
+	e2 := &Element{Namespace: ns1, Collection: coll2, Key: key1, Expiry: time.Now().Add(time.Minute)}
+	e3 := &Element{Namespace: ns1, Collection: coll1, Key: key2, Expiry: time.Now().Add(time.Minute)}
+
+	elements := Elements{e1, e2, e3}
+
+	e, ok := elements.Get(ns1, coll1, key1)
+	assert.True(t, ok)
+	require.NotNil(t, e)
+	assert.Equal(t, e1, e)
+
+	e, ok = elements.Get(ns1, coll2, key1)
+	assert.True(t, ok)
+	require.NotNil(t, e)
+	assert.Equal(t, e2, e)
+
+	e, ok = elements.Get(ns1, coll1, key3)
+	assert.False(t, ok)
+	require.Nil(t, e)
+}
+
+func TestResponseMgr(t *testing.T) {
+	t.Parallel()
+
+	m1 := Get(channel1)
+	require.NotNil(t, m1)
+
+	m2 := Get(channel2)
+	require.NotNil(t, m2)
+	require.False(t, m1 == m2)
+
+	t.Run("Response received - channel1", func(t *testing.T) {
+		t.Parallel()
+
+		req1 := m1.NewRequest()
+		require.NotNil(t, req1)
+
+		req2 := m1.NewRequest()
+		require.NotNil(t, req2)
+
+		expect1 := &Response{Endpoint: "p1"}
+		expect2 := &Response{Endpoint: "p2"}
+
+		go func() {
+			m1.Respond(req1.ID(), expect1)
+			m1.Respond(req2.ID(), expect2)
+		}()
+
+		res1, err := req1.GetResponse(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, expect1, res1)
+
+		res2, err := req2.GetResponse(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, expect2, res2)
+	})
+
+	t.Run("Response received - channel2", func(t *testing.T) {
+		t.Parallel()
+
+		req3 := m2.NewRequest()
+		require.NotNil(t, req3)
+
+		expect3 := &Response{Endpoint: "p3"}
+
+		go func() {
+			m2.Respond(req3.ID(), expect3)
+		}()
+
+		res3, err := req3.GetResponse(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, expect3, res3)
+	})
+
+	t.Run("No response", func(t *testing.T) {
+		t.Parallel()
+
+		req4 := m2.NewRequest()
+		require.NotNil(t, req4)
+
+		// Should time out since we never publish a response
+		ctxt, _ := context.WithTimeout(context.Background(), timeout)
+		_, err := req4.GetResponse(ctxt)
+		require.Error(t, err)
+	})
+
+	t.Run("Context cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		req5 := m2.NewRequest()
+		require.NotNil(t, req5)
+
+		ctxt, cancel := context.WithTimeout(context.Background(), timeout)
+
+		go func() {
+			cancel()
+			time.Sleep(10 * time.Millisecond)
+			m2.Respond(req5.ID(), &Response{}) // No subscribers since the context was cancelled
+		}()
+
+		// Should get error that the context was cancelled
+		_, err := req5.GetResponse(ctxt)
+		require.Error(t, err)
+		assert.EqualError(t, err, "context canceled")
+	})
+
+	t.Run("Request cancelled", func(t *testing.T) {
+		t.Parallel()
+
+		req := m2.NewRequest()
+		require.NotNil(t, req)
+		req.Cancel()
+
+		// Should get error that the request was cancelled
+		_, err := req.GetResponse(context.Background())
+		require.Error(t, err)
+		assert.EqualError(t, err, "request has already completed")
+	})
+}

--- a/pkg/common/support/collconfigretriever.go
+++ b/pkg/common/support/collconfigretriever.go
@@ -1,0 +1,193 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package support
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/bluele/gcache"
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/core/ledger"
+	mspmgmt "github.com/hyperledger/fabric/msp/mgmt"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/pkg/errors"
+)
+
+type peerLedger interface {
+	// NewQueryExecutor gives handle to a query executor.
+	// A client can obtain more than one 'QueryExecutor's for parallel execution.
+	// Any synchronization should be performed at the implementation level if required
+	NewQueryExecutor() (ledger.QueryExecutor, error)
+}
+
+// CollectionConfigRetriever loads and caches collection configuration and policies
+type CollectionConfigRetriever struct {
+	channelID string
+	ledger    peerLedger
+	cache     gcache.Cache
+}
+
+// NewCollectionConfigRetriever returns a new collection configuration retriever
+func NewCollectionConfigRetriever(channelID string, ledger peerLedger) *CollectionConfigRetriever {
+	r := &CollectionConfigRetriever{
+		channelID: channelID,
+		ledger:    ledger,
+	}
+
+	r.cache = gcache.New(0).Simple().LoaderFunc(
+		func(key interface{}) (interface{}, error) {
+			ccID := key.(string)
+			configs, err := r.loadConfigAndPolicy(ccID)
+			if err != nil {
+				logger.Debugf("Error loading collection configs for chaincode [%s]: %s", ccID, err)
+				return nil, err
+			}
+			return configs, nil
+		}).Build()
+
+	return r
+}
+
+type cacheItem struct {
+	config *common.StaticCollectionConfig
+	policy privdata.CollectionAccessPolicy
+}
+
+type cacheItems []*cacheItem
+
+func (c cacheItems) get(coll string) (*cacheItem, error) {
+	for _, item := range c {
+		if item.config.Name == coll {
+			return item, nil
+		}
+	}
+	return nil, errors.Errorf("configuration not found for collection [%s]", coll)
+}
+
+func (c cacheItems) config(coll string) (*common.StaticCollectionConfig, error) {
+	item, err := c.get(coll)
+	if err != nil {
+		return nil, err
+	}
+	return item.config, nil
+}
+
+func (c cacheItems) policy(coll string) (privdata.CollectionAccessPolicy, error) {
+	item, err := c.get(coll)
+	if err != nil {
+		return nil, err
+	}
+	return item.policy, nil
+}
+
+// Config returns the configuration for the given collection
+func (s *CollectionConfigRetriever) Config(ns, coll string) (*common.StaticCollectionConfig, error) {
+	logger.Debugf("[%s] Retrieving collection configuration for chaincode [%s]", s.channelID, ns)
+	item, err := s.cache.Get(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	configs, ok := item.(cacheItems)
+	if !ok {
+		panic(fmt.Sprintf("unexpected type in cache: %s", reflect.TypeOf(item)))
+	}
+
+	return configs.config(coll)
+}
+
+// Policy returns the collection access policy
+func (s *CollectionConfigRetriever) Policy(ns, coll string) (privdata.CollectionAccessPolicy, error) {
+	logger.Debugf("[%s] Retrieving collection policy for chaincode [%s]", s.channelID, ns)
+	item, err := s.cache.Get(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	configs, ok := item.(cacheItems)
+	if !ok {
+		panic(fmt.Sprintf("unexpected type in cache: %s", reflect.TypeOf(item)))
+	}
+
+	return configs.policy(coll)
+}
+
+func (s *CollectionConfigRetriever) loadConfigAndPolicy(ns string) (cacheItems, error) {
+	configs, err := s.loadConfigs(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	var items []*cacheItem
+	for _, config := range configs {
+		policy, err := s.loadPolicy(ns, config)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, &cacheItem{
+			config: config,
+			policy: policy,
+		})
+	}
+
+	return items, nil
+}
+
+func (s *CollectionConfigRetriever) loadConfigs(ns string) ([]*common.StaticCollectionConfig, error) {
+	logger.Debugf("[%s] Loading collection configs for chaincode [%s]", s.channelID, ns)
+
+	cpBytes, err := s.getCCPBytes(ns)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error retrieving collection config for chaincode [%s]", ns)
+	}
+	if cpBytes == nil {
+		return nil, errors.Errorf("no collection config for chaincode [%s]", ns)
+	}
+
+	cp := &common.CollectionConfigPackage{}
+	err = proto.Unmarshal(cpBytes, cp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid collection configuration for [%s]", ns)
+	}
+
+	var configs []*common.StaticCollectionConfig
+	for _, collConfig := range cp.Config {
+		config := collConfig.GetStaticCollectionConfig()
+		logger.Debugf("[%s] Checking collection config for [%s:%+v]", s.channelID, ns, config)
+		if config == nil {
+			logger.Warningf("[%s] No config found for a collection in namespace [%s]", s.channelID, ns)
+			continue
+		}
+		configs = append(configs, config)
+	}
+
+	return configs, nil
+}
+
+func (s *CollectionConfigRetriever) loadPolicy(ns string, config *common.StaticCollectionConfig) (privdata.CollectionAccessPolicy, error) {
+	logger.Debugf("[%s] Loading collection policy for [%s:%s]", s.channelID, ns, config.Name)
+
+	colAP := &privdata.SimpleCollection{}
+	err := colAP.Setup(config, mspmgmt.GetIdentityDeserializer(s.channelID))
+	if err != nil {
+		return nil, errors.Wrapf(err, "error setting up collection policy %s", config.Name)
+	}
+
+	return colAP, nil
+}
+
+func (s *CollectionConfigRetriever) getCCPBytes(ns string) ([]byte, error) {
+	qe, err := s.ledger.NewQueryExecutor()
+	if err != nil {
+		return nil, err
+	}
+	defer qe.Done()
+
+	return qe.GetState("lscc", privdata.BuildCollectionKVSKey(ns))
+}

--- a/pkg/common/support/collconfigretriever_test.go
+++ b/pkg/common/support/collconfigretriever_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package support
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	coll3 = "collection3"
+)
+
+func TestConfigRetriever(t *testing.T) {
+	const channelID = "testchannel"
+	const lscc = "lscc"
+
+	nsBuilder := mocks.NewNamespaceBuilder(ns1)
+	nsBuilder.Collection(coll1).StaticConfig("OR ('Org1.member','Org2.member')", 3, 3, 100)
+	nsBuilder.Collection(coll2).TransientConfig("OR ('Org1.member','Org2.member')", 3, 3, "1m")
+
+	configPkgBytes, err := proto.Marshal(nsBuilder.BuildCollectionConfig())
+	require.NoError(t, err)
+
+	state := make(map[string]map[string][]byte)
+	state[lscc] = make(map[string][]byte)
+	state[lscc][privdata.BuildCollectionKVSKey(ns1)] = configPkgBytes
+
+	r := NewCollectionConfigRetriever(channelID, &mocks.Ledger{
+		QueryExecutor: mocks.NewQueryExecutor(state),
+	})
+	require.NotNil(t, r)
+
+	t.Run("Policy", func(t *testing.T) {
+		policy, err := r.Policy(ns1, coll2)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+		assert.Equal(t, 2, len(policy.MemberOrgs()))
+
+		policy2, err := r.Policy(ns1, coll2)
+		require.NoError(t, err)
+		assert.Truef(t, policy == policy2, "expecting policy to be retrieved from cache")
+
+		policy, err = r.Policy(ns1, coll1)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+		assert.Equal(t, 2, len(policy.MemberOrgs()))
+	})
+
+	t.Run("Config", func(t *testing.T) {
+		config, err := r.Config(ns1, coll2)
+		require.NoError(t, err)
+		assert.Equal(t, coll2, config.Name)
+		assert.Equal(t, int32(3), config.RequiredPeerCount)
+		assert.Equal(t, common.CollectionType_COL_TRANSIENT, config.Type)
+		assert.Equal(t, "1m", config.TimeToLive)
+
+		config2, err := r.Config(ns1, coll2)
+		require.NoError(t, err)
+		assert.Truef(t, config == config2, "expecting config to be retrieved from cache")
+	})
+
+	t.Run("Config not found -> error", func(t *testing.T) {
+		config, err := r.Config(ns1, coll3)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "configuration not found")
+		assert.Nil(t, config)
+	})
+}
+
+func TestConfigRetrieverError(t *testing.T) {
+	const channelID = "testchannel"
+
+	state := make(map[string]map[string][]byte)
+
+	expectedErr := fmt.Errorf("injected error")
+	r := NewCollectionConfigRetriever(channelID, &mocks.Ledger{
+		QueryExecutor: mocks.NewQueryExecutor(state).WithError(expectedErr),
+	})
+	require.NotNil(t, r)
+
+	t.Run("Policy", func(t *testing.T) {
+		policy, err := r.Policy(ns1, coll2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+		assert.Nil(t, policy)
+	})
+
+	t.Run("Config", func(t *testing.T) {
+		config, err := r.Config(ns1, coll2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+		assert.Nil(t, config)
+	})
+}

--- a/pkg/common/support/support.go
+++ b/pkg/common/support/support.go
@@ -1,0 +1,57 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package support
+
+import (
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/protos/common"
+)
+
+var logger = flogging.MustGetLogger("kevlar-common")
+
+type ledgerProvider func(channelID string) ledger.PeerLedger
+
+// Support holds the ledger provider and the cache
+type Support struct {
+	getLedger            ledgerProvider
+	configRetrieverCache gcache.Cache
+}
+
+// New creates a new Support using the ledger provider
+func New(ledgerProvider ledgerProvider) *Support {
+	s := &Support{
+		getLedger: ledgerProvider,
+	}
+	s.configRetrieverCache = gcache.New(0).Simple().LoaderFunc(
+		func(key interface{}) (interface{}, error) {
+			channelID := key.(string)
+			logger.Debugf("[%s] Creating collection config retriever", channelID)
+			return NewCollectionConfigRetriever(channelID, s.getLedger(channelID)), nil
+		}).Build()
+	return s
+}
+
+// Config returns the configuration for the given collection
+func (s *Support) Config(channelID, ns, coll string) (*common.StaticCollectionConfig, error) {
+	ccRetriever, err := s.configRetrieverCache.Get(channelID)
+	if err != nil {
+		return nil, err
+	}
+	return ccRetriever.(*CollectionConfigRetriever).Config(ns, coll)
+}
+
+// Policy returns the collection access policy for the given collection
+func (s *Support) Policy(channelID, ns, coll string) (privdata.CollectionAccessPolicy, error) {
+	ccRetriever, err := s.configRetrieverCache.Get(channelID)
+	if err != nil {
+		return nil, err
+	}
+	return ccRetriever.(*CollectionConfigRetriever).Policy(ns, coll)
+}

--- a/pkg/common/support/support_test.go
+++ b/pkg/common/support/support_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package support
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	ns1   = "chaincode1"
+	coll1 = "collection1"
+	coll2 = "collection2"
+)
+
+func TestSupport(t *testing.T) {
+	const channelID = "testchannel"
+	const lscc = "lscc"
+
+	nsBuilder := mocks.NewNamespaceBuilder(ns1)
+	nsBuilder.Collection(coll1).StaticConfig("OR ('Org1.member','Org2.member')", 3, 3, 100)
+	nsBuilder.Collection(coll2).TransientConfig("OR ('Org1.member','Org2.member')", 3, 3, "1m")
+
+	configPkgBytes, err := proto.Marshal(nsBuilder.BuildCollectionConfig())
+	require.NoError(t, err)
+
+	state := make(map[string]map[string][]byte)
+	state[lscc] = make(map[string][]byte)
+	state[lscc][privdata.BuildCollectionKVSKey(ns1)] = configPkgBytes
+
+	ledgerProvider := func(channelID string) ledger.PeerLedger {
+		return &mocks.Ledger{
+			QueryExecutor: mocks.NewQueryExecutor(state),
+		}
+	}
+
+	s := New(ledgerProvider)
+	require.NotNil(t, s)
+
+	t.Run("Policy", func(t *testing.T) {
+		policy, err := s.Policy(channelID, ns1, coll2)
+		require.NoError(t, err)
+		require.NotNil(t, policy)
+	})
+
+	t.Run("Config", func(t *testing.T) {
+		config, err := s.Config(channelID, ns1, coll2)
+		require.NoError(t, err)
+		assert.Equal(t, coll2, config.Name)
+		assert.Equal(t, int32(3), config.RequiredPeerCount)
+		assert.Equal(t, common.CollectionType_COL_TRANSIENT, config.Type)
+		assert.Equal(t, "1m", config.TimeToLive)
+	})
+}

--- a/pkg/gossip/dispatcher/dispatcher.go
+++ b/pkg/gossip/dispatcher/dispatcher.go
@@ -1,0 +1,257 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dispatcher
+
+import (
+	"time"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/extensions/collections/api/store"
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	ledgerconfig "github.com/hyperledger/fabric/extensions/roles"
+	gossipapi "github.com/hyperledger/fabric/gossip/api"
+	gcommon "github.com/hyperledger/fabric/gossip/common"
+	gdiscovery "github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/hyperledger/fabric/gossip/protoext"
+	cb "github.com/hyperledger/fabric/protos/common"
+	gproto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/requestmgr"
+	supp "github.com/trustbloc/fabric-peer-ext/pkg/common/support"
+	"go.uber.org/zap/zapcore"
+)
+
+var logger = flogging.MustGetLogger("kevlar_gossip_state")
+
+type gossipAdapter interface {
+	PeersOfChannel(gcommon.ChainID) []gdiscovery.NetworkMember
+	SelfMembershipInfo() gdiscovery.NetworkMember
+	IdentityInfo() gossipapi.PeerIdentitySet
+}
+
+type ccRetriever interface {
+	Config(ns, coll string) (*cb.StaticCollectionConfig, error)
+	Policy(ns, coll string) (privdata.CollectionAccessPolicy, error)
+}
+
+// isEndorser should only be overridden for unit testing
+var isEndorser = func() bool {
+	return ledgerconfig.IsEndorser()
+}
+
+// New returns a new Gossip message dispatcher
+func New(
+	channelID string,
+	dataStore storeapi.Store,
+	gossipAdapter gossipAdapter,
+	ledger ledger.PeerLedger) *Dispatcher {
+	return &Dispatcher{
+		ccRetriever: supp.NewCollectionConfigRetriever(channelID, ledger),
+		channelID:   channelID,
+		reqMgr:      requestmgr.Get(channelID),
+		dataStore:   dataStore,
+		discovery:   discovery.New(channelID, gossipAdapter),
+	}
+}
+
+// Dispatcher is a Gossip message dispatcher
+type Dispatcher struct {
+	ccRetriever
+	channelID string
+	reqMgr    requestmgr.RequestMgr
+	dataStore storeapi.Store
+	discovery *discovery.Discovery
+}
+
+// Dispatch handles the message and returns true if the message was handled; false if the message is unrecognized
+func (s *Dispatcher) Dispatch(msg protoext.ReceivedMessage) bool {
+	switch {
+	case msg.GetGossipMessage().GetCollDataReq() != nil:
+		logger.Debug("Handling collection data request message")
+		s.handleDataRequest(msg)
+		return true
+	case msg.GetGossipMessage().GetCollDataRes() != nil:
+		logger.Debug("Handling collection data response message")
+		s.handleDataResponse(msg)
+		return true
+	default:
+		logger.Debug("Not handling msg")
+		return false
+	}
+}
+
+func (s *Dispatcher) handleDataRequest(msg protoext.ReceivedMessage) {
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		logger.Debugf("[ENTER] -> handleDataRequest")
+		defer logger.Debug("[EXIT] ->  handleDataRequest")
+	}
+
+	if !isEndorser() {
+		logger.Warningf("Non-endorser should not be receiving collection data request messages")
+		return
+	}
+
+	req := msg.GetGossipMessage().GetCollDataReq()
+	if len(req.Digests) == 0 {
+		logger.Warning("Got nil digests in CollDataRequestMsg")
+		return
+	}
+
+	reqMSPID, ok := s.discovery.GetMSPID(msg.GetConnectionInfo().ID)
+	if !ok {
+		logger.Warningf("Unable to get MSP ID from PKI ID of remote endpoint [%s]", msg.GetConnectionInfo().Endpoint)
+		return
+	}
+
+	responses, err := s.getRequestData(reqMSPID, req)
+	if err != nil {
+		logger.Warningf("[%s] Error processing request for data: %s", s.channelID, err.Error())
+		return
+	}
+
+	logger.Debugf("[%s] Responding with collection data for request %d", s.channelID, req.Nonce)
+
+	msg.Respond(&gproto.GossipMessage{
+		// Copy nonce field from the request, so it will be possible to match response
+		Nonce:   msg.GetGossipMessage().Nonce,
+		Tag:     gproto.GossipMessage_CHAN_ONLY,
+		Channel: []byte(s.channelID),
+		Content: &gproto.GossipMessage_CollDataRes{
+			CollDataRes: &gproto.RemoteCollDataResponse{
+				Nonce:    req.Nonce,
+				Elements: responses,
+			},
+		},
+	})
+}
+
+func (s *Dispatcher) handleDataResponse(msg protoext.ReceivedMessage) {
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		logger.Debug("[ENTER] -> handleDataResponse")
+		defer logger.Debug("[EXIT] ->  handleDataResponse")
+	}
+
+	mspID, ok := s.discovery.GetMSPID(msg.GetConnectionInfo().ID)
+	if !ok {
+		logger.Errorf("Unable to get MSP ID from PKI ID")
+		return
+	}
+
+	res := msg.GetGossipMessage().GetCollDataRes()
+
+	s.reqMgr.Respond(
+		res.Nonce,
+		&requestmgr.Response{
+			Endpoint: msg.GetConnectionInfo().Endpoint,
+			MSPID:    mspID,
+			// FIXME: Should the message be signed?
+			//Signature:   element.Signature,
+			//Identity:    element.Identity,
+			Data: s.getResponseData(res),
+		},
+	)
+}
+
+func (s *Dispatcher) getRequestData(reqMSPID string, req *gproto.RemoteCollDataRequest) ([]*gproto.CollDataElement, error) {
+	var responses []*gproto.CollDataElement
+	for _, digest := range req.Digests {
+		if digest == nil {
+			return nil, errors.New("got nil digest in CollDataRequestMsg")
+		}
+		e, err := s.getRequestDataElement(reqMSPID, digest)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, e)
+	}
+	return responses, nil
+}
+
+func (s *Dispatcher) getRequestDataElement(reqMSPID string, digest *gproto.CollDataDigest) (*gproto.CollDataElement, error) {
+	key := store.NewKey(digest.EndorsedAtTxID, digest.Namespace, digest.Collection, digest.Key)
+
+	logger.Debugf("[%s] Getting data for key [%s]", s.channelID, key)
+	value, err := s.getDataForKey(key)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "error getting data for [%s]", key)
+	}
+
+	e := &gproto.CollDataElement{
+		Digest: digest,
+	}
+
+	authorized, err := s.isAuthorized(reqMSPID, digest.Namespace, digest.Collection)
+	if err != nil {
+		return nil, err
+	}
+
+	if !authorized {
+		logger.Infof("[%s] Requesting MSP [%s] is not authorized to read data for [%s]", s.channelID, reqMSPID, key)
+	} else if value != nil {
+		e.Value = value.Value
+		e.ExpiryTime = common.ToTimestamp(value.Expiry)
+	}
+
+	return e, nil
+}
+
+func (s *Dispatcher) getResponseData(res *gproto.RemoteCollDataResponse) []*requestmgr.Element {
+	var elements []*requestmgr.Element
+	for _, e := range res.Elements {
+		d := e.Digest
+		logger.Debugf("[%s] Coll data response for request %d - [%s:%s:%s] received", s.channelID, res.Nonce, d.Namespace, d.Collection, d.Key)
+
+		element := &requestmgr.Element{
+			Namespace:  d.Namespace,
+			Collection: d.Collection,
+			Key:        d.Key,
+			Value:      e.Value,
+		}
+
+		if e.ExpiryTime != nil {
+			element.Expiry = time.Unix(e.ExpiryTime.Seconds, 0)
+		}
+		elements = append(elements, element)
+	}
+	return elements
+}
+
+func (s *Dispatcher) getDataForKey(key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	logger.Debugf("[%s] Getting config for [%s:%s]", s.channelID, key.Namespace, key.Collection)
+	config, err := s.Config(key.Namespace, key.Collection)
+	if err != nil {
+		return nil, err
+	}
+
+	switch config.Type {
+	case cb.CollectionType_COL_TRANSIENT:
+		logger.Debugf("[%s] Getting transient data for key [%s]", s.channelID, key)
+		return s.dataStore.GetTransientData(key)
+	default:
+		return nil, errors.Errorf("unsupported collection type: [%s]", config.Type)
+	}
+}
+
+// isAuthorized determines whether the given MSP ID is authorized to read data from the given collection
+func (s *Dispatcher) isAuthorized(mspID string, ns, coll string) (bool, error) {
+	policy, err := s.Policy(ns, coll)
+	if err != nil {
+		return false, errors.WithMessagef(err, "unable to get policy for collection [%s:%s]", ns, coll)
+	}
+
+	for _, memberMSPID := range policy.MemberOrgs() {
+		if memberMSPID == mspID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/gossip/dispatcher/dispatcher_test.go
+++ b/pkg/gossip/dispatcher/dispatcher_test.go
@@ -1,0 +1,282 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dispatcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/extensions/collections/api/store"
+	gcommon "github.com/hyperledger/fabric/gossip/common"
+	gproto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/requestmgr"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+var (
+	org1MSPID      = "Org1MSP"
+	p1Org1Endpoint = "p1.org1.com"
+	p2Org1Endpoint = "p2.org1.com"
+	p3Org1Endpoint = "p3.org1.com"
+
+	org2MSPID      = "Org2MSP"
+	p1Org2Endpoint = "p1.org2.com"
+	p2Org2Endpoint = "p2.org2.com"
+	p3Org2Endpoint = "p3.org2.com"
+
+	org3MSPID      = "Org3MSP"
+	p1Org3Endpoint = "p1.org3.com"
+	p2Org3Endpoint = "p2.org3.com"
+	p3Org3Endpoint = "p3.org3.com"
+)
+
+var (
+	p1Org1PKIID = gcommon.PKIidType("pkiid_P1O1")
+	p2Org1PKIID = gcommon.PKIidType("pkiid_P2O1")
+	p3Org1PKIID = gcommon.PKIidType("pkiid_P3O1")
+
+	p1Org2PKIID = gcommon.PKIidType("pkiid_P1O2")
+	p2Org2PKIID = gcommon.PKIidType("pkiid_P2O2")
+	p3Org2PKIID = gcommon.PKIidType("pkiid_P3O2")
+
+	p1Org3PKIID = gcommon.PKIidType("pkiid_P1O3")
+	p2Org3PKIID = gcommon.PKIidType("pkiid_P2O3")
+	p3Org3PKIID = gcommon.PKIidType("pkiid_P3O3")
+
+	endorserRole  = string(roles.EndorserRole)
+	committerRole = string(roles.CommitterRole)
+)
+
+func TestDispatchUnhandled(t *testing.T) {
+	const channelID = "testchannel"
+
+	dispatcher := New(
+		channelID,
+		&mocks.DataStore{},
+		mocks.NewMockGossipAdapter(),
+		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor(nil)},
+	)
+
+	var response *gproto.GossipMessage
+	msg := &mocks.MockReceivedMessage{
+		Message: mocks.NewDataMsg(channelID),
+		RespondTo: func(msg *gproto.GossipMessage) {
+			response = msg
+		},
+	}
+	assert.False(t, dispatcher.Dispatch(msg))
+	require.Nil(t, response)
+}
+
+func TestDispatchDataRequest(t *testing.T) {
+	const channelID = "testchannel"
+	const lscc = "lscc"
+	const ns1 = "ns1"
+	const ns2 = "ns2"
+	const coll1 = "coll1"
+	const coll2 = "coll2"
+
+	key1 := store.NewKey("txID1", ns1, coll1, "key1")
+	key2 := store.NewKey("txID1", ns2, coll2, "key2")
+
+	value1 := &store.ExpiringValue{Value: []byte("value1")}
+	value2 := &store.ExpiringValue{Value: []byte("value2")}
+
+	nsBuilder1 := mocks.NewNamespaceBuilder(ns1)
+	nsBuilder1.Collection(coll1).TransientConfig("OR ('Org1MSP.member','Org2MSP.member')", 3, 3, "1m")
+
+	nsBuilder2 := mocks.NewNamespaceBuilder(ns2)
+	nsBuilder2.Collection(coll2).TransientConfig("OR ('Org1MSP.member','Org2MSP.member','Org3MSP.member')", 3, 3, "1m")
+
+	configPkgBytes1, err := proto.Marshal(nsBuilder1.BuildCollectionConfig())
+	require.NoError(t, err)
+	configPkgBytes2, err := proto.Marshal(nsBuilder2.BuildCollectionConfig())
+	require.NoError(t, err)
+
+	state := make(map[string]map[string][]byte)
+	state[lscc] = make(map[string][]byte)
+	state[lscc][privdata.BuildCollectionKVSKey(ns1)] = configPkgBytes1
+	state[lscc][privdata.BuildCollectionKVSKey(ns2)] = configPkgBytes2
+
+	gossipAdapter := mocks.NewMockGossipAdapter()
+	gossipAdapter.Self(org1MSPID, mocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+		Member(org1MSPID, mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, committerRole)).
+		Member(org1MSPID, mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, committerRole)).
+		Member(org2MSPID, mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)).
+		Member(org2MSPID, mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, committerRole)).
+		Member(org2MSPID, mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p1Org3Endpoint, p1Org3PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p2Org3Endpoint, p2Org3PKIID, committerRole)).
+		Member(org3MSPID, mocks.NewMember(p3Org3Endpoint, p3Org3PKIID, endorserRole))
+
+	dispatcher := New(
+		channelID,
+		mocks.NewDataStore().TransientData(key1, value1).TransientData(key2, value2),
+		gossipAdapter,
+		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor(state)},
+	)
+	require.NotNil(t, dispatcher)
+
+	t.Run("Endorser -> success", func(t *testing.T) {
+		reqID1 := uint64(1000)
+
+		var response *gproto.GossipMessage
+		msg := &mocks.MockReceivedMessage{
+			Message: mocks.NewCollDataReqMsg(channelID, reqID1, key1, key2),
+			RespondTo: func(msg *gproto.GossipMessage) {
+				response = msg
+			},
+			Member: mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole),
+		}
+		assert.True(t, dispatcher.Dispatch(msg))
+		require.NotNil(t, response)
+		assert.Equal(t, []byte(channelID), response.Channel)
+		assert.Equal(t, gproto.GossipMessage_CHAN_ONLY, response.Tag)
+
+		res := response.GetCollDataRes()
+		require.NotNil(t, res)
+		assert.Equal(t, reqID1, res.Nonce)
+		require.Equal(t, 2, len(res.Elements))
+
+		element := res.Elements[0]
+		require.NotNil(t, element.Digest)
+		assert.Equal(t, key1.Namespace, element.Digest.Namespace)
+		assert.Equal(t, key1.Collection, element.Digest.Collection)
+		assert.Equal(t, key1.Key, element.Digest.Key)
+		assert.Equal(t, value1.Value, element.Value)
+
+		element = res.Elements[1]
+		require.NotNil(t, element.Digest)
+		assert.Equal(t, key2.Namespace, element.Digest.Namespace)
+		assert.Equal(t, key2.Collection, element.Digest.Collection)
+		assert.Equal(t, key2.Key, element.Digest.Key)
+		assert.Equal(t, value2.Value, element.Value)
+	})
+
+	t.Run("Non-Endorser -> no response", func(t *testing.T) {
+		f := isEndorser
+		defer func() { isEndorser = f }()
+		isEndorser = func() bool { return false }
+
+		reqID2 := uint64(1001)
+
+		var response *gproto.GossipMessage
+		msg := &mocks.MockReceivedMessage{
+			Message: mocks.NewCollDataReqMsg(channelID, reqID2, key1, key2),
+			RespondTo: func(msg *gproto.GossipMessage) {
+				response = msg
+			},
+		}
+		assert.True(t, dispatcher.Dispatch(msg))
+		require.Nil(t, response)
+	})
+
+	t.Run("Access Denied -> nil response", func(t *testing.T) {
+		reqID2 := uint64(1001)
+
+		var response *gproto.GossipMessage
+		msg := &mocks.MockReceivedMessage{
+			Message: mocks.NewCollDataReqMsg(channelID, reqID2, key1, key2),
+			RespondTo: func(msg *gproto.GossipMessage) {
+				response = msg
+			},
+			Member: mocks.NewMember(p1Org3Endpoint, p1Org3PKIID, endorserRole), // An Org3 member is requesting data he doesn't have access to
+		}
+		assert.True(t, dispatcher.Dispatch(msg))
+		require.NotNil(t, response)
+		require.NotNil(t, response.GetCollDataRes())
+		require.Equal(t, 2, len(response.GetCollDataRes().Elements))
+
+		// Org3 doesn't have access to ns1:collection1
+		require.NotNil(t, response.GetCollDataRes().Elements[0])
+		assert.Nil(t, response.GetCollDataRes().Elements[0].Value)
+
+		// Org3 has access to ns2:collection2
+		require.NotNil(t, response.GetCollDataRes().Elements[1])
+		assert.NotNil(t, response.GetCollDataRes().Elements[1].Value)
+	})
+}
+
+func TestDispatchDataResponse(t *testing.T) {
+	const channelID = "testchannel"
+	key1 := store.NewKey("txID1", "ns1", "coll1", "key1")
+	key2 := store.NewKey("txID1", "ns2", "coll2", "key2")
+
+	value1 := &store.ExpiringValue{Value: []byte("value1")}
+	value2 := &store.ExpiringValue{Value: []byte("value2")}
+
+	p1Org1 := mocks.NewMember(p1Org1Endpoint, p1Org1PKIID)
+	p1Org2 := mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)
+
+	gossip := mocks.NewMockGossipAdapter().
+		Self(org1MSPID, p1Org1).
+		Member(org2MSPID, p1Org2)
+
+	dispatcher := New(
+		channelID,
+		mocks.NewDataStore().TransientData(key1, value1).TransientData(key2, value2),
+		gossip,
+		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor(nil)},
+	)
+	require.NotNil(t, dispatcher)
+
+	reqMgr := requestmgr.Get(channelID)
+	require.NotNil(t, reqMgr)
+
+	t.Run("Endorser -> success", func(t *testing.T) {
+		req := reqMgr.NewRequest()
+
+		msg := &mocks.MockReceivedMessage{
+			Message: mocks.NewCollDataResMsg(channelID, req.ID(), mocks.NewKeyValue(key1, value1), mocks.NewKeyValue(key2, value2)),
+			Member:  p1Org2,
+		}
+
+		go func() {
+			if !dispatcher.Dispatch(msg) {
+				t.Fatal("Message not handled")
+			}
+		}()
+		ctxt, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+
+		res, err := req.GetResponse(ctxt)
+		assert.NoError(t, err)
+		require.NotNil(t, res)
+
+		require.Equal(t, 2, len(res.Data))
+
+		element := res.Data[0]
+		assert.Equal(t, key1.Namespace, element.Namespace)
+		assert.Equal(t, key1.Collection, element.Collection)
+		assert.Equal(t, key1.Key, element.Key)
+		assert.Equal(t, value1.Value, element.Value)
+
+		element = res.Data[1]
+		assert.Equal(t, key2.Namespace, element.Namespace)
+		assert.Equal(t, key2.Collection, element.Collection)
+		assert.Equal(t, key2.Key, element.Key)
+		assert.Equal(t, value2.Value, element.Value)
+	})
+
+	t.Run("Non-Endorser -> no response", func(t *testing.T) {
+		f := isEndorser
+		defer func() { isEndorser = f }()
+		isEndorser = func() bool { return false }
+
+		req := reqMgr.NewRequest()
+		ctxt, _ := context.WithTimeout(context.Background(), 50*time.Millisecond)
+
+		res, err := req.GetResponse(ctxt)
+		assert.EqualError(t, err, "context deadline exceeded")
+		assert.Nil(t, res)
+	})
+}

--- a/pkg/mocks/mockgossipmsg.go
+++ b/pkg/mocks/mockgossipmsg.go
@@ -1,0 +1,130 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/hyperledger/fabric/extensions/collections/api/store"
+	"github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/hyperledger/fabric/gossip/protoext"
+	gproto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common"
+)
+
+// KeyVal stores a key and a value
+type KeyVal struct {
+	*store.Key
+	*store.ExpiringValue
+}
+
+// NewKeyValue creates a new KeyVal
+func NewKeyValue(key *store.Key, value *store.ExpiringValue) *KeyVal {
+	return &KeyVal{
+		Key:           key,
+		ExpiringValue: value,
+	}
+}
+
+// NewCollDataReqMsg returns a mock collection data request message
+func NewCollDataReqMsg(channelID string, reqID uint64, keys ...*store.Key) *protoext.SignedGossipMessage {
+	var digests []*gproto.CollDataDigest
+	for _, key := range keys {
+		digests = append(digests, &gproto.CollDataDigest{
+			Namespace:      key.Namespace,
+			Collection:     key.Collection,
+			Key:            key.Key,
+			EndorsedAtTxID: key.EndorsedAtTxID,
+		})
+	}
+
+	msg, _ := protoext.NoopSign(&gproto.GossipMessage{
+		Tag:     gproto.GossipMessage_CHAN_ONLY,
+		Channel: []byte(channelID),
+		Content: &gproto.GossipMessage_CollDataReq{
+			CollDataReq: &gproto.RemoteCollDataRequest{
+				Nonce:   reqID,
+				Digests: digests,
+			},
+		},
+	})
+	return msg
+}
+
+// NewCollDataResMsg returns a mock collection data response message
+func NewCollDataResMsg(channelID string, reqID uint64, keyVals ...*KeyVal) *protoext.SignedGossipMessage {
+	var elements []*gproto.CollDataElement
+	for _, kv := range keyVals {
+		elements = append(elements, &gproto.CollDataElement{
+			Digest: &gproto.CollDataDigest{
+				Namespace:      kv.Namespace,
+				Collection:     kv.Collection,
+				Key:            kv.Key.Key,
+				EndorsedAtTxID: kv.EndorsedAtTxID,
+			},
+			Value:      kv.Value,
+			ExpiryTime: common.ToTimestamp(kv.Expiry),
+		})
+	}
+
+	msg, _ := protoext.NoopSign(&gproto.GossipMessage{
+		Tag:     gproto.GossipMessage_CHAN_ONLY,
+		Channel: []byte(channelID),
+		Content: &gproto.GossipMessage_CollDataRes{
+			CollDataRes: &gproto.RemoteCollDataResponse{
+				Nonce:    reqID,
+				Elements: elements,
+			},
+		},
+	})
+	return msg
+}
+
+// NewDataMsg returns a mock data message
+func NewDataMsg(channelID string) *protoext.SignedGossipMessage {
+	msg, _ := protoext.NoopSign(&gproto.GossipMessage{
+		Tag:     gproto.GossipMessage_CHAN_ONLY,
+		Channel: []byte(channelID),
+		Content: &gproto.GossipMessage_DataMsg{},
+	})
+	return msg
+}
+
+// MockReceivedMessage mocks the Gossip received message
+type MockReceivedMessage struct {
+	Message   *protoext.SignedGossipMessage
+	RespondTo func(msg *gproto.GossipMessage)
+	Member    discovery.NetworkMember
+}
+
+// Respond responds to the given request
+func (m *MockReceivedMessage) Respond(msg *gproto.GossipMessage) {
+	if m.RespondTo != nil {
+		m.RespondTo(msg)
+	}
+}
+
+// GetGossipMessage returns the mock signed gossip message
+func (m *MockReceivedMessage) GetGossipMessage() *protoext.SignedGossipMessage {
+	return m.Message
+}
+
+// GetSourceEnvelope is not implemented
+func (m *MockReceivedMessage) GetSourceEnvelope() *gproto.Envelope {
+	panic("not implemented")
+}
+
+// GetConnectionInfo returns the connection information of the source of the message
+func (m *MockReceivedMessage) GetConnectionInfo() *protoext.ConnectionInfo {
+	return &protoext.ConnectionInfo{
+		ID:       m.Member.PKIid,
+		Endpoint: m.Member.Endpoint,
+	}
+}
+
+// Ack is a noop
+func (m *MockReceivedMessage) Ack(err error) {
+	// Nothing to do
+}

--- a/pkg/mocks/mockledger.go
+++ b/pkg/mocks/mockledger.go
@@ -1,0 +1,107 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/hyperledger/fabric/common/ledger"
+	ledger2 "github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/peer"
+)
+
+// Ledger is a struct which is used to retrieve data using query
+type Ledger struct {
+	QueryExecutor  *QueryExecutor
+	TxSimulator    *TxSimulator
+	BlockchainInfo *common.BlockchainInfo
+	Error          error
+	BcInfoError    error
+}
+
+// GetConfigHistoryRetriever returns the config history retriever
+func (m *Ledger) GetConfigHistoryRetriever() (ledger2.ConfigHistoryRetriever, error) {
+	panic("not implemented")
+}
+
+// GetBlockchainInfo returns the block chain info
+func (m *Ledger) GetBlockchainInfo() (*common.BlockchainInfo, error) {
+	return m.BlockchainInfo, m.BcInfoError
+}
+
+// GetBlockByNumber returns the block by number
+func (m *Ledger) GetBlockByNumber(blockNumber uint64) (*common.Block, error) {
+	panic("not implemented")
+}
+
+// GetBlocksIterator returns the block iterator
+func (m *Ledger) GetBlocksIterator(startBlockNumber uint64) (ledger.ResultsIterator, error) {
+	panic("not implemented")
+}
+
+// Close closes the ledger
+func (m *Ledger) Close() {
+}
+
+// GetTransactionByID gets the transaction by id
+func (m *Ledger) GetTransactionByID(txID string) (*peer.ProcessedTransaction, error) {
+	panic("not implemented")
+}
+
+// GetBlockByHash returns the block by hash
+func (m *Ledger) GetBlockByHash(blockHash []byte) (*common.Block, error) {
+	panic("not implemented")
+}
+
+// GetBlockByTxID gets the block by transaction id
+func (m *Ledger) GetBlockByTxID(txID string) (*common.Block, error) {
+	panic("not implemented")
+}
+
+// GetTxValidationCodeByTxID gets the validation code
+func (m *Ledger) GetTxValidationCodeByTxID(txID string) (peer.TxValidationCode, error) {
+	panic("not implemented")
+}
+
+// NewTxSimulator returns the transaction simulator
+func (m *Ledger) NewTxSimulator(txid string) (ledger2.TxSimulator, error) {
+	return m.TxSimulator, m.Error
+}
+
+// NewQueryExecutor returns the query executor
+func (m *Ledger) NewQueryExecutor() (ledger2.QueryExecutor, error) {
+	return m.QueryExecutor, m.Error
+}
+
+// NewHistoryQueryExecutor returns the history query executor
+func (m *Ledger) NewHistoryQueryExecutor() (ledger2.HistoryQueryExecutor, error) {
+	panic("not implemented")
+}
+
+// GetPvtDataAndBlockByNum gets private data and block by block number
+func (m *Ledger) GetPvtDataAndBlockByNum(blockNum uint64, filter ledger2.PvtNsCollFilter) (*ledger2.BlockAndPvtData, error) {
+	panic("not implemented")
+}
+
+// GetPvtDataByNum gets private data by number
+func (m *Ledger) GetPvtDataByNum(blockNum uint64, filter ledger2.PvtNsCollFilter) ([]*ledger2.TxPvtData, error) {
+	panic("not implemented")
+}
+
+// CommitWithPvtData commits the private data
+func (m *Ledger) CommitWithPvtData(blockAndPvtdata *ledger2.BlockAndPvtData) error {
+	panic("not implemented")
+}
+
+// CommitPvtDataOfOldBlocks commits the private data of old blocks
+func (m *Ledger) CommitPvtDataOfOldBlocks(blockPvtData []*ledger2.BlockPvtData) ([]*ledger2.PvtdataHashMismatch, error) {
+	panic("not implemented")
+}
+
+// GetMissingPvtDataTracker returns the private data tracker
+func (m *Ledger) GetMissingPvtDataTracker() (ledger2.MissingPvtDataTracker, error) {
+	panic("not implemented")
+}

--- a/pkg/mocks/mockqueryexecutor.go
+++ b/pkg/mocks/mockqueryexecutor.go
@@ -1,0 +1,124 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"fmt"
+
+	commonledger "github.com/hyperledger/fabric/common/ledger"
+	"github.com/hyperledger/fabric/core/ledger"
+)
+
+// QueryExecutor is a mock query executor
+type QueryExecutor struct {
+	State map[string]map[string][]byte
+	Error error
+}
+
+// NewQueryExecutor returns a new mock query executor
+func NewQueryExecutor(state map[string]map[string][]byte) *QueryExecutor {
+	return &QueryExecutor{
+		State: state,
+	}
+}
+
+// WithError injects an error to the mock executor
+func (m *QueryExecutor) WithError(err error) *QueryExecutor {
+	m.Error = err
+	return m
+}
+
+// GetState returns the mock state for the given namespace and key
+func (m *QueryExecutor) GetState(namespace string, key string) ([]byte, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
+
+	ns := m.State[namespace]
+	if ns == nil {
+		return nil, fmt.Errorf("Could not retrieve namespace %s", namespace)
+	}
+
+	return ns[key], nil
+}
+
+// GetStateMultipleKeys returns the mock state for the given namespace and keys
+func (m *QueryExecutor) GetStateMultipleKeys(namespace string, keys []string) ([][]byte, error) {
+	values := make([][]byte, len(keys))
+	for i, k := range keys {
+		v, err := m.GetState(namespace, k)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = v
+	}
+	return values, nil
+}
+
+// GetStateRangeScanIterator is not currently implemented and will panic if called
+func (m *QueryExecutor) GetStateRangeScanIterator(namespace string, startKey string, endKey string) (commonledger.ResultsIterator, error) {
+	panic("not implemented")
+}
+
+// GetStateRangeScanIteratorWithMetadata is not currently implemented and will panic if called
+func (m *QueryExecutor) GetStateRangeScanIteratorWithMetadata(namespace string, startKey, endKey string, metadata map[string]interface{}) (ledger.QueryResultsIterator, error) {
+	panic("not implemented")
+}
+
+// ExecuteQuery is not currently implemented and will panic if called
+func (m *QueryExecutor) ExecuteQuery(namespace, query string) (commonledger.ResultsIterator, error) {
+	panic("not implemented")
+}
+
+// ExecuteQueryWithMetadata is not currently implemented and will panic if called
+func (m *QueryExecutor) ExecuteQueryWithMetadata(namespace, query string, metadata map[string]interface{}) (ledger.QueryResultsIterator, error) {
+	panic("not implemented")
+}
+
+// GetPrivateData returns the private data for the given namespace, collection, and key
+func (m *QueryExecutor) GetPrivateData(namespace, collection, key string) ([]byte, error) {
+	return m.GetState(namespace+"$"+collection, key)
+}
+
+// GetPrivateDataHash is not currently implemented and will panic if called
+func (m *QueryExecutor) GetPrivateDataHash(namespace, collection, key string) ([]byte, error) {
+	panic("not implemented")
+}
+
+// GetPrivateDataMetadataByHash is not currently implemented and will panic if called
+func (m *QueryExecutor) GetPrivateDataMetadataByHash(namespace, collection string, keyhash []byte) (map[string][]byte, error) {
+	panic("not implemented")
+}
+
+// GetPrivateDataMultipleKeys returns the private data for the given namespace, collection, and keys
+func (m *QueryExecutor) GetPrivateDataMultipleKeys(namespace, collection string, keys []string) ([][]byte, error) {
+	return m.GetStateMultipleKeys(namespace+"$"+collection, keys)
+}
+
+// GetPrivateDataRangeScanIterator is not currently implemented and will panic if called
+func (m *QueryExecutor) GetPrivateDataRangeScanIterator(namespace, collection, startKey, endKey string) (commonledger.ResultsIterator, error) {
+	panic("not implemented")
+}
+
+// ExecuteQueryOnPrivateData is not currently implemented and will panic if called
+func (m *QueryExecutor) ExecuteQueryOnPrivateData(namespace, collection, query string) (commonledger.ResultsIterator, error) {
+	panic("not implemented")
+}
+
+// Done does nothing
+func (m *QueryExecutor) Done() {
+}
+
+// GetStateMetadata is not currently implemented and will panic if called
+func (m *QueryExecutor) GetStateMetadata(namespace, key string) (map[string][]byte, error) {
+	panic("not implemented")
+}
+
+// GetPrivateDataMetadata is not currently implemented and will panic if called
+func (m *QueryExecutor) GetPrivateDataMetadata(namespace, collection, key string) (map[string][]byte, error) {
+	panic("not implemented")
+}

--- a/pkg/mocks/mocksupport.go
+++ b/pkg/mocks/mocksupport.go
@@ -1,0 +1,56 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/hyperledger/fabric/core/common/privdata"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	gmocks "github.com/hyperledger/fabric/extensions/gossip/mocks"
+	cb "github.com/hyperledger/fabric/protos/common"
+)
+
+// MockSupport is a holder of policy, config and error
+type MockSupport struct {
+	CollPolicy privdata.CollectionAccessPolicy
+	CollConfig *cb.StaticCollectionConfig
+	Err        error
+	Publisher  gossipapi.BlockPublisher
+}
+
+// NewMockSupport returns a new MockSupport
+func NewMockSupport() *MockSupport {
+	return &MockSupport{
+		Publisher: gmocks.NewBlockPublisher(),
+	}
+}
+
+// CollectionPolicy sets the collection access policy for the given collection
+func (s *MockSupport) CollectionPolicy(collPolicy privdata.CollectionAccessPolicy) *MockSupport {
+	s.CollPolicy = collPolicy
+	return s
+}
+
+// CollectionConfig sets the collection config for the given collection
+func (s *MockSupport) CollectionConfig(collConfig *cb.StaticCollectionConfig) *MockSupport {
+	s.CollConfig = collConfig
+	return s
+}
+
+// Policy returns the collection access policy for the given collection
+func (s *MockSupport) Policy(channelID, ns, coll string) (privdata.CollectionAccessPolicy, error) {
+	return s.CollPolicy, s.Err
+}
+
+// Config returns the collection config for the given collection
+func (s *MockSupport) Config(channelID, ns, coll string) (*cb.StaticCollectionConfig, error) {
+	return s.CollConfig, s.Err
+}
+
+// BlockPublisher returns a mock block publisher for the given channel
+func (s *MockSupport) BlockPublisher(channelID string) gossipapi.BlockPublisher {
+	return s.Publisher
+}

--- a/pkg/mocks/mocktxsim.go
+++ b/pkg/mocks/mocktxsim.go
@@ -1,0 +1,80 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	ledgermocks "github.com/hyperledger/fabric/common/mocks/ledger"
+	"github.com/hyperledger/fabric/core/ledger"
+)
+
+// TxSimulator implements a mock transaction simulator
+type TxSimulator struct {
+	ledgermocks.MockQueryExecutor
+	SimulationResults *ledger.TxSimulationResults
+	Error             error
+	SimError          error
+}
+
+// SetState is not currently implemented and will panic if called
+func (m *TxSimulator) SetState(namespace string, key string, value []byte) error {
+	panic("not implemented")
+}
+
+// DeleteState is not currently implemented and will panic if called
+func (m *TxSimulator) DeleteState(namespace string, key string) error {
+	panic("not implemented")
+}
+
+// SetStateMultipleKeys is not currently implemented and will panic if called
+func (m *TxSimulator) SetStateMultipleKeys(namespace string, kvs map[string][]byte) error {
+	panic("not implemented")
+}
+
+// ExecuteUpdate is not currently implemented and will panic if called
+func (m *TxSimulator) ExecuteUpdate(query string) error {
+	panic("not implemented")
+}
+
+// GetTxSimulationResults returns the mock simulation results
+func (m *TxSimulator) GetTxSimulationResults() (*ledger.TxSimulationResults, error) {
+	return m.SimulationResults, m.SimError
+}
+
+// DeletePrivateData is not currently implemented and will panic if called
+func (m *TxSimulator) DeletePrivateData(namespace, collection, key string) error {
+	panic("not implemented")
+}
+
+// SetPrivateData is not currently implemented and will panic if called
+func (m *TxSimulator) SetPrivateData(namespace, collection, key string, value []byte) error {
+	panic("not implemented")
+}
+
+// SetPrivateDataMultipleKeys currently does nothing except return the mock error (if any)
+func (m *TxSimulator) SetPrivateDataMultipleKeys(namespace, collection string, kvs map[string][]byte) error {
+	return m.Error
+}
+
+// SetStateMetadata is not currently implemented and will panic if called
+func (m *TxSimulator) SetStateMetadata(namespace, key string, metadata map[string][]byte) error {
+	panic("not implemented")
+}
+
+// DeleteStateMetadata is not currently implemented and will panic if called
+func (m *TxSimulator) DeleteStateMetadata(namespace, key string) error {
+	panic("not implemented")
+}
+
+// SetPrivateDataMetadata is not currently implemented and will panic if called
+func (m *TxSimulator) SetPrivateDataMetadata(namespace, collection, key string, metadata map[string][]byte) error {
+	panic("not implemented")
+}
+
+// DeletePrivateDataMetadata is not currently implemented and will panic if called
+func (m *TxSimulator) DeletePrivateDataMetadata(namespace, collection, key string) error {
+	panic("not implemented")
+}


### PR DESCRIPTION
Using a deterministic algorithm, retrieve transient data
from the local peer or, using Gossip, from other peers that
are supposed to contain the data.

The collection policy is checked before returning the data,
i.e. if the requesting peer is not authorized to 'see' the
data then nil is returned for the data request.

closes #55

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>