### PR TITLE
feat: Collection Client

### DIFF
--- a/pkg/collections/client/client.go
+++ b/pkg/collections/client/client.go
@@ -1,0 +1,269 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"encoding/hex"
+	"sync"
+
+	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/bccsp/factory"
+	"github.com/hyperledger/fabric/common/crypto"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/core/peer"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	"github.com/hyperledger/fabric/gossip/service"
+	mspmgmt "github.com/hyperledger/fabric/msp/mgmt"
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/transientstore"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/support"
+)
+
+var logger = flogging.MustGetLogger("offledger")
+
+// PeerLedger defines the ledger functions required by the client
+type PeerLedger interface {
+	// NewQueryExecutor gives handle to a query executor.
+	// A client can obtain more than one 'QueryExecutor's for parallel execution.
+	// Any synchronization should be performed at the implementation level if required
+	NewQueryExecutor() (ledger.QueryExecutor, error)
+	// NewTxSimulator gives handle to a transaction simulator.
+	// A client can obtain more than one 'TxSimulator's for parallel execution.
+	// Any snapshoting/synchronization should be performed at the implementation level if required
+	NewTxSimulator(txid string) (ledger.TxSimulator, error)
+	// GetBlockchainInfo returns basic info about blockchain
+	GetBlockchainInfo() (*cb.BlockchainInfo, error)
+}
+
+// GossipAdapter defines the Gossip functions required by the client
+type GossipAdapter interface {
+	// DistributePrivateData distributes private data to the peers in the collections
+	// according to policies induced by the PolicyStore and PolicyParser
+	DistributePrivateData(chainID string, txID string, privateData *transientstore.TxPvtReadWriteSetWithConfigInfo, blkHt uint64) error
+}
+
+// CollectionConfigRetriever defines the collection config retrieval functions required by the client
+type CollectionConfigRetriever interface {
+	Config(ns, coll string) (*cb.StaticCollectionConfig, error)
+}
+
+// KeyValue holds a key-value pair
+type KeyValue struct {
+	Key   string
+	Value []byte
+}
+
+// Client allows you to put and get Client from outside of a chaincode
+type Client struct {
+	channelID       string
+	ledger          PeerLedger
+	gossip          GossipAdapter
+	configRetriever CollectionConfigRetriever
+	creator         []byte
+	mutex           sync.RWMutex
+}
+
+// New returns a new client
+func New(channelID string) *Client {
+	ledger := getLedger(channelID)
+	blockPublisher := getBlockPublisher(channelID)
+
+	return &Client{
+		channelID:       channelID,
+		ledger:          ledger,
+		gossip:          getGossipAdapter(),
+		configRetriever: getCollConfigRetriever(channelID, ledger, blockPublisher),
+	}
+}
+
+// Put puts the value for the given key
+func (d *Client) Put(ns, coll, key string, value []byte) error {
+	return d.PutMultipleValues(ns, coll, []*KeyValue{{Key: key, Value: value}})
+}
+
+// PutMultipleValues puts the given key/values
+func (d *Client) PutMultipleValues(ns, coll string, kvs []*KeyValue) error {
+	// Generate a new TxID. The TxID doesn't really matter since this transaction is never committed.
+	// It just has to be unique.
+	txID, err := d.newTxID()
+	if err != nil {
+		logger.Warningf("[%s] Error generating transaction ID: %s", d.channelID, err)
+		return errors.WithMessagef(err, "error generating transaction ID in channel [%s]", d.channelID)
+	}
+
+	sim, err := d.ledger.NewTxSimulator(txID)
+	if err != nil {
+		logger.Warningf("[%s] Error getting TxSimulator for transaction [%s]: %s", d.channelID, txID, err)
+		return errors.WithMessagef(err, "error getting TxSimulator for transaction [%s] in channel [%s]", txID, d.channelID)
+	}
+	defer sim.Done()
+
+	mapByKey := make(map[string][]byte)
+	for _, kv := range kvs {
+		mapByKey[kv.Key] = kv.Value
+	}
+
+	err = sim.SetPrivateDataMultipleKeys(ns, coll, mapByKey)
+	if err != nil {
+		logger.Warningf("[%s] Error setting values for transaction [%s]: %s", d.channelID, txID, err)
+		return errors.WithMessagef(err, "error setting keys for transaction [%s] in channel [%s]", txID, d.channelID)
+	}
+
+	results, err := sim.GetTxSimulationResults()
+	if err != nil {
+		logger.Warningf("[%s] Error generating simulation results for transaction [%s]: %s", d.channelID, txID, err)
+		return errors.WithMessagef(err, "error generating simulation results for transaction [%s] in channel [%s]", txID, d.channelID)
+	}
+
+	bcInfo, err := d.ledger.GetBlockchainInfo()
+	if err != nil {
+		logger.Warningf("[%s] Error getting blockchain info: %s", d.channelID, err)
+		return errors.WithMessagef(err, "error getting blockchain info in channel [%s]", d.channelID)
+	}
+
+	configPkg, err := d.getCollectionConfigPackage(ns, coll)
+	if err != nil {
+		logger.Warningf("[%s] Error getting collection config for [%s:%s]: %s", d.channelID, ns, coll, err)
+		return errors.WithMessagef(err, "error getting collection config for [%s:%s] in channel [%s]", ns, coll, d.channelID)
+	}
+
+	pvtData := &transientstore.TxPvtReadWriteSetWithConfigInfo{
+		EndorsedAt: bcInfo.Height,
+		PvtRwset:   results.PvtSimulationResults,
+		CollectionConfigs: map[string]*cb.CollectionConfigPackage{
+			ns: configPkg,
+		},
+	}
+
+	err = d.gossip.DistributePrivateData(d.channelID, txID, pvtData, bcInfo.Height)
+	if err != nil {
+		logger.Warningf("[%s] Failed to distribute private data: %s", d.channelID, err)
+		return errors.WithMessagef(err, "error distributing private data in channel [%s]", d.channelID)
+	}
+
+	return nil
+}
+
+// Get retrieves the value for the given key
+func (d *Client) Get(ns, coll, key string) ([]byte, error) {
+	qe, err := d.ledger.NewQueryExecutor()
+	if err != nil {
+		logger.Warningf("[%s] Error getting QueryExecutor: %s", d.channelID, err)
+		return nil, errors.WithMessagef(err, "error getting QueryExecutor in channel [%s]", d.channelID)
+	}
+	defer qe.Done()
+
+	return qe.GetPrivateData(ns, coll, key)
+}
+
+// GetMultipleKeys retrieves the values for the given keys
+func (d *Client) GetMultipleKeys(ns, coll string, keys ...string) ([][]byte, error) {
+	qe, err := d.ledger.NewQueryExecutor()
+	if err != nil {
+		logger.Warningf("[%s] Error getting QueryExecutor: %s", d.channelID, err)
+		return nil, errors.WithMessagef(err, "error getting QueryExecutor in channel [%s]", d.channelID)
+	}
+	defer qe.Done()
+
+	return qe.GetPrivateDataMultipleKeys(ns, coll, keys)
+}
+
+func (d *Client) getCollectionConfigPackage(ns, coll string) (*cb.CollectionConfigPackage, error) {
+	collConfig, err := d.configRetriever.Config(ns, coll)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cb.CollectionConfigPackage{
+		Config: []*cb.CollectionConfig{
+			{
+				Payload: &cb.CollectionConfig_StaticCollectionConfig{
+					StaticCollectionConfig: collConfig,
+				},
+			},
+		},
+	}, nil
+}
+
+func (d *Client) newTxID() (string, error) {
+	creator, err := d.getCreator()
+	if err != nil {
+		return "", errors.WithMessage(err, "error serializing local signing identity")
+	}
+
+	nonce, err := crypto.GetRandomNonce()
+	if err != nil {
+		return "", errors.WithMessage(err, "nonce creation failed")
+	}
+
+	txnID, err := computeTxID(nonce, creator)
+	if err != nil {
+		return "", errors.WithMessage(err, "txn ID computation failed")
+	}
+
+	return txnID, nil
+}
+
+func (d *Client) getCreator() ([]byte, error) {
+	d.mutex.RLock()
+	c := d.creator
+	d.mutex.RUnlock()
+
+	if c != nil {
+		return c, nil
+	}
+
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	if d.creator == nil {
+		creator, err := newCreator()
+		if err != nil {
+			return nil, errors.WithMessage(err, "error serializing local signing identity")
+		}
+		d.creator = creator
+	}
+
+	return d.creator, nil
+}
+
+func computeTxID(nonce, creator []byte) (string, error) {
+	digest, err := factory.GetDefault().Hash(append(nonce, creator...), &bccsp.SHA256Opts{})
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(digest), nil
+}
+
+// getLedger returns the peer ledger. This var may be overridden in unit tests
+var getLedger = func(channelID string) PeerLedger {
+	return peer.GetLedger(channelID)
+}
+
+// getLedger returns the peer ledger. This var may be overridden in unit tests
+var getBlockPublisher = func(channelID string) gossipapi.BlockPublisher {
+	return peer.BlockPublisher.ForChannel(channelID)
+}
+
+// getGossipAdapter returns the gossip adapter. This var may be overridden in unit tests
+var getGossipAdapter = func() GossipAdapter {
+	return service.GetGossipService()
+}
+
+var getCollConfigRetriever = func(channelID string, ledger PeerLedger, blockPublisher gossipapi.BlockPublisher) CollectionConfigRetriever {
+	return support.NewCollectionConfigRetriever(channelID, ledger, blockPublisher)
+}
+
+var newCreator = func() ([]byte, error) {
+	id, err := mspmgmt.GetLocalMSP().GetDefaultSigningIdentity()
+	if err != nil {
+		return nil, errors.WithMessage(err, "error getting local signing identity")
+	}
+	return id.Serialize()
+}

