### PR TITLE
feat: Extract Off-Ledger data from read/write sets and persist

### DIFF
--- a/mod/peer/collections/api/store/provider.go
+++ b/mod/peer/collections/api/store/provider.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	cb "github.com/hyperledger/fabric/protos/common"
 	proto "github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/trustbloc/fabric-peer-ext/pkg/common"
 )
@@ -33,6 +34,15 @@ type Store interface {
 
 	// GetTransientDataMultipleKeys gets the values for the multiple transient data items in a single call
 	GetTransientDataMultipleKeys(key *MultiKey) (ExpiringValues, error)
+
+	// GetData gets the value for the given item
+	GetData(key *Key) (*ExpiringValue, error)
+
+	// GetDataMultipleKeys gets the values for the multiple items in a single call
+	GetDataMultipleKeys(key *MultiKey) (ExpiringValues, error)
+
+	// PutData stores the key/value.
+	PutData(config *cb.StaticCollectionConfig, key *Key, value *ExpiringValue) error
 
 	// Close closes the store
 	Close()

--- a/mod/peer/gossip/coordinator/coordinator_test.go
+++ b/mod/peer/gossip/coordinator/coordinator_test.go
@@ -9,11 +9,10 @@ package coordinator
 import (
 	"testing"
 
-	"github.com/hyperledger/fabric/extensions/mocks"
 	"github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	extmocks "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
 const (
@@ -34,7 +33,7 @@ func TestCoordinator_StorePvtData(t *testing.T) {
 	c := New(channelID, tStore, collStore)
 	require.NotNil(t, c)
 
-	b := extmocks.NewPvtReadWriteSetBuilder()
+	b := mocks.NewPvtReadWriteSetBuilder()
 	nsBuilder := b.Namespace(ns1)
 	nsBuilder.Collection(coll1).StaticConfig(policy1, 2, 5, 1000)
 	nsBuilder.Collection(coll2).TransientConfig(policy1, 2, 5, "1m")

--- a/mod/peer/mocks/mockdatastore.go
+++ b/mod/peer/mocks/mockdatastore.go
@@ -8,25 +8,34 @@ package mocks
 
 import (
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	cb "github.com/hyperledger/fabric/protos/common"
 	proto "github.com/hyperledger/fabric/protos/transientstore"
 )
 
 // DataStore implements a mock data store
 type DataStore struct {
 	transientData map[storeapi.Key]*storeapi.ExpiringValue
+	olData        map[storeapi.Key]*storeapi.ExpiringValue
 	err           error
 }
 
-// NewDataStore returns a mock data store
+// NewDataStore returns a mock transient data store
 func NewDataStore() *DataStore {
 	return &DataStore{
 		transientData: make(map[storeapi.Key]*storeapi.ExpiringValue),
+		olData:        make(map[storeapi.Key]*storeapi.ExpiringValue),
 	}
 }
 
 // TransientData sets the transient data for the given key
 func (m *DataStore) TransientData(key *storeapi.Key, value *storeapi.ExpiringValue) *DataStore {
 	m.transientData[storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: key.Key}] = value
+	return m
+}
+
+// Data sets the data for the given key
+func (m *DataStore) Data(key *storeapi.Key, value *storeapi.ExpiringValue) *DataStore {
+	m.olData[storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: key.Key}] = value
 	return m
 }
 
@@ -52,6 +61,33 @@ func (m *DataStore) GetTransientDataMultipleKeys(key *storeapi.MultiKey) (storea
 	var values storeapi.ExpiringValues
 	for _, k := range key.Keys {
 		value, err := m.GetTransientData(&storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: k})
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, m.err
+}
+
+// PutData stores the key/value
+func (m *DataStore) PutData(config *cb.StaticCollectionConfig, key *storeapi.Key, value *storeapi.ExpiringValue) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.olData[storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: key.Key}] = value
+	return nil
+}
+
+// GetData gets the value for the given DCAS item
+func (m *DataStore) GetData(key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return m.olData[storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: key.Key}], m.err
+}
+
+// GetDataMultipleKeys gets the values for the multiple DCAS items in a single call
+func (m *DataStore) GetDataMultipleKeys(key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	var values storeapi.ExpiringValues
+	for _, k := range key.Keys {
+		value, err := m.GetData(&storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: k})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/collections/offledger/api/offledger.go
+++ b/pkg/collections/offledger/api/offledger.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	cb "github.com/hyperledger/fabric/protos/common"
+	proto "github.com/hyperledger/fabric/protos/transientstore"
+)
+
+// Store manages the storage of private data collections.
+type Store interface {
+	// Persist stores the private write set of a transaction.
+	Persist(txid string, privateSimulationResultsWithConfig *proto.TxPvtReadWriteSetWithConfigInfo) error
+
+	// PutData stores the key/value.
+	PutData(config *cb.StaticCollectionConfig, key *storeapi.Key, value *storeapi.ExpiringValue) error
+
+	// GetData gets the value for the given item
+	GetData(key *storeapi.Key) (*storeapi.ExpiringValue, error)
+
+	// GetDataMultipleKeys gets the values for the multiple items in a single call
+	GetDataMultipleKeys(key *storeapi.MultiKey) (storeapi.ExpiringValues, error)
+
+	// Close closes the store
+	Close()
+}
+
+// StoreProvider is an interface to open/close a store
+type StoreProvider interface {
+	// OpenStore creates a handle to the private data store for the given ledger ID
+	OpenStore(ledgerid string) (Store, error)
+
+	// Close cleans up the provider
+	Close()
+}

