### PR TITLE
fix: Fix bug in transient data retrieval

### DIFF
--- a/mod/peer/collections/pvtdatahandler/pvtdatahandler.go
+++ b/mod/peer/collections/pvtdatahandler/pvtdatahandler.go
@@ -8,24 +8,10 @@ package pvtdatahandler
 
 import (
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
-	"github.com/hyperledger/fabric/protos/common"
+	extpvtdatahandler "github.com/trustbloc/fabric-peer-ext/pkg/collections/pvtdatahandler"
 )
 
-// Handler handles the retrieval of extensions-defined collection types
-type Handler struct {
-}
-
 // New returns a new Handler
-func New(channelID string, collDataProvider storeapi.Provider) *Handler {
-	return &Handler{}
-}
-
-// HandleGetPrivateData if the collection is one of the custom extensions collections then the private data is returned
-func (h *Handler) HandleGetPrivateData(txID, ns string, config *common.StaticCollectionConfig, key string) ([]byte, bool, error) {
-	return nil, false, nil
-}
-
-// HandleGetPrivateDataMultipleKeys if the collection is one of the custom extensions collections then the private data is returned
-func (h *Handler) HandleGetPrivateDataMultipleKeys(txID, ns string, config *common.StaticCollectionConfig, keys []string) ([][]byte, bool, error) {
-	return nil, false, nil
+func New(channelID string, collDataProvider storeapi.Provider) *extpvtdatahandler.Handler {
+	return extpvtdatahandler.New(channelID, collDataProvider)
 }

--- a/mod/peer/collections/pvtdatahandler/pvtdatahandler_test.go
+++ b/mod/peer/collections/pvtdatahandler/pvtdatahandler_test.go
@@ -18,7 +18,6 @@ func TestHandler_HandleGetPrivateData(t *testing.T) {
 
 	config := &common.StaticCollectionConfig{
 		Name: "coll1",
-		Type: common.CollectionType_COL_TRANSIENT,
 	}
 
 	value, handled, err := h.HandleGetPrivateData("tx1", "ns1", config, "key1")
@@ -32,7 +31,6 @@ func TestHandler_HandleGetPrivateDataMultipleKeys(t *testing.T) {
 
 	config := &common.StaticCollectionConfig{
 		Name: "coll1",
-		Type: common.CollectionType_COL_TRANSIENT,
 	}
 
 	value, handled, err := h.HandleGetPrivateDataMultipleKeys("tx1", "ns1", config, []string{"key1", "key2"})

--- a/pkg/collections/pvtdatahandler/pvtdatahandler.go
+++ b/pkg/collections/pvtdatahandler/pvtdatahandler.go
@@ -1,0 +1,100 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pvtdatahandler
+
+import (
+	"context"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+)
+
+var logger = flogging.MustGetLogger("ext_pvtdatahandler")
+
+// Handler handles the retrieval of kevlar-defined collection types
+type Handler struct {
+	channelID        string
+	collDataProvider storeapi.Provider
+}
+
+// New returns a new Handler
+func New(channelID string, collDataProvider storeapi.Provider) *Handler {
+	return &Handler{
+		channelID:        channelID,
+		collDataProvider: collDataProvider,
+	}
+}
+
+// HandleGetPrivateData if the collection is one of the custom Kevlar collections then the private data is returned
+func (h *Handler) HandleGetPrivateData(txID, ns string, config *common.StaticCollectionConfig, key string) ([]byte, bool, error) {
+	switch config.Type {
+	case common.CollectionType_COL_TRANSIENT:
+		logger.Debugf("Collection [%s:%s] is of type TransientData. Returning transient data for key [%s]", ns, config.Name, key)
+		value, err := h.getTransientData(txID, ns, config.Name, key)
+		if err != nil {
+			return nil, true, err
+		}
+		return value, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+// HandleGetPrivateDataMultipleKeys if the collection is one of the custom Kevlar collections then the private data is returned
+func (h *Handler) HandleGetPrivateDataMultipleKeys(txID, ns string, config *common.StaticCollectionConfig, keys []string) ([][]byte, bool, error) {
+	switch config.Type {
+	case common.CollectionType_COL_TRANSIENT:
+		logger.Debugf("Collection [%s:%s] is of type TransientData. Returning transient data for keys [%s]", ns, config.Name, keys)
+		values, err := h.getTransientDataMultipleKeys(txID, ns, config.Name, keys)
+		if err != nil {
+			return nil, true, err
+		}
+		return values, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+func (h *Handler) getTransientData(txID, ns, coll, key string) ([]byte, error) {
+	ctxt, cancel := context.WithTimeout(context.Background(), config.GetTransientDataPullTimeout())
+	defer cancel()
+
+	v, err := h.collDataProvider.RetrieverForChannel(h.channelID).
+		GetTransientData(ctxt, storeapi.NewKey(txID, ns, coll, key))
+	if err != nil {
+		return nil, err
+	}
+
+	if v == nil {
+		return nil, nil
+	}
+
+	return v.Value, nil
+}
+
+func (h *Handler) getTransientDataMultipleKeys(txID, ns, coll string, keys []string) ([][]byte, error) {
+	ctxt, cancel := context.WithTimeout(context.Background(), config.GetTransientDataPullTimeout())
+	defer cancel()
+
+	vals, err := h.collDataProvider.RetrieverForChannel(h.channelID).
+		GetTransientDataMultipleKeys(ctxt, storeapi.NewMultiKey(txID, ns, coll, keys...))
+	if err != nil {
+		return nil, err
+	}
+
+	values := make([][]byte, len(vals))
+	for i, v := range vals {
+		if v == nil {
+			values[i] = nil
+		} else {
+			values[i] = v.Value
+		}
+	}
+	return values, nil
+}

--- a/pkg/collections/pvtdatahandler/pvtdatahandler_test.go
+++ b/pkg/collections/pvtdatahandler/pvtdatahandler_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pvtdatahandler
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	channelID = "testchannel"
+	tx1       = "tx1"
+	ns1       = "ns1"
+	key1      = "key1"
+	key2      = "key2"
+)
+
+func TestHandler_HandleGetPrivateData(t *testing.T) {
+	storeProvider := mocks.NewDataProvider()
+
+	h := New(channelID, storeProvider)
+	require.NotNil(t, h)
+
+	t.Run("Transient Data", func(t *testing.T) {
+		config := &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_TRANSIENT,
+		}
+
+		value, handled, err := h.HandleGetPrivateData(tx1, ns1, config, key1)
+		assert.NoError(t, err)
+		assert.True(t, handled)
+		assert.NotNil(t, value)
+	})
+}
+
+func TestHandler_HandleGetPrivateDataMultipleKeys(t *testing.T) {
+	storeProvider := mocks.NewDataProvider()
+
+	h := New(channelID, storeProvider)
+	require.NotNil(t, h)
+
+	t.Run("Transient Data", func(t *testing.T) {
+		config := &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_TRANSIENT,
+		}
+
+		value, handled, err := h.HandleGetPrivateDataMultipleKeys(tx1, ns1, config, []string{key1, key2})
+		assert.NoError(t, err)
+		assert.True(t, handled)
+		assert.NotNil(t, value)
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,14 +21,17 @@ const (
 	confTransientDataLeveldb             = "transientDataLeveldb"
 	confTransientDataCleanupIntervalTime = "coll.transientdata.cleanupExpired.Interval"
 	confTransientDataCacheSize           = "coll.transientdata.cacheSize"
-	confBlockPublisherBufferSize         = "blockpublisher.buffersize"
+	confTransientDataPullTimeout         = "peer.gossip.transientData.pullTimeout"
 
 	confOLCollLeveldb             = "offLedgerLeveldb"
 	confOLCollCleanupIntervalTime = "coll.offledger.cleanupExpired.Interval"
 
+	confBlockPublisherBufferSize = "blockpublisher.buffersize"
+
 	defaultTransientDataCleanupIntervalTime = 5 * time.Second
 	defaultTransientDataCacheSize           = 100000
 	defaultOLCollCleanupIntervalTime        = 5 * time.Second
+	defaultTransientDataPullTimeout         = 5 * time.Second
 	defaultBlockPublisherBufferSize         = 100
 )
 
@@ -79,6 +82,15 @@ func GetOLCollExpirationCheckInterval() time.Duration {
 	timeout := viper.GetDuration(confOLCollCleanupIntervalTime)
 	if timeout == 0 {
 		return defaultOLCollCleanupIntervalTime
+	}
+	return timeout
+}
+
+// GetTransientDataPullTimeout is the amount of time a peer waits for a response from another peer for transient data.
+func GetTransientDataPullTimeout() time.Duration {
+	timeout := viper.GetDuration(confTransientDataPullTimeout)
+	if timeout == 0 {
+		timeout = defaultTransientDataPullTimeout
 	}
 	return timeout
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,6 +87,17 @@ func TestGetOLCollExpiredIntervalTime(t *testing.T) {
 	assert.Equal(t, 111*time.Second, GetOLCollExpirationCheckInterval())
 }
 
+func TestGetTransientDataPullTimeout(t *testing.T) {
+	oldVal := viper.Get(confTransientDataPullTimeout)
+	defer viper.Set(confTransientDataPullTimeout, oldVal)
+
+	viper.Set(confTransientDataPullTimeout, "")
+	assert.Equal(t, defaultTransientDataPullTimeout, GetTransientDataPullTimeout())
+
+	viper.Set(confTransientDataPullTimeout, 111*time.Second)
+	assert.Equal(t, 111*time.Second, GetTransientDataPullTimeout())
+}
+
 func TestGetBlockPublisherBufferSize(t *testing.T) {
 	oldVal := viper.Get(confBlockPublisherBufferSize)
 	defer viper.Set(confBlockPublisherBufferSize, oldVal)

--- a/pkg/mocks/mockdataprovider.go
+++ b/pkg/mocks/mockdataprovider.go
@@ -1,0 +1,58 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"context"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+)
+
+// DataProvider is a mock transient data provider
+type DataProvider struct {
+}
+
+// NewDataProvider returns a new Data Provider
+func NewDataProvider() *DataProvider {
+	return &DataProvider{}
+}
+
+// RetrieverForChannel returns the retriever for the given channel
+func (p *DataProvider) RetrieverForChannel(channel string) storeapi.Retriever {
+	return &dataRetriever{}
+}
+
+type dataRetriever struct {
+}
+
+// GetTransientData returns the transient data for the given context and key
+func (m *dataRetriever) GetTransientData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+}
+
+// GetTransientDataMultipleKeys returns the transient data with multiple keys for the given context and key
+func (m *dataRetriever) GetTransientDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	values := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+	}
+	return values, nil
+}
+
+// GetData returns the data for the given context and key
+func (m *dataRetriever) GetData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+}
+
+// GetDataMultipleKeys returns the  data with multiple keys for the given context and key
+func (m *dataRetriever) GetDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	values := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+	}
+	return values, nil
+}


### PR DESCRIPTION
Implement a handler for GetPrivateData that returns transient
data if the collection type is transient.

closes #108

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>