### PR TITLE
feat: LRU for Off-Ledger Collections

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,7 @@ github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2K
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/trustbloc/fabric-mod v0.0.0-20190522001819-bbf763a5c881 h1:JVDhpiuNjc1TYIUsrx9O/c5UoQgHknwIasRhnTm+EiU=
 github.com/trustbloc/fabric-mod v0.0.0-20190522001819-bbf763a5c881/go.mod h1:y/yp/cF5M9+xddNmn6f24tz/PrDjgGCzOk5/0WCKLkU=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/collections/offledger/storeprovider/store/cache/cache.go
+++ b/pkg/collections/offledger/storeprovider/store/cache/cache.go
@@ -1,0 +1,159 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
+)
+
+var logger = flogging.MustGetLogger("ext_offledger")
+
+// Cache implements a cache for collection data
+type Cache struct {
+	channelID  string
+	cache      gcache.Cache
+	dbProvider api.DBProvider
+}
+
+type cacheKey struct {
+	namespace  string
+	collection string
+	key        string
+}
+
+func (k cacheKey) String() string {
+	return fmt.Sprintf("%s:%s:%s", k.namespace, k.collection, k.key)
+}
+
+// New returns a new collection data cache
+func New(channelID string, dbProvider api.DBProvider, size int) *Cache {
+	c := &Cache{
+		channelID:  channelID,
+		dbProvider: dbProvider,
+	}
+	c.cache = gcache.New(size).ARC().LoaderExpireFunc(
+		func(k interface{}) (interface{}, *time.Duration, error) {
+			key := k.(cacheKey)
+			v, remainingTime, err := c.load(key)
+			if err != nil {
+				logger.Warningf("[%s] Error loading key [%s]: %s", c.channelID, key, err)
+				return nil, nil, err
+			}
+			return v, remainingTime, nil
+		}).Build()
+	return c
+}
+
+// Put adds the value for the given key.
+func (c *Cache) Put(ns, coll, key string, value *api.Value) {
+	cKey := cacheKey{
+		namespace:  ns,
+		collection: coll,
+		key:        key,
+	}
+
+	var err error
+	if value.ExpiryTime.IsZero() {
+		logger.Debugf("[%s] Putting key [%s]. Expires: NEVER", c.channelID, cKey)
+		err = c.cache.Set(cKey, value)
+	} else if value.ExpiryTime.Before(time.Now()) {
+		logger.Debugf("[%s] Expiry time for key [%s] occurs in the past. Value will not be added", c.channelID, cKey)
+	} else {
+		logger.Debugf("[%s] Putting key [%s]. Expires: %s", c.channelID, cKey, value.ExpiryTime)
+		err = c.cache.SetWithExpire(cKey, value, time.Until(value.ExpiryTime))
+	}
+
+	if err != nil {
+		panic("Set must never return an error")
+	}
+}
+
+// Get returns the values for the given keys
+func (c *Cache) Get(ns, coll, key string) (*api.Value, error) {
+	cKey := cacheKey{
+		namespace:  ns,
+		collection: coll,
+		key:        key,
+	}
+
+	value, err := c.cache.Get(cKey)
+	if err != nil {
+		logger.Warningf("[%s] Error getting key [%s]: %s", c.channelID, cKey, err)
+		return nil, err
+	}
+
+	if value == nil {
+		logger.Debugf("[%s] Key not found [%s]", c.channelID, cKey)
+		return nil, nil
+	}
+
+	v, ok := value.(*api.Value)
+	if !ok {
+		panic("Invalid value type!")
+	}
+	if v == nil {
+		logger.Debugf("[%s] Key not found [%s]", c.channelID, cKey)
+		return nil, nil
+	}
+
+	logger.Debugf("[%s] Got key [%s]. Expires: %s", c.channelID, cKey, v.ExpiryTime)
+	return v, nil
+}
+
+// GetMultiple returns the values for the given keys
+func (c *Cache) GetMultiple(ns, coll string, keys ...string) ([]*api.Value, error) {
+	values := make([]*api.Value, len(keys))
+	for i, key := range keys {
+		value, err := c.Get(ns, coll, key)
+		if err != nil {
+			return nil, err
+		}
+		values[i] = value
+	}
+	return values, nil
+}
+
+func (c *Cache) load(key cacheKey) (*api.Value, *time.Duration, error) {
+	db, err := c.dbProvider.GetDB(key.namespace, key.collection)
+	if err != nil {
+		return nil, nil, errors.WithMessage(err, "error getting database")
+	}
+
+	logger.Debugf("Loading value for key %s from DB", key)
+	v, err := db.Get(key.key)
+	if err != nil {
+		return nil, nil, errors.WithMessage(err, "error loading value")
+	}
+
+	logger.Debugf("Loaded value %v for key %s from DB", v, key)
+	if v == nil {
+		logger.Debugf("[%s] Value not found for key [%s]", c.channelID, key)
+		return nil, nil, nil
+	}
+
+	logger.Debugf("Checking expiry time for key %s", key)
+	if v.ExpiryTime.IsZero() {
+		logger.Debugf("[%s] Loaded key [%s]. Expires: NEVER", c.channelID, key)
+		return v, nil, nil
+
+	}
+	remainingTime := time.Until(v.ExpiryTime)
+	if remainingTime < 0 {
+		// Already expired
+		logger.Debugf("[%s] Loaded key [%s]. Expires: NOW", c.channelID, key)
+		return nil, nil, nil
+	}
+
+	logger.Debugf("[%s] Loaded key [%s]. Expires: %s", c.channelID, key, v.ExpiryTime)
+	return v, &remainingTime, nil
+}

