### PR TITLE
feat: Clear Caches on Chaincode Upgrade

### DIFF
--- a/mod/peer/collections/retriever/retriever.go
+++ b/mod/peer/collections/retriever/retriever.go
@@ -19,7 +19,7 @@ func NewProvider(
 	storeProvider func(channelID string) storeapi.Store,
 	ledgerProvider func(channelID string) ledger.PeerLedger,
 	gossipProvider func() supportapi.GossipAdapter,
-	_ func(channelID string) gossipapi.BlockPublisher) storeapi.Provider {
+	blockPublisherProvider func(channelID string) gossipapi.BlockPublisher) storeapi.Provider {
 
-	return extretriever.NewProvider(storeProvider, ledgerProvider, gossipProvider)
+	return extretriever.NewProvider(storeProvider, ledgerProvider, gossipProvider, blockPublisherProvider)
 }

--- a/mod/peer/gossip/blockpublisher/blockpublisher.go
+++ b/mod/peer/gossip/blockpublisher/blockpublisher.go
@@ -7,52 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package blockpublisher
 
 import (
-	"github.com/hyperledger/fabric/extensions/gossip/api"
-	cb "github.com/hyperledger/fabric/protos/common"
+	extblockpublisher "github.com/trustbloc/fabric-peer-ext/pkg/gossip/blockpublisher"
 )
 
-// Provider is a noop block publisher provider
-type Provider struct {
-}
-
-// ForChannel returns a noop publisher
-func (p *Provider) ForChannel(channelID string) api.BlockPublisher {
-	return &publisher{}
-}
-
-// Close does nothing
-func (p *Provider) Close() {
-	// Nothing to do
-}
-
 // NewProvider returns a new block publisher provider
-func NewProvider() *Provider {
-	return &Provider{}
-}
-
-type publisher struct {
-}
-
-func (p *publisher) AddCCUpgradeHandler(handler api.ChaincodeUpgradeHandler) {
-	// Not implemented
-}
-
-func (p *publisher) AddConfigUpdateHandler(handler api.ConfigUpdateHandler) {
-	// Not implemented
-}
-
-func (p *publisher) AddWriteHandler(handler api.WriteHandler) {
-	// Not implemented
-}
-
-func (p *publisher) AddReadHandler(handler api.ReadHandler) {
-	// Not implemented
-}
-
-func (p *publisher) AddCCEventHandler(handler api.ChaincodeEventHandler) {
-	// Not implemented
-}
-
-func (p *publisher) Publish(block *cb.Block) {
-	// Not implemented
+func NewProvider() *extblockpublisher.Provider {
+	return extblockpublisher.NewProvider()
 }

--- a/mod/peer/gossip/blockpublisher/blockpublisher_test.go
+++ b/mod/peer/gossip/blockpublisher/blockpublisher_test.go
@@ -8,30 +8,60 @@ package blockpublisher
 
 import (
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
 const (
 	channelID = "testchannel"
+	txID1     = "tx1"
+	ccID1     = "cc1"
+	key1      = "key1"
+	ccEvent1  = "ccevent1"
 )
 
 func TestProvider(t *testing.T) {
+	var (
+		value1 = []byte("value1")
+
+		v1 = &kvrwset.Version{
+			BlockNum: 1000,
+			TxNum:    0,
+		}
+	)
+
 	p := NewProvider()
 	require.NotNil(t, p)
 
 	publisher := p.ForChannel(channelID)
 	require.NotNil(t, publisher)
 
-	assert.NotPanics(t, func() {
-		publisher.AddConfigUpdateHandler(nil)
-		publisher.AddWriteHandler(nil)
-		publisher.AddReadHandler(nil)
-		publisher.AddCCUpgradeHandler(nil)
-		publisher.AddCCEventHandler(nil)
-		publisher.Publish(nil)
-	})
+	handler := mocks.NewMockBlockHandler()
 
-	p.Close()
+	publisher.AddWriteHandler(handler.HandleWrite)
+	publisher.AddReadHandler(handler.HandleRead)
+	publisher.AddCCEventHandler(handler.HandleChaincodeEvent)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+	defer p.Close()
+
+	b.Transaction(txID1, pb.TxValidationCode_VALID).
+		ChaincodeAction(ccID1).
+		Write(key1, value1).
+		Read(key1, v1).
+		ChaincodeEvent(ccEvent1, []byte("ccpayload"))
+
+	publisher.Publish(b.Build())
+
+	// Wait a bit for the events to be published
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, handler.NumReads(), 1)
+	assert.Equal(t, handler.NumWrites(), 1)
+	assert.Equal(t, handler.NumCCEvents(), 1)
 }

--- a/mod/peer/gossip/dispatcher/dispatcher.go
+++ b/mod/peer/gossip/dispatcher/dispatcher.go
@@ -32,6 +32,6 @@ func New(
 	dataStore storeapi.Store,
 	gossipAdapter gossipAdapter,
 	ledger ledger.PeerLedger,
-	_ blockPublisher) *extdispatcher.Dispatcher {
-	return extdispatcher.New(channelID, dataStore, gossipAdapter, ledger)
+	blockPublisher blockPublisher) *extdispatcher.Dispatcher {
+	return extdispatcher.New(channelID, dataStore, gossipAdapter, ledger, blockPublisher)
 }

--- a/mod/peer/gossip/dispatcher/dispatcher_test.go
+++ b/mod/peer/gossip/dispatcher/dispatcher_test.go
@@ -23,7 +23,7 @@ func TestProvider(t *testing.T) {
 		&mocks.DataStore{},
 		mocks.NewMockGossipAdapter(),
 		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor(nil)},
-		nil,
+		mocks.NewBlockPublisher(),
 	)
 
 	var response *gproto.GossipMessage