--- a/pkg/collections/client/client_test.go
+++ b/pkg/collections/client/client_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/transientstore"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	channelID   = "testchannel"
+	ns1         = "ns1"
+	coll1       = "coll1"
+	key1        = "key1"
+	key2        = "key2"
+	blockHeight = uint64(1000)
+)
+
+func TestClient_Put(t *testing.T) {
+	ledger := &mocks.Ledger{
+		TxSimulator: &mocks.TxSimulator{
+			SimulationResults: &ledger.TxSimulationResults{},
+		},
+		BlockchainInfo: &cb.BlockchainInfo{
+			Height: blockHeight,
+		},
+	}
+	gossip := &mockGossipAdapter{}
+	configRetriever := &mockCollectionConfigRetriever{}
+	var creatorError error
+
+	// Mock out all of the dependencies
+	getLedger = func(channelID string) PeerLedger { return ledger }
+	getGossipAdapter = func() GossipAdapter { return gossip }
+	getBlockPublisher = func(channelID string) gossipapi.BlockPublisher { return mocks.NewBlockPublisher() }
+	getCollConfigRetriever = func(_ string, _ PeerLedger, _ gossipapi.BlockPublisher) CollectionConfigRetriever {
+		return configRetriever
+	}
+	newCreator = func() ([]byte, error) { return []byte("creator"), creatorError }
+
+	c := New(channelID)
+	require.NotNil(t, c)
+
+	value1 := []byte("value1")
+
+	t.Run("TxID error", func(t *testing.T) {
+		creatorError = errors.New("mock creator error")
+		defer func() { creatorError = nil }()
+
+		err := c.Put(ns1, coll1, key1, value1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error generating transaction ID")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		err := c.Put(ns1, coll1, key1, value1)
+		require.NoError(t, err)
+	})
+
+	t.Run("Simulation results error", func(t *testing.T) {
+		ledger.TxSimulator.SimError = errors.New("mock TxSimulator error")
+		defer func() { ledger.TxSimulator.SimError = nil }()
+
+		err := c.Put(ns1, coll1, key1, value1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error generating simulation results")
+	})
+
+	t.Run("GetTxSimulator error", func(t *testing.T) {
+		ledger.Error = errors.New("mock TxSimulator error")
+		defer func() { ledger.Error = nil }()
+
+		err := c.Put(ns1, coll1, key1, value1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error getting TxSimulator")
+	})
+
+	t.Run("TxSimulator - Put error", func(t *testing.T) {
+		ledger.TxSimulator.Error = errors.New("mock TxSimulator error")
+		defer func() { ledger.TxSimulator.Error = nil }()
+
+		err := c.Put(ns1, coll1, key1, value1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error setting keys")
+	})
+
+	t.Run("Gossip error", func(t *testing.T) {
+		gossip.Error = errors.New("mock gossip error")
+		defer func() { gossip.Error = nil }()
+
+		err := c.Put(ns1, coll1, key1, value1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error distributing private data")
+	})
+
+	t.Run("GetBlockchainInfo error", func(t *testing.T) {
+		ledger.BcInfoError = errors.New("mock ledger error")
+		defer func() { ledger.BcInfoError = nil }()
+
+		err := c.Put(ns1, coll1, key1, value1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error getting blockchain info")
+	})
+
+	t.Run("CollectionConfig error", func(t *testing.T) {
+		configRetriever.Error = errors.New("mock config error")
+		defer func() { configRetriever.Error = nil }()
+
+		err := c.Put(ns1, coll1, key1, value1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error getting collection config")
+	})
+}
+
+func TestClient_Get(t *testing.T) {
+	value1 := []byte("value1")
+	value2 := []byte("value2")
+
+	pvtNS := ns1 + "$" + coll1
+	state := make(map[string]map[string][]byte)
+	state[pvtNS] = make(map[string][]byte)
+	state[pvtNS][key1] = value1
+	state[pvtNS][key2] = value2
+
+	ledger := &mocks.Ledger{
+		QueryExecutor: mocks.NewQueryExecutor(state),
+	}
+
+	gossip := &mockGossipAdapter{}
+	configRetriever := &mockCollectionConfigRetriever{}
+	var creatorError error
+
+	// Mock out all of the dependencies
+	getLedger = func(channelID string) PeerLedger { return ledger }
+	getGossipAdapter = func() GossipAdapter { return gossip }
+	getBlockPublisher = func(channelID string) gossipapi.BlockPublisher { return mocks.NewBlockPublisher() }
+	getCollConfigRetriever = func(_ string, _ PeerLedger, _ gossipapi.BlockPublisher) CollectionConfigRetriever {
+		return configRetriever
+	}
+	newCreator = func() ([]byte, error) { return []byte("creator"), creatorError }
+
+	c := New(channelID)
+	require.NotNil(t, c)
+
+	t.Run("Get - success", func(t *testing.T) {
+		value, err := c.Get(ns1, coll1, key1)
+		require.NoError(t, err)
+		assert.Equal(t, value1, value)
+	})
+
+	t.Run("Get - error", func(t *testing.T) {
+		ledger.Error = errors.New("mock QueryExecutor error")
+		defer func() { ledger.Error = nil }()
+
+		_, err := c.Get(ns1, coll1, key1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error getting QueryExecutor")
+	})
+
+	t.Run("GetMultipleKeys - success", func(t *testing.T) {
+		values, err := c.GetMultipleKeys(ns1, coll1, key1, key2)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(values))
+		assert.Equal(t, value1, values[0])
+		assert.Equal(t, value2, values[1])
+	})
+
+	t.Run("GetMultipleKeys - error", func(t *testing.T) {
+		ledger.Error = errors.New("mock QueryExecutor error")
+		defer func() { ledger.Error = nil }()
+
+		_, err := c.GetMultipleKeys(ns1, coll1, key1, key2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error getting QueryExecutor")
+	})
+}
+
+type mockCollectionConfigRetriever struct {
+	Error error
+}
+
+func (m *mockCollectionConfigRetriever) Config(ns, coll string) (*cb.StaticCollectionConfig, error) {
+	return &cb.StaticCollectionConfig{}, m.Error
+}
+
+type mockGossipAdapter struct {
+	Error error
+}
+
+func (m *mockGossipAdapter) DistributePrivateData(chainID string, txID string, privateData *transientstore.TxPvtReadWriteSetWithConfigInfo, blkHt uint64) error {
+	return m.Error
+}


### PR DESCRIPTION
Added an client API that allows you to persist and retrieve off-ledger
collection data (including transient data) from outside of a chaincode.

closes #56

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>