### PR TITLE
feat: Remove transient data read-write sets from simulation results

### DIFF
--- a/mod/peer/endorser/endorser.go
+++ b/mod/peer/endorser/endorser.go
@@ -9,10 +9,10 @@ package endorser
 import (
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
+	extendorser "github.com/trustbloc/fabric-peer-ext/pkg/endorser"
 )
 
 // FilterPubSimulationResults filters the public simulation results and returns the filtered results or error.
-// TODO: Filter out transient data R/W sets (Issue #88).
-func FilterPubSimulationResults(_ map[string]*common.CollectionConfigPackage, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
-	return pubSimulationResults, nil
+func FilterPubSimulationResults(collConfigs map[string]*common.CollectionConfigPackage, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
+	return extendorser.FilterPubSimulationResults(collConfigs, pubSimulationResults)
 }

--- a/pkg/endorser/endorser.go
+++ b/pkg/endorser/endorser.go
@@ -1,0 +1,110 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorser
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset"
+	"github.com/pkg/errors"
+)
+
+var endorserLogger = flogging.MustGetLogger("ext_endorser")
+
+// FilterPubSimulationResults filters out all off-ledger (including transient data) read-write sets from the simulation results
+// so that they won't be included in the block.
+func FilterPubSimulationResults(collConfigs map[string]*common.CollectionConfigPackage, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
+	if collConfigs != nil {
+		// Filter out all off-ledger hashed read/write sets
+		return newFilter(collConfigs).filter(pubSimulationResults)
+	}
+
+	endorserLogger.Debugf("No collection r/w sets.")
+	return pubSimulationResults, nil
+}
+
+type collRWSetFilter struct {
+	collConfigs map[string]*common.CollectionConfigPackage
+}
+
+func newFilter(collConfigs map[string]*common.CollectionConfigPackage) *collRWSetFilter {
+	return &collRWSetFilter{
+		collConfigs: collConfigs,
+	}
+}
+
+func (f *collRWSetFilter) filter(pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
+	endorserLogger.Debugf("Filtering off-ledger collection types...")
+	filteredResults := &rwset.TxReadWriteSet{
+		DataModel: pubSimulationResults.DataModel,
+	}
+
+	// Filter out off-ledger collections from read/write sets
+	for _, rwSet := range pubSimulationResults.NsRwset {
+		endorserLogger.Debugf("Checking chaincode [%s] for off-ledger collection types...", rwSet.Namespace)
+
+		filteredRWSet, err := f.filterNamespace(rwSet)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(filteredRWSet.Rwset) > 0 || len(filteredRWSet.CollectionHashedRwset) > 0 {
+			endorserLogger.Debugf("Adding rw-set for [%s]", rwSet.Namespace)
+			filteredResults.NsRwset = append(filteredResults.NsRwset, filteredRWSet)
+		} else {
+			endorserLogger.Debugf("Not adding rw-set for [%s] since everything has been filtered out", rwSet.Namespace)
+		}
+	}
+
+	return filteredResults, nil
+}
+
+func (f *collRWSetFilter) filterNamespace(nsRWSet *rwset.NsReadWriteSet) (*rwset.NsReadWriteSet, error) {
+	var filteredCollRWSets []*rwset.CollectionHashedReadWriteSet
+	for _, collRWSet := range nsRWSet.CollectionHashedRwset {
+		endorserLogger.Debugf("Checking collection [%s:%s] to see if it is an off-ledger type...", nsRWSet.Namespace, collRWSet.CollectionName)
+		offLedger, err := f.isOffLedger(nsRWSet.Namespace, collRWSet.CollectionName)
+		if err != nil {
+			return nil, err
+		}
+		if !offLedger {
+			endorserLogger.Debugf("... adding hashed rw-set for collection [%s:%s] since it IS NOT an off-ledger type", nsRWSet.Namespace, collRWSet.CollectionName)
+			filteredCollRWSets = append(filteredCollRWSets, collRWSet)
+		} else {
+			endorserLogger.Debugf("... removing hashed rw-set for collection [%s:%s] since it IS an off-ledger type", nsRWSet.Namespace, collRWSet.CollectionName)
+		}
+	}
+
+	return &rwset.NsReadWriteSet{
+		Namespace:             nsRWSet.Namespace,
+		Rwset:                 nsRWSet.Rwset,
+		CollectionHashedRwset: filteredCollRWSets,
+	}, nil
+}
+
+func (f *collRWSetFilter) isOffLedger(ns, coll string) (bool, error) {
+	collConfig, ok := f.collConfigs[ns]
+	if !ok {
+		return false, errors.Errorf("config for collection [%s:%s] not found", ns, coll)
+	}
+
+	for _, config := range collConfig.Config {
+		staticConfig := config.GetStaticCollectionConfig()
+		if staticConfig == nil {
+			return false, errors.Errorf("config for collection [%s:%s] not found", ns, coll)
+		}
+		if staticConfig.Name == coll {
+			return isCollOffLedger(staticConfig), nil
+		}
+	}
+
+	return false, errors.Errorf("config for collection [%s:%s] not found", ns, coll)
+}
+
+func isCollOffLedger(collConfig *common.StaticCollectionConfig) bool {
+	return collConfig.Type == common.CollectionType_COL_TRANSIENT
+}