--- a/pkg/collections/pvtdatastore/pvtdatastore.go
+++ b/pkg/collections/pvtdatastore/pvtdatastore.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var logger = flogging.MustGetLogger("kevlar_gossip_state")
+var logger = flogging.MustGetLogger("ext_pvtdatastore")
 
 type transientStore interface {
 	// PersistWithConfig stores the private write set of a transaction along with the collection config

--- a/pkg/collections/retriever/retriever.go
+++ b/pkg/collections/retriever/retriever.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	cb "github.com/hyperledger/fabric/protos/common"
 	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
 	tretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/retriever"
@@ -31,9 +32,10 @@ type Provider struct {
 func NewProvider(
 	storeProvider func(channelID string) storeapi.Store,
 	ledgerProvider func(channelID string) ledger.PeerLedger,
-	gossipProvider func() supportapi.GossipAdapter) storeapi.Provider {
+	gossipProvider func() supportapi.GossipAdapter,
+	blockPublisherProvider func(channelID string) gossipapi.BlockPublisher) storeapi.Provider {
 
-	support := supp.New(ledgerProvider)
+	support := supp.New(ledgerProvider, blockPublisherProvider)
 
 	tdataStoreProvider := func(channelID string) tdataapi.Store { return storeProvider(channelID) }
 
@@ -89,6 +91,7 @@ func (r *retriever) GetTransientDataMultipleKeys(ctxt context.Context, key *stor
 type Support interface {
 	Config(channelID, ns, coll string) (*cb.StaticCollectionConfig, error)
 	Policy(channel, ns, collection string) (privdata.CollectionAccessPolicy, error)
+	BlockPublisher(channelID string) gossipapi.BlockPublisher
 }
 
 var getTransientDataProvider = func(storeProvider func(channelID string) tdataapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider {

--- a/pkg/collections/retriever/retriever_test.go
+++ b/pkg/collections/retriever/retriever_test.go
@@ -27,7 +27,7 @@ func TestRetriever(t *testing.T) {
 		return &tdatamocks.TransientDataProvider{}
 	}
 
-	p := NewProvider(nil, nil, nil)
+	p := NewProvider(nil, nil, nil, nil)
 	require.NotNil(t, p)
 
 	retriever := p.RetrieverForChannel(channelID)

--- a/pkg/collections/transientdata/retriever/transientdataretriever_test.go
+++ b/pkg/collections/transientdata/retriever/transientdataretriever_test.go
@@ -262,6 +262,18 @@ func TestTransientDataProvider_AccessDenied(t *testing.T) {
 		require.Equal(t, 1, len(values))
 		assert.Nil(t, values[0])
 	})
+
+	t.Run("GetTransientData - From remote peer after CC upgrade -> success", func(t *testing.T) {
+		support.CollectionPolicy(&mocks.MockAccessPolicy{
+			MaxPeerCount: 2,
+			Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+		})
+		require.NoError(t, support.Publisher.HandleUpgrade(1001, txID, ns1))
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetTransientData(ctx, storeapi.NewKey(txID, ns1, coll1, key2))
+		assert.NoError(t, err)
+		assert.NotNil(t, value)
+	})
 }
 
 type mockGossipMsgHandler struct {

--- a/pkg/common/multirequest/multirequest.go
+++ b/pkg/common/multirequest/multirequest.go
@@ -13,7 +13,7 @@ import (
 	"github.com/trustbloc/fabric-peer-ext/pkg/common"
 )
 
-var logger = flogging.MustGetLogger("kevlar-common")
+var logger = flogging.MustGetLogger("ext_multirequest")
 
 // Request is the request to execute
 type Request func(ctxt context.Context) (common.Values, error)

--- a/pkg/common/requestmgr/requestmgr.go
+++ b/pkg/common/requestmgr/requestmgr.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var logger = flogging.MustGetLogger("kevlar-common")
+var logger = flogging.MustGetLogger("ext_requestmgr")
 
 // Element contains transient data for a single key
 type Element struct {

--- a/pkg/common/support/support_test.go
+++ b/pkg/common/support/support_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/common/privdata"
 	"github.com/hyperledger/fabric/core/ledger"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,7 +46,11 @@ func TestSupport(t *testing.T) {
 		}
 	}
 
-	s := New(ledgerProvider)
+	blockPublisherProvider := func(channelID string) gossipapi.BlockPublisher {
+		return mocks.NewBlockPublisher()
+	}
+
+	s := New(ledgerProvider, blockPublisherProvider)
 	require.NotNil(t, s)
 
 	t.Run("Policy", func(t *testing.T) {
@@ -61,5 +66,10 @@ func TestSupport(t *testing.T) {
 		assert.Equal(t, int32(3), config.RequiredPeerCount)
 		assert.Equal(t, common.CollectionType_COL_TRANSIENT, config.Type)
 		assert.Equal(t, "1m", config.TimeToLive)
+	})
+
+	t.Run("BlockPublisher", func(t *testing.T) {
+		p := s.BlockPublisher(channelID)
+		require.NotNil(t, p)
 	})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ const (
 	confTransientDataLeveldb             = "transientDataLeveldb"
 	confTransientDataCleanupIntervalTime = "coll.transientdata.cleanupExpired.Interval"
 	confTransientDataCacheSize           = "coll.transientdata.cacheSize"
+	confBlockPublisherBufferSize         = "blockpublisher.buffersize"
 
 	confOLCollLeveldb             = "offLedgerLeveldb"
 	confOLCollCleanupIntervalTime = "coll.offledger.cleanupExpired.Interval"
@@ -28,6 +29,7 @@ const (
 	defaultTransientDataCleanupIntervalTime = 5 * time.Second
 	defaultTransientDataCacheSize           = 100000
 	defaultOLCollCleanupIntervalTime        = 5 * time.Second
+	defaultBlockPublisherBufferSize         = 100
 )
 
 // GetRoles returns the roles of the peer. Empty return value indicates that the peer has all roles.
@@ -79,4 +81,13 @@ func GetOLCollExpirationCheckInterval() time.Duration {
 		return defaultOLCollCleanupIntervalTime
 	}
 	return timeout
+}
+
+// GetBlockPublisherBufferSize returns the size of the block publisher channel buffer for various block events
+func GetBlockPublisherBufferSize() int {
+	size := viper.GetInt(confBlockPublisherBufferSize)
+	if size == 0 {
+		return defaultBlockPublisherBufferSize
+	}
+	return size
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -86,3 +86,14 @@ func TestGetOLCollExpiredIntervalTime(t *testing.T) {
 	viper.Set(confOLCollCleanupIntervalTime, 111*time.Second)
 	assert.Equal(t, 111*time.Second, GetOLCollExpirationCheckInterval())
 }
+
+func TestGetBlockPublisherBufferSize(t *testing.T) {
+	oldVal := viper.Get(confBlockPublisherBufferSize)
+	defer viper.Set(confBlockPublisherBufferSize, oldVal)
+
+	viper.Set(confBlockPublisherBufferSize, "")
+	assert.Equal(t, defaultBlockPublisherBufferSize, GetBlockPublisherBufferSize())
+
+	viper.Set(confBlockPublisherBufferSize, 1234)
+	assert.Equal(t, 1234, GetBlockPublisherBufferSize())
+}

--- a/pkg/gossip/blockpublisher/blockpublisher.go
+++ b/pkg/gossip/blockpublisher/blockpublisher.go
@@ -1,0 +1,514 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockpublisher
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/bluele/gcache"
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	ledgerutil "github.com/hyperledger/fabric/core/ledger/util"
+	"github.com/hyperledger/fabric/extensions/gossip/api"
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+)
+
+const (
+	lsccID       = "lscc"
+	upgradeEvent = "upgrade"
+)
+
+var logger = flogging.MustGetLogger("ext_blockpublisher")
+
+type write struct {
+	blockNum  uint64
+	txID      string
+	namespace string
+	w         *kvrwset.KVWrite
+}
+
+type read struct {
+	blockNum  uint64
+	txID      string
+	namespace string
+	r         *kvrwset.KVRead
+}
+
+type ccEvent struct {
+	blockNum uint64
+	txID     string
+	event    *pb.ChaincodeEvent
+}
+
+type configUpdate struct {
+	blockNum     uint64
+	configUpdate *cb.ConfigUpdate
+}
+
+// Provider maintains a cache of Block Publishers - one per channel
+type Provider struct {
+	cache gcache.Cache
+}
+
+// NewProvider returns a new block publisher provider
+func NewProvider() *Provider {
+	return &Provider{
+		cache: gcache.New(0).LoaderFunc(func(channelID interface{}) (interface{}, error) {
+			return New(channelID.(string)), nil
+		}).Build(),
+	}
+}
+
+// ForChannel returns the block publisher for the given channel
+func (p *Provider) ForChannel(channelID string) api.BlockPublisher {
+	publisher, err := p.cache.Get(channelID)
+	if err != nil {
+		// This should never happen
+		panic(err.Error())
+	}
+	return publisher.(*Publisher)
+}
+
+// Close closes all block publishers
+func (p *Provider) Close() {
+	for _, publisher := range p.cache.GetALL() {
+		publisher.(*Publisher).Close()
+	}
+}
+
+// Publisher traverses a block and publishes KV read, KV write, and chaincode events to registered handlers
+type Publisher struct {
+	channelID            string
+	writeHandlers        []api.WriteHandler
+	readHandlers         []api.ReadHandler
+	ccEventHandlers      []api.ChaincodeEventHandler
+	configUpdateHandlers []api.ConfigUpdateHandler
+	mutex                sync.RWMutex
+	blockChan            chan *cb.Block
+	wChan                chan *write
+	rChan                chan *read
+	ccEvtChan            chan *ccEvent
+	configUpdateChan     chan *configUpdate
+	doneChan             chan struct{}
+	closed               uint32
+}
+
+// New returns a new block Publisher for the given channel
+func New(channelID string) *Publisher {
+	bufferSize := config.GetBlockPublisherBufferSize()
+
+	p := &Publisher{
+		channelID:        channelID,
+		blockChan:        make(chan *cb.Block, bufferSize),
+		wChan:            make(chan *write, bufferSize),
+		rChan:            make(chan *read, bufferSize),
+		ccEvtChan:        make(chan *ccEvent, bufferSize),
+		configUpdateChan: make(chan *configUpdate, bufferSize),
+		doneChan:         make(chan struct{}),
+	}
+	go p.listen()
+	return p
+}
+
+// Close releases all resources associated with the Publisher. Calling this function
+// multiple times has no effect.
+func (p *Publisher) Close() {
+	if atomic.CompareAndSwapUint32(&p.closed, 0, 1) {
+		p.doneChan <- struct{}{}
+	} else {
+		logger.Debugf("[%s] Block Publisher already closed", p.channelID)
+	}
+}
+
+// AddConfigUpdateHandler adds a handler for config update events
+func (p *Publisher) AddConfigUpdateHandler(handler api.ConfigUpdateHandler) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	logger.Debugf("[%s] Adding config update", p.channelID)
+	p.configUpdateHandlers = append(p.configUpdateHandlers, handler)
+}
+
+// AddWriteHandler adds a new handler for KV writes
+func (p *Publisher) AddWriteHandler(handler api.WriteHandler) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	logger.Debugf("[%s] Adding write", p.channelID)
+	p.writeHandlers = append(p.writeHandlers, handler)
+}
+
+// AddReadHandler adds a new handler for KV reads
+func (p *Publisher) AddReadHandler(handler api.ReadHandler) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	logger.Debugf("[%s] Adding read", p.channelID)
+	p.readHandlers = append(p.readHandlers, handler)
+}
+
+// AddCCEventHandler adds a new handler for chaincode events
+func (p *Publisher) AddCCEventHandler(handler api.ChaincodeEventHandler) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	logger.Debugf("[%s] Adding chaincode event", p.channelID)
+	p.ccEventHandlers = append(p.ccEventHandlers, handler)
+}
+
+// AddCCUpgradeHandler adds a handler for chaincode upgrade events
+func (p *Publisher) AddCCUpgradeHandler(handler api.ChaincodeUpgradeHandler) {
+	logger.Debugf("[%s] Adding chaincode upgrade", p.channelID)
+	p.AddCCEventHandler(newChaincodeUpgradeHandler(p.channelID, handler))
+}
+
+// Publish publishes a block
+func (p *Publisher) Publish(block *cb.Block) {
+	newBlockEvent(p.channelID, block, p.wChan, p.rChan, p.ccEvtChan, p.configUpdateChan).publish()
+}
+
+func (p *Publisher) listen() {
+	for {
+		select {
+		case w := <-p.wChan:
+			p.handleWrite(w)
+		case r := <-p.rChan:
+			p.handleRead(r)
+		case ccEvt := <-p.ccEvtChan:
+			p.handleCCEvent(ccEvt)
+		case cu := <-p.configUpdateChan:
+			p.handleConfigUpdate(cu)
+		case <-p.doneChan:
+			logger.Debugf("[%s] Exiting block Publisher", p.channelID)
+			return
+		}
+	}
+}
+
+func (p *Publisher) handleRead(r *read) {
+	logger.Debugf("[%s] Handling read: [%s]", p.channelID, r)
+	for _, handleRead := range p.getReadHandlers() {
+		if err := handleRead(r.blockNum, r.txID, r.namespace, r.r); err != nil {
+			logger.Warningf("[%s] Error returned from KV read handler: %s", p.channelID, err)
+		}
+	}
+}
+
+func (p *Publisher) handleWrite(w *write) {
+	logger.Debugf("[%s] Handling write: [%s]", p.channelID, w)
+	for _, handleWrite := range p.getWriteHandlers() {
+		if err := handleWrite(w.blockNum, w.txID, w.namespace, w.w); err != nil {
+			logger.Warningf("[%s] Error returned from KV write handler: %s", p.channelID, err)
+		}
+	}
+}
+
+func (p *Publisher) handleCCEvent(event *ccEvent) {
+	logger.Debugf("[%s] Handling chaincode event: [%s]", p.channelID, event)
+	for _, handleCCEvent := range p.getCCEventHandlers() {
+		if err := handleCCEvent(event.blockNum, event.txID, event.event); err != nil {
+			logger.Warningf("[%s] Error returned from CC event handler: %s", p.channelID, err)
+		}
+	}
+}
+
+func (p *Publisher) handleConfigUpdate(cu *configUpdate) {
+	logger.Debugf("[%s] Handling config update [%s]", p.channelID, cu)
+	for _, handleConfigUpdate := range p.getConfigUpdateHandlers() {
+		if err := handleConfigUpdate(cu.blockNum, cu.configUpdate); err != nil {
+			logger.Warningf("[%s] Error returned from config update handler: %s", p.channelID, err)
+		}
+	}
+}
+
+func (p *Publisher) getReadHandlers() []api.ReadHandler {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	handlers := make([]api.ReadHandler, len(p.readHandlers))
+	copy(handlers, p.readHandlers)
+	return handlers
+}
+
+func (p *Publisher) getWriteHandlers() []api.WriteHandler {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	handlers := make([]api.WriteHandler, len(p.writeHandlers))
+	copy(handlers, p.writeHandlers)
+	return handlers
+}
+
+func (p *Publisher) getCCEventHandlers() []api.ChaincodeEventHandler {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	handlers := make([]api.ChaincodeEventHandler, len(p.ccEventHandlers))
+	copy(handlers, p.ccEventHandlers)
+	return handlers
+}
+
+func (p *Publisher) getConfigUpdateHandlers() []api.ConfigUpdateHandler {
+	p.mutex.RLock()
+	defer p.mutex.RUnlock()
+
+	handlers := make([]api.ConfigUpdateHandler, len(p.configUpdateHandlers))
+	copy(handlers, p.configUpdateHandlers)
+	return handlers
+}
+
+type blockEvent struct {
+	channelID        string
+	block            *cb.Block
+	wChan            chan<- *write
+	rChan            chan<- *read
+	ccEvtChan        chan<- *ccEvent
+	configUpdateChan chan<- *configUpdate
+}
+
+func newBlockEvent(channelID string, block *cb.Block, wChan chan<- *write, rChan chan<- *read, ccEvtChan chan<- *ccEvent, configUpdateChan chan<- *configUpdate) *blockEvent {
+	return &blockEvent{
+		channelID:        channelID,
+		block:            block,
+		wChan:            wChan,
+		rChan:            rChan,
+		ccEvtChan:        ccEvtChan,
+		configUpdateChan: configUpdateChan,
+	}
+}
+
+func (p *blockEvent) publish() {
+	logger.Debugf("[%s] Publishing block #%d", p.channelID, p.block.Header.Number)
+	for i := range p.block.Data.Data {
+		envelope, err := protoutil.ExtractEnvelope(p.block, i)
+		if err != nil {
+			logger.Warningf("[%s] Error extracting envelope at index %d in block %d: %s", p.channelID, i, p.block.Header.Number, err)
+		} else {
+			err = p.visitEnvelope(i, envelope)
+			if err != nil {
+				logger.Warningf("[%s] Error checking envelope at index %d in block %d: %s", p.channelID, i, p.block.Header.Number, err)
+			}
+		}
+	}
+}
+
+func (p *blockEvent) visitEnvelope(i int, envelope *cb.Envelope) error {
+	payload, err := protoutil.ExtractPayload(envelope)
+	if err != nil {
+		return err
+	}
+
+	chdr, err := protoutil.UnmarshalChannelHeader(payload.Header.ChannelHeader)
+	if err != nil {
+		return err
+	}
+
+	if cb.HeaderType(chdr.Type) == cb.HeaderType_ENDORSER_TRANSACTION {
+		txFilter := ledgerutil.TxValidationFlags(p.block.Metadata.Metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER])
+		code := txFilter.Flag(i)
+		if code != pb.TxValidationCode_VALID {
+			logger.Debugf("[%s] Transaction at index %d in block %d is not valid. Status code: %s", p.channelID, i, p.block.Header.Number, code)
+			return nil
+		}
+		tx, err := protoutil.GetTransaction(payload.Data)
+		if err != nil {
+			return err
+		}
+		newTxEvent(p.channelID, p.block.Header.Number, chdr.TxId, tx, p.wChan, p.rChan, p.ccEvtChan).publish()
+		return nil
+	}
+
+	if cb.HeaderType(chdr.Type) == cb.HeaderType_CONFIG_UPDATE {
+		envelope := &cb.ConfigUpdateEnvelope{}
+		if err := proto.Unmarshal(payload.Data, envelope); err != nil {
+			return err
+		}
+		newConfigUpdateEvent(p.channelID, p.block.Header.Number, envelope, p.configUpdateChan).publish()
+		return nil
+	}
+
+	return nil
+}
+
+type txEvent struct {
+	channelID string
+	blockNum  uint64
+	txID      string
+	tx        *pb.Transaction
+	wChan     chan<- *write
+	rChan     chan<- *read
+	ccEvtChan chan<- *ccEvent
+}
+
+func newTxEvent(channelID string, blockNum uint64, txID string, tx *pb.Transaction, wChan chan<- *write, rChan chan<- *read, ccEvtChan chan<- *ccEvent) *txEvent {
+	return &txEvent{
+		channelID: channelID,
+		blockNum:  blockNum,
+		txID:      txID,
+		tx:        tx,
+		wChan:     wChan,
+		rChan:     rChan,
+		ccEvtChan: ccEvtChan,
+	}
+}
+
+func (p *txEvent) publish() {
+	logger.Debugf("[%s] Publishing Tx %s in block #%d", p.channelID, p.txID, p.blockNum)
+	for i, action := range p.tx.Actions {
+		err := p.visitTXAction(action)
+		if err != nil {
+			logger.Warningf("[%s] Error checking TxAction at index %d: %s", p.channelID, i, err)
+		}
+	}
+}
+
+func (p *txEvent) visitTXAction(action *pb.TransactionAction) error {
+	chaPayload, err := protoutil.GetChaincodeActionPayload(action.Payload)
+	if err != nil {
+		return err
+	}
+	return p.visitChaincodeActionPayload(chaPayload)
+}
+
+func (p *txEvent) visitChaincodeActionPayload(chaPayload *pb.ChaincodeActionPayload) error {
+	cpp := &pb.ChaincodeProposalPayload{}
+	err := proto.Unmarshal(chaPayload.ChaincodeProposalPayload, cpp)
+	if err != nil {
+		return err
+	}
+
+	return p.visitAction(chaPayload.Action)
+}
+
+func (p *txEvent) visitAction(action *pb.ChaincodeEndorsedAction) error {
+	prp := &pb.ProposalResponsePayload{}
+	err := proto.Unmarshal(action.ProposalResponsePayload, prp)
+	if err != nil {
+		return err
+	}
+	return p.visitProposalResponsePayload(prp)
+}
+
+func (p *txEvent) visitProposalResponsePayload(prp *pb.ProposalResponsePayload) error {
+	chaincodeAction := &pb.ChaincodeAction{}
+	err := proto.Unmarshal(prp.Extension, chaincodeAction)
+	if err != nil {
+		return err
+	}
+	return p.visitChaincodeAction(chaincodeAction)
+}
+
+func (p *txEvent) visitChaincodeAction(chaincodeAction *pb.ChaincodeAction) error {
+	if len(chaincodeAction.Results) > 0 {
+		txRWSet := &rwsetutil.TxRwSet{}
+		if err := txRWSet.FromProtoBytes(chaincodeAction.Results); err != nil {
+			return err
+		}
+		p.visitTxReadWriteSet(txRWSet)
+	}
+
+	if len(chaincodeAction.Events) > 0 {
+		evt := &pb.ChaincodeEvent{}
+		if err := proto.Unmarshal(chaincodeAction.Events, evt); err != nil {
+			logger.Warningf("[%s] Invalid chaincode event for chaincode [%s]", p.channelID, chaincodeAction.ChaincodeId)
+			return errors.WithMessagef(err, "invalid chaincode event for chaincode [%s]", chaincodeAction.ChaincodeId)
+		}
+		p.ccEvtChan <- &ccEvent{
+			blockNum: p.blockNum,
+			txID:     p.txID,
+			event:    evt,
+		}
+	}
+
+	return nil
+}
+
+func (p *txEvent) visitTxReadWriteSet(txRWSet *rwsetutil.TxRwSet) {
+	for _, nsRWSet := range txRWSet.NsRwSets {
+		p.visitNsReadWriteSet(nsRWSet)
+	}
+}
+
+func (p *txEvent) visitNsReadWriteSet(nsRWSet *rwsetutil.NsRwSet) {
+	for _, r := range nsRWSet.KvRwSet.Reads {
+		p.rChan <- &read{
+			blockNum:  p.blockNum,
+			txID:      p.txID,
+			namespace: nsRWSet.NameSpace,
+			r:         r,
+		}
+	}
+	for _, w := range nsRWSet.KvRwSet.Writes {
+		p.wChan <- &write{
+			blockNum:  p.blockNum,
+			txID:      p.txID,
+			namespace: nsRWSet.NameSpace,
+			w:         w,
+		}
+	}
+}
+
+type configUpdateEvent struct {
+	channelID        string
+	blockNum         uint64
+	envelope         *cb.ConfigUpdateEnvelope
+	configUpdateChan chan<- *configUpdate
+}
+
+func newConfigUpdateEvent(channelID string, blockNum uint64, envelope *cb.ConfigUpdateEnvelope, configUpdateChan chan<- *configUpdate) *configUpdateEvent {
+	return &configUpdateEvent{
+		channelID:        channelID,
+		blockNum:         blockNum,
+		envelope:         envelope,
+		configUpdateChan: configUpdateChan,
+	}
+}
+
+func (p *configUpdateEvent) publish() {
+	cu := &cb.ConfigUpdate{}
+	if err := proto.Unmarshal(p.envelope.ConfigUpdate, cu); err != nil {
+		logger.Warningf("[%s] Error unmarshalling config update: %s", p.channelID, err)
+		return
+	}
+
+	logger.Debugf("[%s] Publishing Config Update [%s] in block #%d", p.channelID, cu, p.blockNum)
+
+	p.configUpdateChan <- &configUpdate{
+		blockNum:     p.blockNum,
+		configUpdate: cu,
+	}
+}
+
+func newChaincodeUpgradeHandler(channelID string, handleUpgrade api.ChaincodeUpgradeHandler) api.ChaincodeEventHandler {
+	return func(blockNum uint64, txID string, event *pb.ChaincodeEvent) error {
+		logger.Debugf("[%s] Handling chaincode event: %s", channelID, event)
+		if event.ChaincodeId != lsccID {
+			logger.Debugf("[%s] Chaincode event is not from 'lscc'", channelID)
+			return nil
+		}
+		if event.EventName != upgradeEvent {
+			logger.Debugf("[%s] Chaincode event from 'lscc' is not an upgrade event", channelID)
+			return nil
+		}
+
+		ccData := &pb.LifecycleEvent{}
+		err := proto.Unmarshal(event.Payload, ccData)
+		if err != nil {
+			return errors.WithMessage(err, "error unmarshalling chaincode upgrade event")
+		}
+
+		logger.Debugf("[%s] Handling chaincode upgrade of chaincode [%s]", channelID, ccData.ChaincodeName)
+		return handleUpgrade(blockNum, txID, ccData.ChaincodeName)
+	}
+}

--- a/pkg/gossip/blockpublisher/blockpublisher_test.go
+++ b/pkg/gossip/blockpublisher/blockpublisher_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockpublisher
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	channelID = "testchannel"
+
+	txID1 = "tx1"
+	txID2 = "tx2"
+	txID3 = "tx3"
+
+	ccID1 = "cc1"
+	ccID2 = "cc2"
+
+	coll1 = "collection1"
+	coll2 = "collection2"
+
+	key1 = "key1"
+	key2 = "key2"
+	key3 = "key3"
+
+	ccEvent1 = "ccevent1"
+)
+
+func TestPublisher_Get(t *testing.T) {
+	p := New("mychannel")
+	require.NotNil(t, p)
+	p.Close()
+}
+
+func TestPublisher_Close(t *testing.T) {
+	p := New(channelID)
+	require.NotNil(t, p)
+
+	p.Close()
+
+	assert.NotPanics(t, func() {
+		p.Close()
+	}, "Expecting Close to not panic when called multiple times")
+}
+
+func TestPublisher_PublishEndorsementEvents(t *testing.T) {
+	var (
+		value1 = []byte("value1")
+		value2 = []byte("value2")
+		value3 = []byte("value3")
+
+		v1 = &kvrwset.Version{
+			BlockNum: 1000,
+			TxNum:    0,
+		}
+		v2 = &kvrwset.Version{
+			BlockNum: 1001,
+			TxNum:    1,
+		}
+	)
+
+	p := New(channelID)
+	require.NotNil(t, p)
+	defer p.Close()
+
+	handler1 := mocks.NewMockBlockHandler()
+	p.AddReadHandler(handler1.HandleRead)
+	p.AddWriteHandler(handler1.HandleWrite)
+
+	handler2 := mocks.NewMockBlockHandler()
+	p.AddReadHandler(handler2.HandleRead)
+	p.AddCCEventHandler(handler2.HandleChaincodeEvent)
+
+	handler3 := mocks.NewMockBlockHandler()
+	p.AddCCUpgradeHandler(handler3.HandleChaincodeUpgradeEvent)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+
+	tb1 := b.Transaction(txID1, pb.TxValidationCode_VALID)
+	tb1.ChaincodeAction(ccID1).
+		Write(key1, value1).
+		Read(key1, v1).
+		ChaincodeEvent(ccEvent1, []byte("ccpayload"))
+	tb1.ChaincodeAction(ccID2).
+		Write(key2, value2).
+		Read(key2, v2)
+
+	tb2 := b.Transaction(txID2, pb.TxValidationCode_VALID)
+	cc2_1 := tb2.ChaincodeAction(ccID1).
+		Write(key2, value2)
+	cc2_1.Collection(coll1).
+		Write(key1, value2)
+	cc2_1.Collection(coll2).
+		Delete(key1)
+
+	// This transaction should not be published
+	tb3 := b.Transaction(txID3, pb.TxValidationCode_MVCC_READ_CONFLICT)
+	tb3.ChaincodeAction(ccID1).
+		Write(key3, value3).
+		ChaincodeEvent(ccEvent1, []byte("ccpayload"))
+
+	lceBytes, err := proto.Marshal(&pb.LifecycleEvent{ChaincodeName: ccID2})
+	require.NoError(t, err)
+	require.NotNil(t, lceBytes)
+
+	b.Transaction(txID1, pb.TxValidationCode_VALID).
+		ChaincodeAction(lsccID).
+		ChaincodeEvent(upgradeEvent, lceBytes)
+	tb4 := b.Transaction(txID2, pb.TxValidationCode_VALID)
+	tb4.ChaincodeAction(lsccID).
+		ChaincodeEvent(ccEvent1, nil)
+
+	p.Publish(b.Build())
+
+	// Wait a bit for the events to be published
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 2, handler1.NumReads())
+	assert.Equal(t, 5, handler1.NumWrites())
+	assert.Equal(t, 0, handler1.NumCCEvents())
+	assert.Equal(t, 0, handler1.NumCCUpgradeEvents())
+
+	assert.Equal(t, 2, handler2.NumReads())
+	assert.Equal(t, 0, handler2.NumWrites())
+	assert.Equal(t, 3, handler2.NumCCEvents())
+	assert.Equal(t, 0, handler2.NumCCUpgradeEvents())
+
+	assert.Equal(t, 0, handler3.NumReads())
+	assert.Equal(t, 0, handler3.NumWrites())
+	assert.Equal(t, 0, handler3.NumCCEvents())
+	assert.Equal(t, 1, handler3.NumCCUpgradeEvents())
+}
+
+func TestPublisher_PublishConfigUpdateEvents(t *testing.T) {
+	p := New(channelID)
+	require.NotNil(t, p)
+	defer p.Close()
+
+	handler := mocks.NewMockBlockHandler()
+	p.AddConfigUpdateHandler(handler.HandleConfigUpdate)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+	b.ConfigUpdate()
+
+	p.Publish(b.Build())
+
+	// Wait a bit for the events to be published
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 1, handler.NumConfigUpdates())
+}
+
+func TestPublisher_Error(t *testing.T) {
+	var (
+		value1 = []byte("value1")
+		value2 = []byte("value2")
+
+		v1 = &kvrwset.Version{
+			BlockNum: 1000,
+			TxNum:    3,
+		}
+		v2 = &kvrwset.Version{
+			BlockNum: 1001,
+			TxNum:    5,
+		}
+	)
+
+	p := New(channelID)
+	require.NotNil(t, p)
+	defer p.Close()
+
+	expectedErr := fmt.Errorf("injected error")
+
+	handler1 := mocks.NewMockBlockHandler().WithError(expectedErr)
+	p.AddReadHandler(handler1.HandleRead)
+	p.AddWriteHandler(handler1.HandleWrite)
+	p.AddCCEventHandler(handler1.HandleChaincodeEvent)
+	p.AddCCUpgradeHandler(handler1.HandleChaincodeUpgradeEvent)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+
+	tb1 := b.Transaction(txID1, pb.TxValidationCode_VALID)
+	tb1.ChaincodeAction(ccID1).
+		Write(key1, value1).
+		Read(key1, v1).
+		ChaincodeEvent(ccEvent1, []byte("ccpayload"))
+	tb1.ChaincodeAction(ccID2).
+		Write(key2, value2).
+		Read(key2, v2)
+
+	tb2 := b.Transaction(txID2, pb.TxValidationCode_VALID)
+	cc2_1 := tb2.ChaincodeAction(ccID1).
+		Write(key2, value2)
+	cc2_1.Collection(coll1).
+		Write(key1, value2)
+	cc2_1.Collection(coll2).
+		Delete(key1)
+
+	lceBytes, err := proto.Marshal(&pb.LifecycleEvent{ChaincodeName: ccID2})
+	require.NoError(t, err)
+	require.NotNil(t, lceBytes)
+
+	b.Transaction(txID1, pb.TxValidationCode_VALID).
+		ChaincodeAction(lsccID).
+		ChaincodeEvent(upgradeEvent, lceBytes)
+	tb4 := b.Transaction(txID2, pb.TxValidationCode_VALID)
+	tb4.ChaincodeAction(lsccID).
+		ChaincodeEvent(ccEvent1, nil)
+
+	p.Publish(b.Build())
+
+	// Wait a bit for the events to be published
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, 2, handler1.NumReads())
+	assert.Equal(t, 5, handler1.NumWrites())
+	assert.Equal(t, 3, handler1.NumCCEvents())
+	assert.Equal(t, 1, handler1.NumCCUpgradeEvents())
+}