--- a/pkg/collections/offledger/storeprovider/olstore.go
+++ b/pkg/collections/offledger/storeprovider/olstore.go
@@ -1,0 +1,316 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storeprovider
+
+import (
+	"time"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	mspmgmt "github.com/hyperledger/fabric/msp/mgmt"
+	"github.com/hyperledger/fabric/protos/common"
+	cb "github.com/hyperledger/fabric/protos/common"
+	pb "github.com/hyperledger/fabric/protos/transientstore"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/cache"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+)
+
+var logger = flogging.MustGetLogger("offledgerstore")
+
+type store struct {
+	channelID   string
+	dbProvider  api.DBProvider
+	cache       *cache.Cache
+	collConfigs map[common.CollectionType]*collTypeConfig
+}
+
+func newStore(channelID string, dbProvider api.DBProvider, collConfigs map[common.CollectionType]*collTypeConfig) *store {
+	logger.Debugf("constructing collection data store")
+	return &store{
+		channelID:   channelID,
+		collConfigs: collConfigs,
+		dbProvider:  dbProvider,
+		cache:       cache.New(channelID, dbProvider, config.GetOLCollCacheSize()),
+	}
+}
+
+// Close closes the store
+func (s *store) Close() {
+	s.dbProvider.Close()
+}
+
+// Persist persists all data within the private data simulation results
+func (s *store) Persist(txID string, privateSimulationResultsWithConfig *pb.TxPvtReadWriteSetWithConfigInfo) error {
+	rwSet, err := rwsetutil.TxPvtRwSetFromProtoMsg(privateSimulationResultsWithConfig.PvtRwset)
+	if err != nil {
+		return errors.WithMessage(err, "error getting pvt RW set from bytes")
+	}
+
+	for _, nsRWSet := range rwSet.NsPvtRwSet {
+		for _, collRWSet := range nsRWSet.CollPvtRwSets {
+			if err := s.persistColl(txID, nsRWSet.NameSpace, privateSimulationResultsWithConfig.CollectionConfigs, collRWSet); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// PutData returns the  data for the given key
+func (s *store) PutData(config *cb.StaticCollectionConfig, key *storeapi.Key, value *storeapi.ExpiringValue) error {
+	if value.Value == nil {
+		return errors.Errorf("attempt to put nil value for key [%s]", key)
+	}
+	if config.Name != key.Collection {
+		return errors.Errorf("invalid collection config for key [%s]", key)
+	}
+
+	key, value, err := s.decorate(config, key, value)
+	if err != nil {
+		return err
+	}
+
+	if !value.Expiry.IsZero() {
+		if value.Expiry.Before(time.Now()) {
+			// Already expired
+			logger.Debugf("[%s] Key [%s] already expired", s.channelID, key)
+			return nil
+		}
+	}
+
+	db, err := s.dbProvider.GetDB(key.Namespace, key.Collection)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("[%s] Putting key [%s] to DB", s.channelID, key)
+	err = db.Put(api.NewKeyValue(key.Key, value.Value, key.EndorsedAtTxID, value.Expiry))
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("[%s] Putting key [%s] to cache", s.channelID, key)
+	s.cache.Put(key.Namespace, key.Collection, key.Key,
+		&api.Value{
+			Value:      value.Value,
+			TxID:       key.EndorsedAtTxID,
+			ExpiryTime: value.Expiry,
+		},
+	)
+
+	return nil
+}
+
+// GetData returns the  data for the given key
+func (s *store) GetData(key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return s.getData(key.EndorsedAtTxID, key.Namespace, key.Collection, key.Key)
+}
+
+// tDataMultipleKeys returns the  data for the given keys
+func (s *store) GetDataMultipleKeys(key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	return s.getDataMultipleKeys(key.EndorsedAtTxID, key.Namespace, key.Collection, key.Keys...)
+}
+
+func (s *store) persistColl(txID string, ns string, collConfigPkgs map[string]*common.CollectionConfigPackage, collRWSet *rwsetutil.CollPvtRwSet) error {
+	config, exists := s.getCollectionConfig(collConfigPkgs, ns, collRWSet.CollectionName)
+	if !exists {
+		logger.Debugf("[%s]  config for collection [%s:%s] not found in config packages", s.channelID, ns, collRWSet.CollectionName)
+		return nil
+	}
+
+	authorized, err := s.isAuthorized(ns, config)
+	if err != nil {
+		return err
+	}
+	if !authorized {
+		logger.Infof("[%s] Will not store  collection [%s:%s] since local peer is not authorized.", s.channelID, ns, collRWSet.CollectionName)
+		return nil
+	}
+
+	logger.Debugf("[%s] Collection [%s:%s] is a  collection", s.channelID, ns, collRWSet.CollectionName)
+
+	expiryTime, err := s.getExpirationTime(config)
+	if err != nil {
+		return err
+	}
+
+	batch, err := s.createBatch(txID, ns, config, collRWSet, expiryTime)
+	if err != nil {
+		return err
+	}
+
+	db, err := s.dbProvider.GetDB(ns, collRWSet.CollectionName)
+	if err != nil {
+		return err
+	}
+
+	err = db.Put(batch...)
+	if err != nil {
+		return errors.WithMessagef(err, "error persisting to [%s:%s]", ns, collRWSet.CollectionName)
+	}
+
+	for _, kv := range batch {
+		logger.Debugf("[%s] Putting key [%s:%s:%s] in Tx [%s]", s.channelID, ns, collRWSet.CollectionName, kv.Key, kv.TxID)
+		s.cache.Put(ns, collRWSet.CollectionName, kv.Key, kv.Value)
+	}
+
+	return nil
+}
+
+func (s *store) getData(txID, ns, coll, key string) (*storeapi.ExpiringValue, error) {
+	value, err := s.cache.Get(ns, coll, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if value == nil {
+		return nil, nil
+	}
+
+	logger.Debugf("[%s] Got value for key [%s:%s:%s] which was persisted in transaction [%s]. Current tx [%s]", s.channelID, ns, coll, key, value.TxID, txID)
+	if value.TxID == txID {
+		logger.Debugf("[%s] Key [%s:%s:%s] was persisted in same transaction [%s] as caller. Returning nil.", s.channelID, ns, coll, key, txID)
+		return nil, nil
+	}
+
+	return &storeapi.ExpiringValue{Value: value.Value, Expiry: value.ExpiryTime}, nil
+}
+
+func (s *store) getDataMultipleKeys(txID, ns, coll string, keys ...string) (storeapi.ExpiringValues, error) {
+	values, err := s.cache.GetMultiple(ns, coll, keys...)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(values) != len(keys) {
+		return nil, errors.New("not all of the values were returned for the set of keys")
+	}
+
+	var ret storeapi.ExpiringValues
+	for i, value := range values {
+		var v *storeapi.ExpiringValue
+		if value != nil {
+			logger.Debugf("[%s] Got value for key [%s:%s:%s] which was persisted in transaction [%s]. Current tx [%s]", s.channelID, ns, coll, keys[i], value.TxID, txID)
+			if value.TxID == txID {
+				logger.Debugf("[%s] Key [%s:%s:%s] was persisted in same transaction [%s] as caller. Returning nil.", s.channelID, ns, coll, keys[i], txID)
+			} else {
+				v = &storeapi.ExpiringValue{Value: value.Value, Expiry: value.ExpiryTime}
+			}
+		}
+		ret = append(ret, v)
+	}
+
+	return ret, nil
+}
+
+func (s *store) createBatch(txID, ns string, config *cb.StaticCollectionConfig, collRWSet *rwsetutil.CollPvtRwSet, expiryTime time.Time) ([]*api.KeyValue, error) {
+	var batch []*api.KeyValue
+	for _, wSet := range collRWSet.KvRwSet.Writes {
+		if wSet.IsDelete {
+			return nil, errors.Errorf("[%s] Attempt to delete key [%s] in collection [%s:%s]", s.channelID, wSet.Key, ns, collRWSet.CollectionName)
+		}
+
+		key := storeapi.NewKey(txID, ns, collRWSet.CollectionName, wSet.Key)
+		value := &storeapi.ExpiringValue{
+			Value:  wSet.Value,
+			Expiry: expiryTime,
+		}
+
+		key, value, err := s.decorate(config, key, value)
+		if err != nil {
+			return nil, err
+		}
+
+		batch = append(batch, api.NewKeyValue(key.Key, value.Value, txID, value.Expiry))
+	}
+	return batch, nil
+}
+
+func (s *store) isAuthorized(ns string, config *common.StaticCollectionConfig) (bool, error) {
+	policy, err := s.loadPolicy(ns, config)
+	if err != nil {
+		logger.Errorf("[%s] Error loading policy for collection [%s:%s]: %s", s.channelID, ns, config.Name, err)
+		return false, err
+	}
+
+	localMSPID, err := getLocalMSPID()
+	if err != nil {
+		logger.Errorf("[%s] Error getting local MSP ID: %s", s.channelID, err)
+		return false, err
+	}
+	for _, mspID := range policy.MemberOrgs() {
+		if mspID == localMSPID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// TODO: Consider caching policies to avoid marshalling every time
+func (s *store) loadPolicy(ns string, config *common.StaticCollectionConfig) (privdata.CollectionAccessPolicy, error) {
+	logger.Debugf("[%s] Loading collection policy for [%s:%s]", s.channelID, ns, config.Name)
+
+	colAP := &privdata.SimpleCollection{}
+	err := colAP.Setup(config, mspmgmt.GetIdentityDeserializer(s.channelID))
+	if err != nil {
+		return nil, errors.Wrapf(err, "error setting up collection policy %s", config.Name)
+	}
+
+	return colAP, nil
+}
+
+func (s *store) getExpirationTime(config *common.StaticCollectionConfig) (time.Time, error) {
+	var expiryTime time.Time
+	if config.TimeToLive == "" {
+		return expiryTime, nil
+	}
+	ttl, e := time.ParseDuration(config.TimeToLive)
+	if e != nil {
+		// This shouldn't happen since the config was validated before being persisted
+		return expiryTime, errors.Wrapf(e, "error parsing time-to-live for collection [%s]", config.Name)
+	}
+	return time.Now().Add(ttl), nil
+}
+
+func (s *store) getCollectionConfig(collConfigPkgs map[string]*common.CollectionConfigPackage, namespace, collName string) (*common.StaticCollectionConfig, bool) {
+	collConfigPkg, ok := collConfigPkgs[namespace]
+	if !ok {
+		return nil, false
+	}
+
+	for _, collConfig := range collConfigPkg.Config {
+		config := collConfig.GetStaticCollectionConfig()
+		if config != nil && config.Name == collName && s.collTypeSupported(config.Type) {
+			return config, true
+		}
+	}
+
+	return nil, false
+}
+
+func (s *store) decorate(config *cb.StaticCollectionConfig, key *storeapi.Key, value *storeapi.ExpiringValue) (*storeapi.Key, *storeapi.ExpiringValue, error) {
+	cfg, ok := s.collConfigs[config.Type]
+	if !ok || cfg.decorator == nil {
+		return key, value, nil
+	}
+	return cfg.decorator(key, value)
+}
+
+func (s *store) collTypeSupported(collType cb.CollectionType) bool {
+	_, ok := s.collConfigs[collType]
+	return ok
+}
+
+// getLocalMSPID returns the MSP ID of the local peer. This variable may be overridden by unit tests.
+var getLocalMSPID = func() (string, error) {
+	return mspmgmt.GetLocalMSP().GetIdentifier()
+}

--- a/pkg/collections/offledger/storeprovider/olstore_test.go
+++ b/pkg/collections/offledger/storeprovider/olstore_test.go
@@ -1,0 +1,427 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storeprovider
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	olstoreapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
+	olmocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	channelID = "testchannel"
+
+	txID1 = "txid1"
+	txID2 = "txid2"
+	txID3 = "txid3"
+
+	ns1 = "ns1"
+
+	coll0 = "coll0"
+	coll1 = "coll1"
+	coll2 = "coll2"
+	coll3 = "coll3"
+
+	org1MSP = "Org1MSP"
+	org2MSP = "Org2MSP"
+)
+
+var (
+	value1_1 = []byte("value1_1")
+	value1_2 = []byte("value1_2")
+	value2_1 = []byte("value2_1")
+	value3_1 = []byte("value3_1")
+	value4_1 = []byte("value4_1")
+
+	key1 = "key1"
+	key2 = "key2"
+	key3 = "key3"
+)
+
+func TestStore_Close(t *testing.T) {
+	collTypeConfig := map[cb.CollectionType]*collTypeConfig{cb.CollectionType_COL_OFFLEDGER: {}}
+	s := newStore(channelID, olmocks.NewDBProvider(), collTypeConfig)
+	require.NotNil(t, s)
+
+	s.Close()
+
+	// Multiple calls on Close are allowed
+	assert.NotPanics(t, func() {
+		s.Close()
+	})
+}
+
+func TestStore_PutAndGet(t *testing.T) {
+	collTypeConfig := map[cb.CollectionType]*collTypeConfig{cb.CollectionType_COL_OFFLEDGER: {}}
+	s := newStore(channelID, olmocks.NewDBProvider(), collTypeConfig)
+	require.NotNil(t, s)
+	defer s.Close()
+
+	getLocalMSPID = func() (string, error) { return org1MSP, nil }
+
+	b := mocks.NewPvtReadWriteSetBuilder()
+	ns1Builder := b.Namespace(ns1)
+	coll1Builder := ns1Builder.Collection(coll1)
+	coll1Builder.
+		OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "1m").
+		Write(key1, value1_1).
+		Write(key2, value1_2)
+	coll2Builder := ns1Builder.Collection(coll2)
+	coll2Builder.
+		OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "").
+		Write(key2, value2_1)
+	coll3Builder := ns1Builder.Collection(coll3)
+	coll3Builder.
+		StaticConfig("OR('Org1MSP.member')", 1, 2, 100).
+		Write(key1, value3_1)
+
+	err := s.Persist(txID1, b.Build())
+	assert.NoError(t, err)
+
+	t.Run("GetData invalid collection -> nil", func(t *testing.T) {
+		value, err := s.GetData(storeapi.NewKey(txID1, ns1, coll0, key1))
+		assert.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetData in same transaction -> nil", func(t *testing.T) {
+		value, err := s.GetData(storeapi.NewKey(txID1, ns1, coll1, key1))
+		assert.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetData in new transaction -> valid", func(t *testing.T) {
+		value, err := s.GetData(storeapi.NewKey(txID2, ns1, coll1, key1))
+		assert.NoError(t, err)
+		require.NotNil(t, value)
+		assert.Equal(t, value1_1, value.Value)
+
+		value, err = s.GetData(storeapi.NewKey(txID2, ns1, coll1, key2))
+		assert.NoError(t, err)
+		require.NotNil(t, value)
+		assert.Equal(t, value1_2, value.Value)
+	})
+
+	t.Run("GetData collection2 -> valid", func(t *testing.T) {
+		// Collection2
+		value, err := s.GetData(storeapi.NewKey(txID2, ns1, coll2, key2))
+		assert.NoError(t, err)
+		require.NotNil(t, value)
+		assert.Equal(t, value2_1, value.Value)
+	})
+
+	t.Run("GetData on non-off-ledger collection -> nil", func(t *testing.T) {
+		value, err := s.GetData(storeapi.NewKey(txID2, ns1, coll3, key1))
+		assert.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetDataMultipleKeys in same transaction -> nil", func(t *testing.T) {
+		values, err := s.GetDataMultipleKeys(storeapi.NewMultiKey(txID1, ns1, coll1, key1, key2))
+		assert.NoError(t, err)
+		require.Equal(t, 2, len(values))
+		assert.Nil(t, values[0])
+		assert.Nil(t, values[1])
+	})
+
+	t.Run("GetDataMultipleKeys in new transaction -> valid", func(t *testing.T) {
+		values, err := s.GetDataMultipleKeys(storeapi.NewMultiKey(txID2, ns1, coll1, key1, key2))
+		assert.NoError(t, err)
+		require.Equal(t, 2, len(values))
+		require.NotNil(t, values[0])
+		require.NotNil(t, values[1])
+		assert.Equal(t, value1_1, values[0].Value)
+		assert.Equal(t, value1_2, values[1].Value)
+	})
+
+	t.Run("Disallow delete data", func(t *testing.T) {
+		b := mocks.NewPvtReadWriteSetBuilder()
+		ns1Builder := b.Namespace(ns1)
+		coll1Builder := ns1Builder.Collection(coll1)
+		coll1Builder.
+			OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "1m").
+			Delete(key1)
+
+		err = s.Persist(txID2, b.Build())
+		assert.Error(t, err)
+	})
+
+	t.Run("Expire data", func(t *testing.T) {
+		b := mocks.NewPvtReadWriteSetBuilder()
+		ns1Builder := b.Namespace(ns1)
+		coll1Builder := ns1Builder.Collection(coll1)
+		coll1Builder.
+			OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "10ms").
+			Write(key3, value3_1)
+
+		err = s.Persist(txID2, b.Build())
+		assert.NoError(t, err)
+
+		value, err := s.GetData(storeapi.NewKey(txID3, ns1, coll1, key3))
+		assert.NoError(t, err)
+		require.NotNil(t, value)
+		assert.Equal(t, value3_1, value.Value)
+
+		time.Sleep(200 * time.Millisecond)
+
+		value, err = s.GetData(storeapi.NewKey(txID3, ns1, coll1, key3))
+		assert.NoError(t, err)
+		assert.Nilf(t, value, "expecting key to have expired")
+	})
+}
+
+func TestStore_LoadFromDB(t *testing.T) {
+	getLocalMSPID = func() (string, error) { return org1MSP, nil }
+
+	dbProvider := olmocks.NewDBProvider().
+		WithValue(ns1, coll1, key1, &olstoreapi.Value{Value: value1_1})
+
+	collTypeConfig := map[cb.CollectionType]*collTypeConfig{cb.CollectionType_COL_OFFLEDGER: {}}
+	s := newStore(channelID, dbProvider, collTypeConfig)
+	require.NotNil(t, s)
+	defer s.Close()
+
+	t.Run("GetData -> success", func(t *testing.T) {
+		value, err := s.GetData(storeapi.NewKey(txID2, ns1, coll1, key1))
+		assert.NoError(t, err)
+		assert.Equal(t, value1_1, value.Value)
+	})
+}
+
+func TestStore_PersistError(t *testing.T) {
+	getLocalMSPID = func() (string, error) { return org1MSP, nil }
+
+	collTypeConfig := map[cb.CollectionType]*collTypeConfig{cb.CollectionType_COL_OFFLEDGER: {}}
+	s := newStore(channelID, olmocks.NewDBProvider(), collTypeConfig)
+	require.NotNil(t, s)
+
+	defer s.Close()
+
+	t.Run("Persist marshal error -> error", func(t *testing.T) {
+		b := mocks.NewPvtReadWriteSetBuilder()
+		b.Namespace(ns1).
+			Collection(coll1).
+			OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "1m").
+			Write(key1, value1_1).
+			WithMarshalError()
+
+		err := s.Persist(txID1, b.Build())
+		assert.Errorf(t, err, "expecting marshal error")
+	})
+
+	t.Run("Persist invalid duration -> error", func(t *testing.T) {
+		b := mocks.NewPvtReadWriteSetBuilder()
+		ns1Builder := b.Namespace(ns1)
+		coll1Builder := ns1Builder.Collection(coll1)
+		coll1Builder.
+			OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "xxxxx")
+
+		err := s.Persist(txID1, b.Build())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid duration")
+	})
+}
+
+func TestStore_PutData(t *testing.T) {
+	getLocalMSPID = func() (string, error) { return org1MSP, nil }
+
+	collTypeConfig := map[cb.CollectionType]*collTypeConfig{cb.CollectionType_COL_OFFLEDGER: {}}
+	s := newStore(channelID, olmocks.NewDBProvider(), collTypeConfig)
+	require.NotNil(t, s)
+
+	defer s.Close()
+
+	collConfig := &cb.StaticCollectionConfig{
+		Type: cb.CollectionType_COL_OFFLEDGER,
+		Name: coll1,
+	}
+
+	t.Run("Valid key -> success", func(t *testing.T) {
+		err := s.PutData(
+			collConfig,
+			&storeapi.Key{
+				EndorsedAtTxID: txID1,
+				Namespace:      ns1,
+				Collection:     coll1,
+				Key:            key1,
+			},
+			&storeapi.ExpiringValue{
+				Value: value1_1,
+			},
+		)
+		assert.NoError(t, err)
+
+		v, err := s.GetData(&storeapi.Key{EndorsedAtTxID: txID2, Namespace: ns1, Collection: coll1, Key: key1})
+		assert.NoError(t, err)
+		require.NotNil(t, v)
+		assert.Equal(t, value1_1, v.Value)
+	})
+
+	t.Run("Nil value -> error", func(t *testing.T) {
+		err := s.PutData(
+			collConfig,
+			&storeapi.Key{
+				EndorsedAtTxID: txID1,
+				Namespace:      ns1,
+				Collection:     coll1,
+			},
+			&storeapi.ExpiringValue{},
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("Already expired -> not added", func(t *testing.T) {
+		err := s.PutData(
+			collConfig,
+			&storeapi.Key{
+				EndorsedAtTxID: txID1,
+				Namespace:      ns1,
+				Collection:     coll1,
+				Key:            key3,
+			},
+			&storeapi.ExpiringValue{
+				Value:  value4_1,
+				Expiry: time.Now().Add(-1 * time.Second),
+			},
+		)
+		assert.NoError(t, err)
+
+		v, err := s.GetData(&storeapi.Key{EndorsedAtTxID: txID2, Namespace: ns1, Collection: coll1, Key: key3})
+		assert.NoError(t, err)
+		require.Nil(t, v)
+	})
+}
+
+func TestStore_DBError(t *testing.T) {
+	getLocalMSPID = func() (string, error) { return org1MSP, nil }
+
+	dbProvider := olmocks.NewDBProvider()
+	collTypeConfig := map[cb.CollectionType]*collTypeConfig{cb.CollectionType_COL_OFFLEDGER: {}}
+	s := newStore(channelID, dbProvider, collTypeConfig)
+	require.NotNil(t, s)
+
+	t.Run("GetData -> error", func(t *testing.T) {
+		key := storeapi.NewKey(txID1, ns1, coll1, key1)
+
+		expectedErr := fmt.Errorf("error getting DB")
+		dbProvider.WithError(expectedErr)
+		v, err := s.GetData(key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+		assert.Nil(t, v)
+
+		expectedErr = fmt.Errorf("error getting value")
+		dbProvider.WithError(nil).MockDB(ns1, coll1).WithError(expectedErr)
+		v, err = s.GetData(key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+		assert.Nil(t, v)
+	})
+
+	t.Run("GetDataMultipleKeys -> error", func(t *testing.T) {
+		key := storeapi.NewMultiKey(txID1, ns1, coll1, key1)
+
+		expectedErr := fmt.Errorf("error getting DB")
+		dbProvider.WithError(expectedErr)
+		v, err := s.GetDataMultipleKeys(key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+		assert.Nil(t, v)
+
+		expectedErr = fmt.Errorf("error getting value")
+		dbProvider.WithError(nil).MockDB(ns1, coll1).WithError(expectedErr)
+		v, err = s.GetDataMultipleKeys(key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+		assert.Nil(t, v)
+	})
+
+	t.Run("Persist -> error", func(t *testing.T) {
+		expectedErr := fmt.Errorf("error getting DB")
+		dbProvider.WithError(expectedErr)
+
+		b := mocks.NewPvtReadWriteSetBuilder()
+		b.Namespace(ns1).Collection(coll1).OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "1m")
+
+		err := s.Persist(txID1, b.Build())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+
+		expectedErr = fmt.Errorf("error putting value")
+		dbProvider.WithError(nil).MockDB(ns1, coll1).WithError(expectedErr)
+
+		err = s.Persist(txID1, b.Build())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+	})
+
+	t.Run("Persist -> error", func(t *testing.T) {
+		expectedErr := fmt.Errorf("error getting DB")
+		dbProvider.WithError(expectedErr)
+
+		collConfig := &cb.StaticCollectionConfig{
+			Type: cb.CollectionType_COL_OFFLEDGER,
+			Name: coll1,
+		}
+
+		key := &storeapi.Key{EndorsedAtTxID: txID1, Namespace: ns1, Collection: coll1}
+		value := &storeapi.ExpiringValue{Value: value1_1}
+
+		err := s.PutData(collConfig, key, value)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+
+		expectedErr = fmt.Errorf("error putting value")
+		dbProvider.WithError(nil).MockDB(ns1, coll1).WithError(expectedErr)
+
+		err = s.PutData(collConfig, key, value)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), expectedErr.Error())
+	})
+}
+
+func TestStore_PersistNotAuthorized(t *testing.T) {
+	getLocalMSPID = func() (string, error) { return org2MSP, nil }
+
+	collTypeConfig := map[cb.CollectionType]*collTypeConfig{cb.CollectionType_COL_OFFLEDGER: {}}
+	s := newStore(channelID, olmocks.NewDBProvider(), collTypeConfig)
+	require.NotNil(t, s)
+	defer s.Close()
+
+	b := mocks.NewPvtReadWriteSetBuilder()
+	ns1Builder := b.Namespace(ns1)
+	coll1Builder := ns1Builder.Collection(coll1)
+	coll1Builder.
+		OffLedgerConfig("OR('Org1MSP.member')", 1, 2, "1m").
+		Write(key1, value1_1)
+	coll2Builder := ns1Builder.Collection(coll2)
+	coll2Builder.
+		OffLedgerConfig("OR('Org1MSP.member','Org2MSP.member')", 1, 2, "").
+		Write(key2, value2_1)
+
+	err := s.Persist(txID1, b.Build())
+	assert.NoError(t, err)
+
+	// Key shouldn't have been persisted since org2 doesn't have access to collection1
+	value, err := s.GetData(storeapi.NewKey(txID2, ns1, coll1, key1))
+	assert.NoError(t, err)
+	assert.Nil(t, value)
+
+	// Key should have been persisted to collection2
+	value, err = s.GetData(storeapi.NewKey(txID2, ns1, coll2, key2))
+	assert.NoError(t, err)
+	require.NotNil(t, value)
+	assert.Equal(t, value2_1, value.Value)
+}

--- a/pkg/collections/offledger/storeprovider/olstoreprovider.go
+++ b/pkg/collections/offledger/storeprovider/olstoreprovider.go
@@ -1,0 +1,108 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storeprovider
+
+import (
+	"sync"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	"github.com/hyperledger/fabric/protos/common"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/couchdbstore"
+)
+
+// Option is a store provider option
+type Option func(p *StoreProvider)
+
+// CollOption is a collection option
+type CollOption func(c *collTypeConfig)
+
+// WithCollectionType adds a collection type to the set of collection types supported by the off-ledger store
+// along with any options
+func WithCollectionType(collType common.CollectionType, opts ...CollOption) Option {
+	return func(p *StoreProvider) {
+		c := &collTypeConfig{}
+		p.collConfigs[collType] = c
+
+		for _, opt := range opts {
+			opt(c)
+		}
+	}
+}
+
+// Decorator allows the key/value to be modified before being persisted
+type Decorator func(key *storeapi.Key, value *storeapi.ExpiringValue) (*storeapi.Key, *storeapi.ExpiringValue, error)
+
+// WithDecorator sets a decorator for a collection type allowing the key/value to be modified before being persisted
+func WithDecorator(decorator Decorator) CollOption {
+	return func(c *collTypeConfig) {
+		c.decorator = decorator
+	}
+}
+
+type collTypeConfig struct {
+	decorator Decorator
+}
+
+// New returns a store provider factory
+func New(opts ...Option) *StoreProvider {
+	p := &StoreProvider{
+		stores:      make(map[string]olapi.Store),
+		dbProvider:  getDBProvider(),
+		collConfigs: make(map[common.CollectionType]*collTypeConfig),
+	}
+
+	// OFF_LEDGER collection type supported by default
+	opts = append(opts, WithCollectionType(common.CollectionType_COL_OFFLEDGER))
+
+	// Apply options
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// StoreProvider is a store provider
+type StoreProvider struct {
+	stores map[string]olapi.Store
+	sync.RWMutex
+	dbProvider  api.DBProvider
+	collConfigs map[common.CollectionType]*collTypeConfig
+}
+
+// StoreForChannel returns the store for the given channel
+func (sp *StoreProvider) StoreForChannel(channelID string) olapi.Store {
+	sp.RLock()
+	defer sp.RUnlock()
+	return sp.stores[channelID]
+}
+
+// OpenStore opens the store for the given channel
+func (sp *StoreProvider) OpenStore(channelID string) (olapi.Store, error) {
+	sp.Lock()
+	defer sp.Unlock()
+
+	store, ok := sp.stores[channelID]
+	if !ok {
+		store = newStore(channelID, sp.dbProvider, sp.collConfigs)
+		sp.stores[channelID] = store
+	}
+	return store, nil
+}
+
+// Close shuts down all of the stores
+func (sp *StoreProvider) Close() {
+	for _, s := range sp.stores {
+		s.Close()
+	}
+}
+
+// getDBProvider returns the DB provider. This var may be overridden by unit tests
+var getDBProvider = func() api.DBProvider {
+	return couchdbstore.NewDBProvider()
+}

--- a/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
+++ b/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package storeprovider
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/extensions/testutil"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore(t *testing.T) {
+	channel1 := "channel1"
+	channel2 := "channel2"
+
+	f := New()
+	require.NotNil(t, f)
+
+	s1, err := f.OpenStore(channel1)
+	require.NotNil(t, s1)
+	assert.NoError(t, err)
+	assert.Equal(t, "*storeprovider.store", reflect.TypeOf(s1).String())
+	assert.Equal(t, s1, f.StoreForChannel(channel1))
+
+	s2, err := f.OpenStore(channel2)
+	require.NotNil(t, s2)
+	assert.NoError(t, err)
+	assert.NotEqual(t, s1, s2)
+	assert.Equal(t, s2, f.StoreForChannel(channel2))
+
+	assert.NotPanics(t, func() {
+		f.Close()
+	})
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(testMain(m))
+}
+
+func testMain(m *testing.M) int {
+	_, _, stop := testutil.SetupExtTestEnv()
+
+	//set the logging level to DEBUG to test debug only code
+	flogging.ActivateSpec("couchdb=debug")
+
+	viper.Set("coll.offledger.cleanupExpired.Interval", "500ms")
+
+	//run the tests
+	code := m.Run()
+
+	//stop couchdb
+	stop()
+
+	return code
+}

--- a/pkg/collections/pvtdatastore/pvtdatastore_test.go
+++ b/pkg/collections/pvtdatastore/pvtdatastore_test.go
@@ -9,13 +9,12 @@ package pvtdatastore
 import (
 	"testing"
 
-	"github.com/hyperledger/fabric/extensions/mocks"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	extmocks "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
 const (
@@ -40,7 +39,7 @@ func TestStore_StorePvtData(t *testing.T) {
 		c := New(channelID, tStore, collStore)
 		require.NotNil(t, c)
 
-		b := extmocks.NewPvtReadWriteSetBuilder()
+		b := mocks.NewPvtReadWriteSetBuilder()
 		b.Namespace(ns1).Collection(coll1).StaticConfig(policy1, 2, 5, 1000)
 		pvtData := b.Build()
 
@@ -56,7 +55,7 @@ func TestStore_StorePvtData(t *testing.T) {
 		c := New(channelID, tStore, collStore)
 		require.NotNil(t, c)
 
-		b := extmocks.NewPvtReadWriteSetBuilder()
+		b := mocks.NewPvtReadWriteSetBuilder()
 		b.Namespace(ns1).Collection(coll2).DCASConfig(policy1, 2, 5, "10m")
 		pvtData := b.Build()
 
@@ -71,7 +70,7 @@ func TestStore_StorePvtData(t *testing.T) {
 		c := New(channelID, tStore, collStore)
 		require.NotNil(t, c)
 
-		b := extmocks.NewPvtReadWriteSetBuilder()
+		b := mocks.NewPvtReadWriteSetBuilder()
 		nsb := b.Namespace(ns1)
 		nsb.Collection(coll1).StaticConfig(policy1, 2, 5, 1000)
 		nsb.Collection(coll2).TransientConfig(policy1, 2, 5, "10m")
@@ -101,7 +100,7 @@ func TestStore_StorePvtData_error(t *testing.T) {
 		c := New(channelID, tStore, collStore)
 		require.NotNil(t, c)
 
-		b := extmocks.NewPvtReadWriteSetBuilder()
+		b := mocks.NewPvtReadWriteSetBuilder()
 		b.Namespace(ns1).Collection(coll1).StaticConfig(policy1, 2, 5, 1000).WithMarshalError()
 		pvtData := b.Build()
 
@@ -118,7 +117,7 @@ func TestStore_StorePvtData_error(t *testing.T) {
 		c := New(channelID, tStore, collStore)
 		require.NotNil(t, c)
 
-		b := extmocks.NewPvtReadWriteSetBuilder()
+		b := mocks.NewPvtReadWriteSetBuilder()
 		b.Namespace(ns1).Collection(coll1).StaticConfig(policy1, 2, 5, 1000)
 		pvtData := b.Build()
 

--- a/pkg/collections/storeprovider/mocks/mockolstore.go
+++ b/pkg/collections/storeprovider/mocks/mockolstore.go
@@ -1,0 +1,129 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	cb "github.com/hyperledger/fabric/protos/common"
+	proto "github.com/hyperledger/fabric/protos/transientstore"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+)
+
+// StoreProvider implements a mock transient data store provider
+type StoreProvider struct {
+	store *Store
+	err   error
+}
+
+// NewOffLedgerStoreProvider returns a new  provider
+func NewOffLedgerStoreProvider() *StoreProvider {
+	return &StoreProvider{
+		store: NewStore(),
+	}
+}
+
+// Data invokes the Data of the store for the given key and value
+func (p *StoreProvider) Data(key *storeapi.Key, value *storeapi.ExpiringValue) *StoreProvider {
+	p.store.Data(key, value)
+	return p
+}
+
+// Error stores the error
+func (p *StoreProvider) Error(err error) *StoreProvider {
+	p.err = err
+	return p
+}
+
+// StoreError stores the storeError
+func (p *StoreProvider) StoreError(err error) *StoreProvider {
+	p.store.Error(err)
+	return p
+}
+
+// StoreForChannel returns the transient data store for the given channel
+func (p *StoreProvider) StoreForChannel(channelID string) olapi.Store {
+	return p.store
+}
+
+// OpenStore opens the transient data store for the given channel
+func (p *StoreProvider) OpenStore(channelID string) (olapi.Store, error) {
+	return p.store, p.err
+}
+
+// Close closes the  store for the given channel
+func (p *StoreProvider) Close() {
+	p.store.Close()
+}
+
+// IsStoreClosed indicates whether the  store is closed
+func (p *StoreProvider) IsStoreClosed() bool {
+	return p.store.closed
+}
+
+// Store implements a mock store
+type Store struct {
+	data   map[storeapi.Key]*storeapi.ExpiringValue
+	err    error
+	closed bool
+}
+
+// NewStore returns a mock transient data store
+func NewStore() *Store {
+	return &Store{
+		data: make(map[storeapi.Key]*storeapi.ExpiringValue),
+	}
+}
+
+// Data sets the data for the given key
+func (m *Store) Data(key *storeapi.Key, value *storeapi.ExpiringValue) *Store {
+	m.data[storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: key.Key}] = value
+	return m
+}
+
+// Error sets an err
+func (m *Store) Error(err error) *Store {
+	m.err = err
+	return m
+}
+
+// Persist stores the private write set of a transaction along with the collection config
+// in the transient store based on txid and the block height the private data was received at
+func (m *Store) Persist(txid string, privateSimulationResultsWithConfig *proto.TxPvtReadWriteSetWithConfigInfo) error {
+	return m.err
+}
+
+// PutData stores the key/value
+func (m *Store) PutData(config *cb.StaticCollectionConfig, key *storeapi.Key, value *storeapi.ExpiringValue) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.data[storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: key.Key}] = value
+	return nil
+}
+
+// GetData gets the value for the given item
+func (m *Store) GetData(key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return m.data[storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: key.Key}], m.err
+}
+
+// GetDataMultipleKeys gets the values for the multiple items in a single call
+func (m *Store) GetDataMultipleKeys(key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	var values storeapi.ExpiringValues
+	for _, k := range key.Keys {
+		value, err := m.GetData(&storeapi.Key{Namespace: key.Namespace, Collection: key.Collection, Key: k})
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, m.err
+}
+
+// Close closes the store
+func (m *Store) Close() {
+	m.closed = true
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ const (
 	confOLCollLeveldb              = "offLedgerLeveldb"
 	confOLCollCleanupIntervalTime  = "coll.offledger.cleanupExpired.Interval"
 	confOLCollMaxPeersForRetrieval = "coll.offledger.maxpeers"
+	confOLCollCacheSize            = "coll.offledger.cacheSize"
 
 	confBlockPublisherBufferSize = "blockpublisher.buffersize"
 
@@ -35,6 +36,7 @@ const (
 
 	defaultOLCollCleanupIntervalTime  = 5 * time.Second
 	defaultOLCollMaxPeersForRetrieval = 2
+	defaultOLCollCacheSize            = 10000
 
 	defaultBlockPublisherBufferSize = 100
 )
@@ -116,4 +118,13 @@ func GetOLCollMaxPeersForRetrieval() int {
 		maxPeers = defaultOLCollMaxPeersForRetrieval
 	}
 	return maxPeers
+}
+
+// GetOLCollCacheSize returns the size of the off-ledger cache
+func GetOLCollCacheSize() int {
+	size := viper.GetInt(confOLCollCacheSize)
+	if size <= 0 {
+		return defaultOLCollCacheSize
+	}
+	return size
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,6 +87,17 @@ func TestGetOLCollExpiredIntervalTime(t *testing.T) {
 	assert.Equal(t, 111*time.Second, GetOLCollExpirationCheckInterval())
 }
 
+func TestGetOLCacheSize(t *testing.T) {
+	oldVal := viper.Get(confOLCollCacheSize)
+	defer viper.Set(confOLCollCacheSize, oldVal)
+
+	viper.Set(confOLCollCacheSize, 0)
+	assert.Equal(t, defaultOLCollCacheSize, GetOLCollCacheSize())
+
+	viper.Set(confOLCollCacheSize, 10)
+	assert.Equal(t, 10, GetOLCollCacheSize())
+}
+
 func TestGetTransientDataPullTimeout(t *testing.T) {
 	oldVal := viper.Get(confTransientDataPullTimeout)
 	defer viper.Set(confTransientDataPullTimeout, oldVal)

--- a/pkg/endorser/endorser.go
+++ b/pkg/endorser/endorser.go
@@ -106,5 +106,6 @@ func (f *collRWSetFilter) isOffLedger(ns, coll string) (bool, error) {
 }
 
 func isCollOffLedger(collConfig *common.StaticCollectionConfig) bool {
-	return collConfig.Type == common.CollectionType_COL_TRANSIENT
+	return collConfig.Type == common.CollectionType_COL_TRANSIENT ||
+		collConfig.Type == common.CollectionType_COL_OFFLEDGER
 }

--- a/pkg/endorser/endorser_test.go
+++ b/pkg/endorser/endorser_test.go
@@ -31,7 +31,7 @@ func TestFilterPubSimulationResults(t *testing.T) {
 	pvtNSBuilder1.Collection(coll1).StaticConfig("OR('Org1.member','Org2.member')", 2, 3, 100)
 	pvtNSBuilder1.Collection(coll2).TransientConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
 	pvtNSBuilder3 := pvtBuilder.Namespace(ns3)
-	pvtNSBuilder3.Collection(coll2).TransientConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
+	pvtNSBuilder3.Collection(coll2).OffLedgerConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
 
 	builder := mocks.NewReadWriteSetBuilder()
 	nsBuilder1 := builder.Namespace(ns1)

--- a/pkg/mocks/mockrwsetbuilder.go
+++ b/pkg/mocks/mockrwsetbuilder.go
@@ -265,6 +265,16 @@ func (c *CollectionBuilder) StaticConfig(policy string, requiredPeerCount, maxim
 	return c
 }
 
+// OffLedgerConfig sets the off-ledger collection config
+func (c *CollectionBuilder) OffLedgerConfig(policy string, requiredPeerCount, maximumPeerCount int32, ttl string) *CollectionBuilder {
+	c.policy = policy
+	c.requiredPeerCount = requiredPeerCount
+	c.maximumPeerCount = maximumPeerCount
+	c.collType = common.CollectionType_COL_OFFLEDGER
+	c.ttl = ttl
+	return c
+}
+
 // DCASConfig sets the DCAS collection config
 func (c *CollectionBuilder) DCASConfig(policy string, requiredPeerCount, maximumPeerCount int32, ttl string) *CollectionBuilder {
 	c.policy = policy


### PR DESCRIPTION
During endorsement, traverse the read-write sets and store off-ledger data
to the database and cache.

closes #60

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>