--- a/pkg/collections/offledger/storeprovider/store/cache/cache_test.go
+++ b/pkg/collections/offledger/storeprovider/store/cache/cache_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/mocks"
+)
+
+const (
+	channelID = "testchannel"
+
+	ns1 = "ns1"
+
+	coll1 = "coll1"
+	coll2 = "coll2"
+
+	key1 = "key1"
+	key2 = "key2"
+	key3 = "key3"
+	key4 = "key4"
+	key5 = "key5"
+
+	txID1 = "tx1"
+)
+
+var (
+	value1 = []byte("value1")
+	value2 = []byte("value2")
+)
+
+func TestCache_PutAndGet(t *testing.T) {
+	now := time.Now()
+	v1 := &api.Value{Value: value1, TxID: txID1}
+	v2 := &api.Value{Value: value2, TxID: txID1}
+	v4 := &api.Value{Value: value2, TxID: txID1, ExpiryTime: now.Add(50 * time.Millisecond)}
+	v5 := &api.Value{Value: value2, TxID: txID1, ExpiryTime: now.Add(-1 * time.Minute)}
+
+	dbProvider := mocks.NewDBProvider()
+
+	c := New(channelID, dbProvider, 100)
+	require.NotNil(t, c)
+
+	c.Put(ns1, coll1, key1, v1)
+	c.Put(ns1, coll1, key2, v2)
+	c.Put(ns1, coll1, key4, v4)
+	c.Put(ns1, coll1, key5, v5)
+
+	v, err := c.Get(ns1, coll1, key1)
+	assert.NoError(t, err)
+	require.NotNil(t, v)
+	assert.Equal(t, v1, v)
+
+	values, err := c.GetMultiple(ns1, coll1, key1, key2, key3, key4, key5)
+	assert.NoError(t, err)
+	require.Equal(t, 5, len(values))
+	assert.Equal(t, v1, values[0])
+	assert.Equal(t, v2, values[1])
+	assert.Nil(t, values[2]) // Not added
+	assert.Equal(t, v4, values[3])
+	assert.Nil(t, values[4]) // Should not have been added
+
+	time.Sleep(100 * time.Millisecond)
+
+	v, err = c.Get(ns1, coll1, key4)
+	assert.NoError(t, err)
+	require.Nil(t, v) // Should have expired
+}
+
+func TestCache_LoadFromDB(t *testing.T) {
+	valueWithExpiry := &api.Value{
+		Value:      []byte("value1"),
+		ExpiryTime: time.Now().Add(time.Minute),
+	}
+	valueWithNoExpiry := &api.Value{
+		Value: []byte("value1"),
+	}
+	expiredValue := &api.Value{
+		Value:      []byte("value1"),
+		ExpiryTime: time.Now().Add(-1 * time.Minute),
+	}
+
+	dbProvider := mocks.NewDBProvider().
+		WithValue(ns1, coll1, key1, valueWithExpiry).
+		WithValue(ns1, coll1, key2, valueWithNoExpiry).
+		WithValue(ns1, coll1, key3, expiredValue)
+
+	c := New(channelID, dbProvider, 100)
+	require.NotNil(t, c)
+
+	// Not found
+	v, err := c.Get(ns1, coll2, key1)
+	assert.NoError(t, err)
+	assert.Nil(t, v)
+
+	// Found
+	v, err = c.Get(ns1, coll1, key1)
+	assert.NoError(t, err)
+	assert.Equal(t, valueWithExpiry, v)
+	v, err = c.Get(ns1, coll1, key2)
+	assert.NoError(t, err)
+	assert.Equal(t, valueWithNoExpiry, v)
+
+	// Expired
+	v, err = c.Get(ns1, coll1, key3)
+	assert.NoError(t, err)
+	assert.Nil(t, v)
+}
+
+func TestCache_LoadFromDBError(t *testing.T) {
+	t.Run("Error getting DB", func(t *testing.T) {
+		expectedErr := fmt.Errorf("get DB error")
+		dbProvider := mocks.NewDBProvider().
+			WithError(expectedErr)
+
+		c := New(channelID, dbProvider, 100)
+		require.NotNil(t, c)
+
+		v, err := c.Get(ns1, coll1, key1)
+		require.Error(t, err)
+		assert.Nil(t, v)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+	})
+
+	t.Run("Error loading key from DB", func(t *testing.T) {
+		expectedErr := fmt.Errorf("load key from DB error")
+		dbProvider := mocks.NewDBProvider()
+		dbProvider.MockDB(ns1, coll1).WithError(expectedErr)
+
+		c := New(channelID, dbProvider, 100)
+		require.NotNil(t, c)
+
+		v, err := c.Get(ns1, coll1, key1)
+		require.Error(t, err)
+		assert.Nil(t, v)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+
+		values, err := c.GetMultiple(ns1, coll1, key1, key2)
+		require.Error(t, err)
+		assert.Nil(t, values)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+	})
+}
+
+func TestCache_ReloadFromDB(t *testing.T) {
+	v1 := &api.Value{
+		Value:      []byte("value1"),
+		ExpiryTime: time.Now().Add(50 * time.Millisecond),
+	}
+	v2 := &api.Value{
+		Value:      []byte("value2"),
+		ExpiryTime: time.Now().Add(time.Minute),
+	}
+	v3 := &api.Value{
+		Value:      []byte("value3"),
+		ExpiryTime: time.Now().Add(time.Minute),
+	}
+	v4 := &api.Value{
+		Value:      []byte("value4"),
+		ExpiryTime: time.Now().Add(time.Minute),
+	}
+
+	dbProvider := mocks.NewDBProvider().
+		WithValue(ns1, coll1, key1, v1)
+
+	c := New(channelID, dbProvider, 1)
+	require.NotNil(t, c)
+
+	// v1 should be retrieved from the DB and cached
+	v, err := c.Get(ns1, coll1, key1)
+	assert.NoError(t, err)
+	assert.Equal(t, v1, v)
+
+	// Update the value in the DB
+	dbProvider.WithValue(ns1, coll1, key1, v2)
+
+	// v1 should still be retrieved from cache
+	v, err = c.Get(ns1, coll1, key1)
+	assert.NoError(t, err)
+	assert.Equal(t, v1, v)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// key1 should have expired and v2 will be retrieved from the DB
+	v, err = c.Get(ns1, coll1, key1)
+	assert.NoError(t, err)
+	assert.Equal(t, v2, v)
+
+	// Update the value in the DB
+	dbProvider.WithValue(ns1, coll1, key1, v3)
+
+	// The following call should evict key1 from the cache
+	c.Put(ns1, coll1, key2, v4)
+
+	// key1 should have been evicted and v3 will be retrieved from the DB
+	v, err = c.Get(ns1, coll1, key1)
+	assert.NoError(t, err)
+	assert.Equal(t, v3, v)
+}
+
+func Test_Concurrency(t *testing.T) {
+	const (
+		nReaders = 10
+		nWriters = 3
+		nItems   = 1000
+		nReads   = 1000
+		txID1    = "tx1"
+	)
+
+	dbProvider := mocks.NewDBProvider()
+
+	c := New(channelID, dbProvider, 100)
+
+	var wWg sync.WaitGroup
+	wWg.Add(nWriters)
+
+	var rWg sync.WaitGroup
+	rWg.Add(nReaders)
+
+	for i := 0; i < nWriters; i++ {
+		go func() {
+			defer wWg.Done()
+
+			for j := 0; j < nItems; j++ {
+				key := fmt.Sprintf("k_%d", j)
+				expiry := time.Now().Add(getRandomDuration(100) * time.Millisecond)
+				c.Put(ns1, coll1, key, &api.Value{Value: []byte(key), TxID: txID1, ExpiryTime: expiry})
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+
+	var mutex sync.Mutex
+	var errors []error
+	for i := 0; i < nReaders; i++ {
+		go func() {
+			defer rWg.Done()
+
+			for j := 0; j < nReads; j++ {
+				_, err := c.Get(ns1, coll1, getRandomKey(nItems))
+				if err != nil {
+					mutex.Lock()
+					errors = append(errors, err)
+					mutex.Unlock()
+				}
+			}
+		}()
+	}
+
+	wWg.Wait()
+	rWg.Wait()
+
+	if len(errors) > 0 {
+		t.Errorf("Got errors: %s", errors)
+	}
+}
+
+func getRandomKey(max int32) string {
+	return fmt.Sprintf("k_%d", rand.Int31n(max))
+}
+
+func getRandomDuration(max int32) time.Duration {
+	return time.Duration(rand.Int31n(max))
+}

--- a/pkg/collections/offledger/storeprovider/store/mocks/mockdbprovider.go
+++ b/pkg/collections/offledger/storeprovider/store/mocks/mockdbprovider.go
@@ -1,0 +1,142 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"sync"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
+)
+
+// DBProvider is a mock DB provider
+type DBProvider struct {
+	mutex sync.Mutex
+	dbs   map[string]*DB
+	err   error
+}
+
+// NewDBProvider returns a new mock DB provider
+func NewDBProvider() *DBProvider {
+	return &DBProvider{
+		dbs: make(map[string]*DB),
+	}
+}
+
+// WithValue sets a value for the given key
+func (m *DBProvider) WithValue(ns, coll, key string, value *api.Value) *DBProvider {
+	m.MockDB(ns, coll).WithValue(key, value)
+	return m
+}
+
+// WithError simulates an error on the provider
+func (m *DBProvider) WithError(err error) *DBProvider {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.err = err
+	return m
+}
+
+// MockDB is a mock database
+func (m *DBProvider) MockDB(ns, coll string) *DB {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	dbKey := ns + "_" + coll
+	db, ok := m.dbs[dbKey]
+	if !ok {
+		db = newMockDB()
+		m.dbs[dbKey] = db
+	}
+	return db
+}
+
+// GetDB returns a mock DB for the given namespace/collection
+func (m *DBProvider) GetDB(ns, coll string) (api.DB, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.MockDB(ns, coll), nil
+}
+
+// Close currently does nothing
+func (m *DBProvider) Close() {
+}
+
+// DB implements a mock DB
+type DB struct {
+	mutex sync.RWMutex
+	data  map[string]*api.Value
+	err   error
+}
+
+func newMockDB() *DB {
+	return &DB{
+		data: make(map[string]*api.Value),
+	}
+}
+
+// WithValue sets a value for the given key
+func (m *DB) WithValue(key string, value *api.Value) *DB {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.data[key] = value
+	return m
+}
+
+// WithError simulates an error on the DB
+func (m *DB) WithError(err error) *DB {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	m.err = err
+	return m
+}
+
+// Put sets the given values
+func (m *DB) Put(keyVals ...*api.KeyValue) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.err != nil {
+		return m.err
+	}
+
+	for _, kv := range keyVals {
+		m.data[kv.Key] = kv.Value
+	}
+
+	return nil
+}
+
+// Get retrieves the value for the given key
+func (m *DB) Get(key string) (*api.Value, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	return m.data[key], m.err
+}
+
+// GetMultiple retrieves multiple keys at once
+func (m *DB) GetMultiple(keys ...string) ([]*api.Value, error) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	values := make([]*api.Value, len(keys))
+	for i, k := range keys {
+		values[i] = m.data[k]
+	}
+	return values, m.err
+}
+
+// DeleteExpiredKeys currently does nothing
+func (m *DB) DeleteExpiredKeys() error {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	return m.err
+}


### PR DESCRIPTION
Implement a cache in front of Off-Ledger collections. The item is stored
in the cache and in the DB but retrieved from the cache. On cache-miss,
the item is loaded from the DB.

closes #59

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>