--- a/pkg/gossip/dispatcher/dispatcher.go
+++ b/pkg/gossip/dispatcher/dispatcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/extensions/collections/api/store"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	extgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	ledgerconfig "github.com/hyperledger/fabric/extensions/roles"
 	gossipapi "github.com/hyperledger/fabric/gossip/api"
 	gcommon "github.com/hyperledger/fabric/gossip/common"
@@ -37,6 +38,10 @@ type gossipAdapter interface {
 	IdentityInfo() gossipapi.PeerIdentitySet
 }
 
+type blockPublisher interface {
+	AddCCUpgradeHandler(handler extgossipapi.ChaincodeUpgradeHandler)
+}
+
 type ccRetriever interface {
 	Config(ns, coll string) (*cb.StaticCollectionConfig, error)
 	Policy(ns, coll string) (privdata.CollectionAccessPolicy, error)
@@ -52,9 +57,10 @@ func New(
 	channelID string,
 	dataStore storeapi.Store,
 	gossipAdapter gossipAdapter,
-	ledger ledger.PeerLedger) *Dispatcher {
+	ledger ledger.PeerLedger,
+	blockPublisher blockPublisher) *Dispatcher {
 	return &Dispatcher{
-		ccRetriever: supp.NewCollectionConfigRetriever(channelID, ledger),
+		ccRetriever: supp.NewCollectionConfigRetriever(channelID, ledger, blockPublisher),
 		channelID:   channelID,
 		reqMgr:      requestmgr.Get(channelID),
 		dataStore:   dataStore,

--- a/pkg/gossip/dispatcher/dispatcher_test.go
+++ b/pkg/gossip/dispatcher/dispatcher_test.go
@@ -65,6 +65,7 @@ func TestDispatchUnhandled(t *testing.T) {
 		&mocks.DataStore{},
 		mocks.NewMockGossipAdapter(),
 		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor(nil)},
+		mocks.NewBlockPublisher(),
 	)
 
 	var response *gproto.GossipMessage
@@ -124,6 +125,7 @@ func TestDispatchDataRequest(t *testing.T) {
 		mocks.NewDataStore().TransientData(key1, value1).TransientData(key2, value2),
 		gossipAdapter,
 		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor(state)},
+		mocks.NewBlockPublisher(),
 	)
 	require.NotNil(t, dispatcher)
 
@@ -227,6 +229,7 @@ func TestDispatchDataResponse(t *testing.T) {
 		mocks.NewDataStore().TransientData(key1, value1).TransientData(key2, value2),
 		gossip,
 		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor(nil)},
+		mocks.NewBlockPublisher(),
 	)
 	require.NotNil(t, dispatcher)
 