--- a/pkg/endorser/endorser_test.go
+++ b/pkg/endorser/endorser_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorser
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	ns1 = "ns1"
+	ns2 = "ns2"
+	ns3 = "ns3"
+
+	coll1 = "coll1"
+	coll2 = "coll2"
+)
+
+func TestFilterPubSimulationResults(t *testing.T) {
+	pvtBuilder := mocks.NewPvtReadWriteSetBuilder()
+	pvtNSBuilder1 := pvtBuilder.Namespace(ns1)
+	pvtNSBuilder1.Collection(coll1).StaticConfig("OR('Org1.member','Org2.member')", 2, 3, 100)
+	pvtNSBuilder1.Collection(coll2).TransientConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
+	pvtNSBuilder3 := pvtBuilder.Namespace(ns3)
+	pvtNSBuilder3.Collection(coll2).TransientConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
+
+	builder := mocks.NewReadWriteSetBuilder()
+	nsBuilder1 := builder.Namespace(ns1)
+	nsBuilder1.Write("key1", []byte("value1"))
+	nsBuilder1.Collection(coll1)
+	nsBuilder1.Collection(coll2)
+
+	nsBuilder2 := builder.Namespace(ns2)
+	nsBuilder2.Write("key1", []byte("value1"))
+
+	nsBuilder3 := builder.Namespace(ns3)
+	nsBuilder3.Collection(coll2)
+
+	results := builder.Build()
+	require.NotNil(t, results)
+
+	// Should be 3 namespaces
+	require.Equal(t, 3, len(results.NsRwset))
+
+	// ns1 should have a rw-set and 2 coll-hashed rw-sets
+	assert.Equal(t, ns1, results.NsRwset[0].Namespace)
+	require.Equal(t, 2, len(results.NsRwset[0].CollectionHashedRwset))
+	assert.Equal(t, coll1, results.NsRwset[0].CollectionHashedRwset[0].CollectionName)
+	assert.Equal(t, coll2, results.NsRwset[0].CollectionHashedRwset[1].CollectionName)
+	assert.NotEmpty(t, len(results.NsRwset[0].Rwset))
+
+	// ns2 should have a rw-set and no coll-hashed rw-sets
+	assert.Equal(t, ns2, results.NsRwset[1].Namespace)
+	require.Equal(t, 0, len(results.NsRwset[1].CollectionHashedRwset))
+	assert.NotEmpty(t, len(results.NsRwset[1].Rwset))
+
+	// ns3 should have no rw-set and 1 coll-hashed rw-sets
+	assert.Equal(t, ns3, results.NsRwset[2].Namespace)
+	require.Equal(t, 1, len(results.NsRwset[2].CollectionHashedRwset))
+	assert.Empty(t, len(results.NsRwset[2].Rwset))
+
+	filteredResults, err := FilterPubSimulationResults(pvtBuilder.BuildCollectionConfigs(), results)
+	assert.NoError(t, err)
+	require.NotNil(t, filteredResults)
+
+	require.Equalf(t, 2, len(filteredResults.NsRwset), "expecting the rw-set for [%s] to be filtered out completely", ns1)
+	assert.Equal(t, ns1, filteredResults.NsRwset[0].Namespace)
+	require.Equalf(t, 1, len(filteredResults.NsRwset[0].CollectionHashedRwset), "expecting only one collection rw-set since the off-ledger rw-set should have been filtered out")
+	assert.Equal(t, coll1, filteredResults.NsRwset[0].CollectionHashedRwset[0].CollectionName)
+	assert.NotEmptyf(t, len(filteredResults.NsRwset[0].Rwset), "expecting rw-set to still exist for [%s]", ns1)
+
+	assert.Equal(t, ns2, filteredResults.NsRwset[1].Namespace)
+	require.Equalf(t, 0, len(filteredResults.NsRwset[1].CollectionHashedRwset), "expecting rw-set to still exist for [%s]", ns2)
+	assert.NotEmpty(t, len(filteredResults.NsRwset[1].Rwset))
+}
+
+func TestFilterPubSimulationResults_NoCollections(t *testing.T) {
+	var collConfigs map[string]*common.CollectionConfigPackage
+
+	results := &rwset.TxReadWriteSet{
+		DataModel: rwset.TxReadWriteSet_KV,
+		NsRwset:   []*rwset.NsReadWriteSet{},
+	}
+
+	filteredResults, err := FilterPubSimulationResults(collConfigs, results)
+	assert.NoError(t, err)
+	assert.Equal(t, results, filteredResults)
+}


### PR DESCRIPTION
Transient data read-write sets are filtered out from the simulation
resuls before endorsement so as not to show up on the ledger.

closes #88

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>