--- a/pkg/mocks/mockblockbuilder.go
+++ b/pkg/mocks/mockblockbuilder.go
@@ -1,0 +1,367 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"crypto/sha256"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	cutil "github.com/hyperledger/fabric/common/util"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	ledger_util "github.com/hyperledger/fabric/core/ledger/util"
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/hyperledger/fabric/protoutil"
+)
+
+// BlockBuilder builds a mock Block
+type BlockBuilder struct {
+	channelID    string
+	blockNum     uint64
+	previousHash []byte
+	configUpdate *ConfigUpdateBuilder
+	transactions []*TxBuilder
+}
+
+// NewBlockBuilder returns a new mock BlockBuilder
+func NewBlockBuilder(channelID string, blockNum uint64) *BlockBuilder {
+	return &BlockBuilder{
+		channelID: channelID,
+		blockNum:  blockNum,
+	}
+}
+
+// Build builds the block
+func (b *BlockBuilder) Build() *cb.Block {
+	block := &cb.Block{}
+	block.Header = &cb.BlockHeader{}
+	block.Header.Number = b.blockNum
+	block.Header.PreviousHash = b.previousHash
+	block.Data = &cb.BlockData{}
+
+	var metadataContents [][]byte
+	for i := 0; i < len(cb.BlockMetadataIndex_name); i++ {
+		metadataContents = append(metadataContents, []byte{})
+	}
+	block.Metadata = &cb.BlockMetadata{Metadata: metadataContents}
+
+	if b.configUpdate != nil {
+		block.Data.Data = append(block.Data.Data, b.configUpdate.Build())
+	} else {
+		var txValidationCodes []uint8
+		for _, tx := range b.transactions {
+			txBytes, txValidationCode := tx.Build()
+			block.Data.Data = append(block.Data.Data, txBytes)
+			txValidationCodes = append(txValidationCodes, uint8(txValidationCode))
+		}
+		txsfltr := ledger_util.NewTxValidationFlags(len(block.Data.Data))
+		for i := 0; i < len(block.Data.Data); i++ {
+			txsfltr[i] = txValidationCodes[i]
+		}
+		block.Metadata.Metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER] = txsfltr
+	}
+
+	blockbytes := cutil.ConcatenateBytes(block.Data.Data...)
+	block.Header.DataHash = computeSHA256(blockbytes)
+
+	return block
+}
+
+// ConfigUpdate adds a config update
+func (b *BlockBuilder) ConfigUpdate() *ConfigUpdateBuilder {
+	if len(b.transactions) > 0 {
+		panic("Cannot mix config updates with endorsement transactions")
+	}
+	cb := NewConfigUpdateBuilder(b.channelID)
+	b.configUpdate = cb
+	return cb
+}
+
+// ConfigUpdateBuilder builds a mock config update envelope
+type ConfigUpdateBuilder struct {
+	channelID string
+}
+
+// NewConfigUpdateBuilder returns a new mock ConfigUpdateBuilder
+func NewConfigUpdateBuilder(channelID string) *ConfigUpdateBuilder {
+	return &ConfigUpdateBuilder{
+		channelID: channelID,
+	}
+}
+
+// Build builds a config update envelope
+func (b *ConfigUpdateBuilder) Build() []byte {
+	chdr := &cb.ChannelHeader{
+		Type:    int32(cb.HeaderType_CONFIG_UPDATE),
+		Version: 1,
+		Timestamp: &timestamp.Timestamp{
+			Seconds: time.Now().Unix(),
+			Nanos:   0,
+		},
+		ChannelId: b.channelID}
+	hdr := &cb.Header{ChannelHeader: protoutil.MarshalOrPanic(chdr)}
+	payload := &cb.Payload{Header: hdr}
+
+	env := &cb.Envelope{}
+
+	var err error
+	env.Payload, err = protoutil.GetBytesPayload(payload)
+	if err != nil {
+		panic(err.Error())
+	}
+	ebytes, err := protoutil.GetBytesEnvelope(env)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return ebytes
+}
+
+// Transaction adds a new transaction
+func (b *BlockBuilder) Transaction(txID string, validationCode pb.TxValidationCode) *TxBuilder {
+	if b.configUpdate != nil {
+		panic("Cannot mix config updates with endorsement transactions")
+	}
+	tx := NewTxBuilder(b.channelID, txID, validationCode)
+	b.transactions = append(b.transactions, tx)
+	return tx
+}
+
+// TxBuilder builds a mock Transaction
+type TxBuilder struct {
+	channelID        string
+	txID             string
+	validationCode   pb.TxValidationCode
+	chaincodeActions []*ChaincodeActionBuilder
+}
+
+// NewTxBuilder returns a new mock TxBuilder
+func NewTxBuilder(channelID, txID string, validationCode pb.TxValidationCode) *TxBuilder {
+	return &TxBuilder{
+		channelID:      channelID,
+		txID:           txID,
+		validationCode: validationCode,
+	}
+}
+
+// Build builds a transaction
+func (b *TxBuilder) Build() ([]byte, pb.TxValidationCode) {
+	chdr := &cb.ChannelHeader{
+		Type:    int32(cb.HeaderType_ENDORSER_TRANSACTION),
+		Version: 1,
+		Timestamp: &timestamp.Timestamp{
+			Seconds: time.Now().Unix(),
+			Nanos:   0,
+		},
+		ChannelId: b.channelID,
+		TxId:      b.txID}
+	hdr := &cb.Header{ChannelHeader: protoutil.MarshalOrPanic(chdr)}
+	payload := &cb.Payload{Header: hdr}
+
+	env := &cb.Envelope{}
+
+	tx := &pb.Transaction{}
+
+	for _, ccAction := range b.chaincodeActions {
+		tx.Actions = append(tx.Actions, &pb.TransactionAction{
+			Payload: ccAction.Build(),
+		})
+	}
+
+	var err error
+	payload.Data, err = protoutil.GetBytesTransaction(tx)
+	if err != nil {
+		panic(err.Error())
+	}
+	env.Payload, err = protoutil.GetBytesPayload(payload)
+	if err != nil {
+		panic(err.Error())
+	}
+	ebytes, err := protoutil.GetBytesEnvelope(env)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return ebytes, b.validationCode
+}
+
+// ChaincodeAction adds a chaincode action to the transaction
+func (b *TxBuilder) ChaincodeAction(ccID string) *ChaincodeActionBuilder {
+	cc := NewChaincodeActionBuilder(ccID, b.txID)
+	b.chaincodeActions = append(b.chaincodeActions, cc)
+	return cc
+}
+
+// ChaincodeActionBuilder builds a mock Chaincode Action
+type ChaincodeActionBuilder struct {
+	ccID         string
+	txID         string
+	response     *pb.Response
+	ccEvent      *pb.ChaincodeEvent
+	nsRWSet      *NamespaceRWSetBuilder
+	collNSRWSets []*NamespaceRWSetBuilder
+}
+
+// NewChaincodeActionBuilder returns a new ChaincodeActionBuilder
+func NewChaincodeActionBuilder(ccID, txID string) *ChaincodeActionBuilder {
+	return &ChaincodeActionBuilder{
+		ccID:    ccID,
+		txID:    txID,
+		nsRWSet: NewNamespaceRWSetBuilder(ccID),
+	}
+}
+
+// Build builds the chaincode action
+func (b *ChaincodeActionBuilder) Build() []byte {
+	ccID := &pb.ChaincodeID{
+		Name: b.ccID,
+	}
+
+	var ccEventBytes []byte
+	if b.ccEvent != nil {
+		var err error
+		ccEventBytes, err = proto.Marshal(b.ccEvent)
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+
+	txRWSet := &rwsetutil.TxRwSet{}
+	txRWSet.NsRwSets = append(txRWSet.NsRwSets, b.nsRWSet.Build())
+	for _, collRWSet := range b.collNSRWSets {
+		txRWSet.NsRwSets = append(txRWSet.NsRwSets, collRWSet.Build())
+	}
+
+	nsRWSetBytes, err := txRWSet.ToProtoBytes()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	proposalResponsePayload, err := protoutil.GetBytesProposalResponsePayload(
+		[]byte("proposal_hash"), b.response, nsRWSetBytes, ccEventBytes, ccID)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	ccaPayload := &pb.ChaincodeActionPayload{
+		Action: &pb.ChaincodeEndorsedAction{
+			ProposalResponsePayload: proposalResponsePayload,
+		},
+	}
+
+	payload, err := protoutil.GetBytesChaincodeActionPayload(ccaPayload)
+	if err != nil {
+		panic(err.Error())
+	}
+	return payload
+}
+
+// Response sets the chaincode response
+func (b *ChaincodeActionBuilder) Response(response *pb.Response) *ChaincodeActionBuilder {
+	b.response = response
+	return b
+}
+
+// Read adds a KV read to the read/write set
+func (b *ChaincodeActionBuilder) Read(key string, version *kvrwset.Version) *ChaincodeActionBuilder {
+	b.nsRWSet.Read(key, version)
+	return b
+}
+
+// Write adds a KV write to the read/write set
+func (b *ChaincodeActionBuilder) Write(key string, value []byte) *ChaincodeActionBuilder {
+	b.nsRWSet.Write(key, value)
+	return b
+}
+
+// Delete adds a KV write (with delete=true) to the read/write set
+func (b *ChaincodeActionBuilder) Delete(key string) *ChaincodeActionBuilder {
+	b.nsRWSet.Delete(key)
+	return b
+}
+
+// ChaincodeEvent adds a chaincode event to the chaincode action
+func (b *ChaincodeActionBuilder) ChaincodeEvent(eventName string, payload []byte) *ChaincodeActionBuilder {
+	b.ccEvent = &pb.ChaincodeEvent{
+		ChaincodeId: b.ccID,
+		TxId:        b.txID,
+		EventName:   eventName,
+		Payload:     payload,
+	}
+	return b
+}
+
+// Collection starts a new collection read/write set
+func (b *ChaincodeActionBuilder) Collection(coll string) *NamespaceRWSetBuilder {
+	nsRWSetBuilder := NewNamespaceRWSetBuilder(b.ccID + "~" + coll)
+	b.collNSRWSets = append(b.collNSRWSets, nsRWSetBuilder)
+	return nsRWSetBuilder
+}
+
+// NamespaceRWSetBuilder builds a mock read/write set for a given namespace
+type NamespaceRWSetBuilder struct {
+	namespace string
+	reads     []*kvrwset.KVRead
+	writes    []*kvrwset.KVWrite
+}
+
+// NewNamespaceRWSetBuilder returns a new namespace read/write set builder
+func NewNamespaceRWSetBuilder(ns string) *NamespaceRWSetBuilder {
+	return &NamespaceRWSetBuilder{
+		namespace: ns,
+	}
+}
+
+// Build builds a namespace read/write set
+func (b *NamespaceRWSetBuilder) Build() *rwsetutil.NsRwSet {
+	return &rwsetutil.NsRwSet{
+		NameSpace: b.namespace,
+		KvRwSet: &kvrwset.KVRWSet{
+			Reads:  b.reads,
+			Writes: b.writes,
+		},
+	}
+}
+
+// Read adds a KV read to the read/write set
+func (b *NamespaceRWSetBuilder) Read(key string, version *kvrwset.Version) *NamespaceRWSetBuilder {
+	b.reads = append(b.reads, &kvrwset.KVRead{
+		Key:     key,
+		Version: version,
+	})
+	return b
+}
+
+// Write adds a KV write to the read/write set
+func (b *NamespaceRWSetBuilder) Write(key string, value []byte) *NamespaceRWSetBuilder {
+	b.writes = append(b.writes, &kvrwset.KVWrite{
+		Key:   key,
+		Value: value,
+	})
+	return b
+}
+
+// Delete adds a KV write (with delete=true) to the read/write set
+func (b *NamespaceRWSetBuilder) Delete(key string) *NamespaceRWSetBuilder {
+	b.writes = append(b.writes, &kvrwset.KVWrite{
+		Key:      key,
+		IsDelete: true,
+	})
+	return b
+}
+
+func computeSHA256(data []byte) (hash []byte) {
+	h := sha256.New()
+	_, err := h.Write(data)
+	if err != nil {
+		panic("unable to create digest")
+	}
+	return h.Sum(nil)
+}

--- a/pkg/mocks/mockblockhandler.go
+++ b/pkg/mocks/mockblockhandler.go
@@ -1,0 +1,91 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync/atomic"
+
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	pb "github.com/hyperledger/fabric/protos/peer"
+)
+
+// MockBlockHandler is a mock block handler
+type MockBlockHandler struct {
+	numReads           int32
+	numWrites          int32
+	numCCEvents        int32
+	numCCUpgradeEvents int32
+	numConfigUpdates   int32
+	err                error
+}
+
+// NewMockBlockHandler returns a mock Block Handler
+func NewMockBlockHandler() *MockBlockHandler {
+	return &MockBlockHandler{}
+}
+
+// WithError sets an error
+func (m *MockBlockHandler) WithError(err error) *MockBlockHandler {
+	m.err = err
+	return m
+}
+
+// NumReads returns the number of reads handled
+func (m *MockBlockHandler) NumReads() int {
+	return int(atomic.LoadInt32(&m.numReads))
+}
+
+// NumWrites returns the number of writes handled
+func (m *MockBlockHandler) NumWrites() int {
+	return int(atomic.LoadInt32(&m.numWrites))
+}
+
+// NumCCEvents returns the number of chaincode events handled
+func (m *MockBlockHandler) NumCCEvents() int {
+	return int(atomic.LoadInt32(&m.numCCEvents))
+}
+
+// NumCCUpgradeEvents returns the number of chaincode upgrades handled
+func (m *MockBlockHandler) NumCCUpgradeEvents() int {
+	return int(atomic.LoadInt32(&m.numCCUpgradeEvents))
+}
+
+// NumConfigUpdates returns the number of configuration updates handled
+func (m *MockBlockHandler) NumConfigUpdates() int {
+	return int(atomic.LoadInt32(&m.numConfigUpdates))
+}
+
+// HandleRead handles a read event by incrementing the read counter
+func (m *MockBlockHandler) HandleRead(blockNum uint64, txID string, namespace string, kvRead *kvrwset.KVRead) error {
+	atomic.AddInt32(&m.numReads, 1)
+	return m.err
+}
+
+// HandleWrite handles a write event by incrementing the write counter
+func (m *MockBlockHandler) HandleWrite(blockNum uint64, txID string, namespace string, kvWrite *kvrwset.KVWrite) error {
+	atomic.AddInt32(&m.numWrites, 1)
+	return m.err
+}
+
+// HandleChaincodeEvent handle a chaincode event by incrementing the CC event counter
+func (m *MockBlockHandler) HandleChaincodeEvent(blockNum uint64, txID string, event *pb.ChaincodeEvent) error {
+	atomic.AddInt32(&m.numCCEvents, 1)
+	return m.err
+}
+
+// HandleChaincodeUpgradeEvent handles a chaincode upgrade event by incrementing the chaincode upgrade counter
+func (m *MockBlockHandler) HandleChaincodeUpgradeEvent(blockNum uint64, txID string, chaincodeName string) error {
+	atomic.AddInt32(&m.numCCUpgradeEvents, 1)
+	return m.err
+}
+
+// HandleConfigUpdate handles a config update by incrementing the config update counter
+func (m *MockBlockHandler) HandleConfigUpdate(blockNum uint64, configUpdate *cb.ConfigUpdate) error {
+	atomic.AddInt32(&m.numConfigUpdates, 1)
+	return m.err
+}

--- a/pkg/mocks/mockblockpublisher.go
+++ b/pkg/mocks/mockblockpublisher.go
@@ -1,0 +1,56 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	"github.com/hyperledger/fabric/protos/common"
+)
+
+// MockBlockPublisher is a mock block publisher
+type MockBlockPublisher struct {
+	HandleUpgrade      gossipapi.ChaincodeUpgradeHandler
+	HandleConfigUpdate gossipapi.ConfigUpdateHandler
+	HandleWrite        gossipapi.WriteHandler
+	HandleRead         gossipapi.ReadHandler
+	HandleCCEvent      gossipapi.ChaincodeEventHandler
+}
+
+// NewBlockPublisher returns a mock block publisher
+func NewBlockPublisher() *MockBlockPublisher {
+	return &MockBlockPublisher{}
+}
+
+// AddCCUpgradeHandler adds a chaincode upgrade handler
+func (m *MockBlockPublisher) AddCCUpgradeHandler(handler gossipapi.ChaincodeUpgradeHandler) {
+	m.HandleUpgrade = handler
+}
+
+// AddConfigUpdateHandler adds a config update handler
+func (m *MockBlockPublisher) AddConfigUpdateHandler(handler gossipapi.ConfigUpdateHandler) {
+	m.HandleConfigUpdate = handler
+}
+
+// AddWriteHandler adds a write handler
+func (m *MockBlockPublisher) AddWriteHandler(handler gossipapi.WriteHandler) {
+	m.HandleWrite = handler
+}
+
+// AddReadHandler adds a read handler
+func (m *MockBlockPublisher) AddReadHandler(handler gossipapi.ReadHandler) {
+	m.HandleRead = handler
+}
+
+// AddCCEventHandler adds a chaincode event handler
+func (m *MockBlockPublisher) AddCCEventHandler(handler gossipapi.ChaincodeEventHandler) {
+	m.HandleCCEvent = handler
+}
+
+// Publish is not implemented and panics if invoked
+func (m *MockBlockPublisher) Publish(block *common.Block) {
+	panic("not implemented")
+}

--- a/pkg/mocks/mocksupport.go
+++ b/pkg/mocks/mocksupport.go
@@ -9,7 +9,6 @@ package mocks
 import (
 	"github.com/hyperledger/fabric/core/common/privdata"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
-	gmocks "github.com/hyperledger/fabric/extensions/gossip/mocks"
 	cb "github.com/hyperledger/fabric/protos/common"
 )
 
@@ -18,13 +17,13 @@ type MockSupport struct {
 	CollPolicy privdata.CollectionAccessPolicy
 	CollConfig *cb.StaticCollectionConfig
 	Err        error
-	Publisher  gossipapi.BlockPublisher
+	Publisher  *MockBlockPublisher
 }
 
 // NewMockSupport returns a new MockSupport
 func NewMockSupport() *MockSupport {
 	return &MockSupport{
-		Publisher: gmocks.NewBlockPublisher(),
+		Publisher: NewBlockPublisher(),
 	}
 }
 


### PR DESCRIPTION
When a chaincode is upgraded then all collection policy caches
for that chaincode are cleared.

closes #61

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>