### PR TITLE
feat: Retrieve Off-Ledger data

### DIFF
--- a/mod/peer/collections/api/store/provider.go
+++ b/mod/peer/collections/api/store/provider.go
@@ -55,6 +55,12 @@ type Retriever interface {
 
 	// GetTransientDataMultipleKeys gets the values for the multiple transient data items in a single call
 	GetTransientDataMultipleKeys(ctxt context.Context, key *MultiKey) (ExpiringValues, error)
+
+	// GetData gets the value for the given data item
+	GetData(ctxt context.Context, key *Key) (*ExpiringValue, error)
+
+	// GetDataMultipleKeys gets the values for the multiple data items in a single call
+	GetDataMultipleKeys(ctxt context.Context, key *MultiKey) (ExpiringValues, error)
 }
 
 // Provider provides private data retrievers

--- a/mod/peer/collections/retriever/retriever_test.go
+++ b/mod/peer/collections/retriever/retriever_test.go
@@ -11,6 +11,8 @@ import (
 
 	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
 	"github.com/stretchr/testify/require"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+	olmocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/mocks"
 	extretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/retriever"
 	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
 	tdatamocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/mocks"
@@ -19,6 +21,10 @@ import (
 func TestNewProvider(t *testing.T) {
 	extretriever.SetTransientDataProvider(func(storeProvider func(channelID string) tdataapi.Store, support extretriever.Support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider {
 		return &tdatamocks.TransientDataProvider{}
+	})
+
+	extretriever.SetOffLedgerProvider(func(storeProvider func(channelID string) olapi.Store, support extretriever.Support, gossipProvider func() supportapi.GossipAdapter) olapi.Provider {
+		return &olmocks.Provider{}
 	})
 
 	p := NewProvider(nil, nil, nil, nil)

--- a/mod/peer/mocks/mockprovider.go
+++ b/mod/peer/mocks/mockprovider.go
@@ -37,3 +37,17 @@ func (m *dataRetriever) GetTransientDataMultipleKeys(ctxt context.Context, key *
 	}
 	return values, nil
 }
+
+// GetData returns the data for the given context and key
+func (m *dataRetriever) GetData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+}
+
+// GetDataMultipleKeys returns the  data with multiple keys for the given context and key
+func (m *dataRetriever) GetDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	values := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+	}
+	return values, nil
+}

--- a/pkg/collections/offledger/api/offledger.go
+++ b/pkg/collections/offledger/api/offledger.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
+	"context"
+
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	cb "github.com/hyperledger/fabric/protos/common"
 	proto "github.com/hyperledger/fabric/protos/transientstore"
@@ -37,4 +39,18 @@ type StoreProvider interface {
 
 	// Close cleans up the provider
 	Close()
+}
+
+// Retriever retrieves data
+type Retriever interface {
+	// GetData gets the value for the given data item
+	GetData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error)
+
+	// GetDataMultipleKeys gets the values for the multiple data items in a single call
+	GetDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error)
+}
+
+// Provider provides data retrievers
+type Provider interface {
+	RetrieverForChannel(channel string) Retriever
 }

--- a/pkg/collections/offledger/dissemination/disseminator.go
+++ b/pkg/collections/offledger/dissemination/disseminator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
 )
 
-var logger = flogging.MustGetLogger("offledgerstore")
+var logger = flogging.MustGetLogger("ext_offledger")
 
 // Disseminator disseminates collection data to other endorsers
 type Disseminator struct {

--- a/pkg/collections/offledger/mocks/mockprovider.go
+++ b/pkg/collections/offledger/mocks/mockprovider.go
@@ -1,0 +1,40 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"context"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+)
+
+// Provider is a mock off-ledger data data provider
+type Provider struct {
+}
+
+// RetrieverForChannel returns the retriever for the given channel
+func (p *Provider) RetrieverForChannel(channel string) olapi.Retriever {
+	return &retriever{}
+}
+
+type retriever struct {
+}
+
+// GetData gets data for the given key
+func (m *retriever) GetData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+}
+
+// GetDataMultipleKeys gets data for multiple keys
+func (m *retriever) GetDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	values := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+	}
+	return values, nil
+}

--- a/pkg/collections/offledger/retriever/olprovider.go
+++ b/pkg/collections/offledger/retriever/olprovider.go
@@ -1,0 +1,368 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package retriever
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/privdata"
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	"github.com/hyperledger/fabric/gossip/comm"
+	mspmgmt "github.com/hyperledger/fabric/msp/mgmt"
+	cb "github.com/hyperledger/fabric/protos/common"
+	gproto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/pkg/errors"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dissemination"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/multirequest"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/requestmgr"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+var logger = flogging.MustGetLogger("ext_offledger")
+
+type support interface {
+	Config(channelID, ns, coll string) (*cb.StaticCollectionConfig, error)
+	Policy(channel, ns, collection string) (privdata.CollectionAccessPolicy, error)
+	BlockPublisher(channelID string) gossipapi.BlockPublisher
+}
+
+// Validator is a key/value validator
+type Validator func(txID, ns, coll, key string, value []byte) error
+
+// Provider is a collection data data provider.
+type Provider struct {
+	support
+	storeForChannel func(channelID string) olapi.Store
+	gossipAdapter   func() supportapi.GossipAdapter
+}
+
+// NewProvider returns a new collection data provider
+func NewProvider(storeProvider func(channelID string) olapi.Store, support support, gossipProvider func() supportapi.GossipAdapter) olapi.Provider {
+	return &Provider{
+		support:         support,
+		storeForChannel: storeProvider,
+		gossipAdapter:   gossipProvider,
+	}
+}
+
+// RetrieverForChannel returns the collection data retriever for the given channel
+func (p *Provider) RetrieverForChannel(channelID string) olapi.Retriever {
+	return &retriever{
+		support:       p.support,
+		gossipAdapter: p.gossipAdapter(),
+		store:         p.storeForChannel(channelID),
+		channelID:     channelID,
+		reqMgr:        requestmgr.Get(channelID),
+		resolvers:     make(map[collKey]resolver),
+	}
+}
+
+type resolver interface {
+	// ResolvePeersForRetrieval resolves to a set of peers from which data should be retrieved
+	ResolvePeersForRetrieval() discovery.PeerGroup
+}
+
+type collKey struct {
+	ns   string
+	coll string
+}
+
+func newCollKey(ns, coll string) collKey {
+	return collKey{ns: ns, coll: coll}
+}
+
+type retriever struct {
+	support
+	gossipAdapter supportapi.GossipAdapter
+	channelID     string
+	store         olapi.Store
+	resolvers     map[collKey]resolver
+	lock          sync.RWMutex
+	reqMgr        requestmgr.RequestMgr
+}
+
+// GetData gets the values for the data item
+func (r *retriever) GetData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
+	values, err := r.GetDataMultipleKeys(ctxt, storeapi.NewMultiKey(key.EndorsedAtTxID, key.Namespace, key.Collection, key.Key))
+	if err != nil {
+		return nil, err
+	}
+
+	if values.Values().IsEmpty() {
+		return nil, nil
+	}
+
+	return values[0], nil
+}
+
+// GetDataMultipleKeys gets the values for the multiple data items in a single call
+func (r *retriever) GetDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	authorized, err := r.isAuthorized(key.Namespace, key.Collection)
+	if err != nil {
+		return nil, err
+	}
+	if !authorized {
+		logger.Infof("[%s] This peer does not have access to the collection [%s:%s]", r.channelID, key.Namespace, key.Collection)
+		return nil, nil
+	}
+
+	localValues, err := r.getMultipleKeysFromLocal(key)
+	if err != nil {
+		return nil, err
+	}
+	if localValues.Values().AllSet() {
+		return localValues, nil
+	}
+
+	res, err := r.getResolver(key.Namespace, key.Collection)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unable to get resolver for channel [%s] and [%s:%s]", r.channelID, key.Namespace, key.Collection)
+	}
+
+	// Retrieve from the remote peers
+	cReq := multirequest.New()
+	for _, peer := range res.ResolvePeersForRetrieval() {
+		logger.Debugf("Adding request to get data for [%s] from [%s] ...", key, peer)
+		cReq.Add(peer.String(), r.getDataFromPeer(key, peer))
+	}
+
+	response := cReq.Execute(ctxt)
+
+	// Merge the values with the values received locally
+	values := asExpiringValues(localValues.Values().Merge(response.Values))
+	if roles.IsCommitter() {
+		r.persistMissingKeys(key, localValues, values)
+	}
+
+	return values, nil
+}
+
+func (r *retriever) getMultipleKeysFromLocal(key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	localValues := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		value, retrieveErr := r.store.GetData(storeapi.NewKey(key.EndorsedAtTxID, key.Namespace, key.Collection, k))
+		if retrieveErr != nil {
+			logger.Warningf("[%s] Error getting data from local store for [%s]: %s", r.channelID, key, retrieveErr)
+			return nil, errors.WithMessagef(retrieveErr, "unable to get data for channel [%s] and [%s]", r.channelID, key)
+		}
+		localValues[i] = value
+	}
+	return localValues, nil
+}
+
+func getMissingKeyIndexes(values []*storeapi.ExpiringValue) []int {
+	var missingIndexes []int
+	for i, v := range values {
+		if v == nil {
+			missingIndexes = append(missingIndexes, i)
+		}
+	}
+	return missingIndexes
+}
+
+// persistMissingKeys persists the keys that were missing from the local store
+func (r *retriever) persistMissingKeys(key *storeapi.MultiKey, localValues, values storeapi.ExpiringValues) {
+	for _, i := range getMissingKeyIndexes(localValues) {
+		v := values[i]
+		if v != nil {
+			r.persistMissingKey(
+				storeapi.NewKey(key.EndorsedAtTxID, key.Namespace, key.Collection, key.Keys[i]),
+				&storeapi.ExpiringValue{Value: v.Value, Expiry: v.Expiry},
+			)
+		}
+	}
+}
+
+func (r *retriever) persistMissingKey(k *storeapi.Key, val *storeapi.ExpiringValue) {
+	logger.Debugf("Persisting key [%s] that was missing from the local store", k)
+	collConfig, err := r.Config(r.channelID, k.Namespace, k.Collection)
+	if err != nil {
+		logger.Warningf("Error persisting key [%s] that was missing from the local store: %s", k, err)
+	}
+	if err := r.store.PutData(collConfig, k, val); err != nil {
+		logger.Warningf("Error persisting key [%s] that was missing from the local store: %s", k, err)
+	}
+}
+
+func (r *retriever) getDataFromPeer(key *storeapi.MultiKey, endorser *discovery.Member) multirequest.Request {
+	return func(ctxt context.Context) (common.Values, error) {
+		logger.Debugf("Getting data for [%s] from [%s] ...", key, endorser)
+
+		values, err := r.getData(ctxt, key, endorser)
+		if err != nil {
+			if err == context.Canceled {
+				logger.Debugf("[%s] Request to get data from [%s] for [%s] was cancelled", r.channelID, endorser, key)
+			} else {
+				logger.Debugf("[%s] Error getting data from [%s] for [%s]: %s", r.channelID, endorser, key, err)
+			}
+			return nil, err
+		}
+
+		return values.Values(), nil
+	}
+}
+
+func (r *retriever) getResolver(ns, coll string) (resolver, error) {
+	key := newCollKey(ns, coll)
+
+	r.lock.RLock()
+	resolver, ok := r.resolvers[key]
+	r.lock.RUnlock()
+
+	if ok {
+		return resolver, nil
+	}
+
+	return r.getOrCreateResolver(key)
+}
+
+func (r *retriever) getOrCreateResolver(key collKey) (resolver, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	resolver, ok := r.resolvers[key]
+	if ok {
+		return resolver, nil
+	}
+
+	policy, err := r.Policy(r.channelID, key.ns, key.coll)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver = dissemination.New(r.channelID, key.ns, key.coll, policy, r.gossipAdapter)
+
+	r.resolvers[key] = resolver
+
+	return resolver, nil
+}
+
+func (r *retriever) removeResolvers(ns string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for key := range r.resolvers {
+		if key.ns == ns {
+			logger.Debugf("[%s] Removing resolver [%s:%s] from cache", r.channelID, key.ns, key.coll)
+			delete(r.resolvers, key)
+		}
+	}
+}
+
+func (r *retriever) getData(ctxt context.Context, key *storeapi.MultiKey, peers ...*discovery.Member) (storeapi.ExpiringValues, error) {
+	logger.Debugf("[%s] Sending Gossip request to %s for data for [%s]", r.channelID, peers, key)
+
+	req := r.reqMgr.NewRequest()
+
+	logger.Debugf("[%s] Creating Gossip request %d for data for [%s]", r.channelID, req.ID(), key)
+	msg := r.createCollDataRequestMsg(req, key)
+
+	logger.Debugf("[%s] Sending Gossip request %d for data for [%s]", r.channelID, req.ID(), key)
+	r.gossipAdapter.Send(msg, asRemotePeers(peers)...)
+
+	logger.Debugf("[%s] Waiting for response for %d for data for [%s]", r.channelID, req.ID(), key)
+	res, err := req.GetResponse(ctxt)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("[%s] Got response for %d for data for [%s]", r.channelID, req.ID(), key)
+
+	data := make(storeapi.ExpiringValues, len(key.Keys))
+	for i, k := range key.Keys {
+		d, ok := res.Data.Get(key.Namespace, key.Collection, k)
+		if !ok {
+			return nil, errors.Errorf("the response does not contain a value for key [%s:%s:%s]", key.Namespace, key.Collection, k)
+		}
+		if d.Value == nil {
+			data[i] = nil
+		} else {
+			data[i] = &storeapi.ExpiringValue{Value: d.Value, Expiry: d.Expiry}
+		}
+	}
+
+	return data, nil
+}
+
+// isAuthorized returns true if the local peer has access to the given collection
+func (r *retriever) isAuthorized(ns, coll string) (bool, error) {
+	policy, err := r.Policy(r.channelID, ns, coll)
+	if err != nil {
+		return false, errors.WithMessagef(err, "unable to get policy for [%s:%s]", ns, coll)
+	}
+
+	localMSPID, err := getLocalMSPID()
+	if err != nil {
+		return false, errors.WithMessagef(err, "unable to get local MSP ID")
+	}
+
+	for _, mspID := range policy.MemberOrgs() {
+		if mspID == localMSPID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *retriever) createCollDataRequestMsg(req requestmgr.Request, key *storeapi.MultiKey) *gproto.GossipMessage {
+	var digests []*gproto.CollDataDigest
+	for _, k := range key.Keys {
+		digests = append(digests, &gproto.CollDataDigest{
+			Namespace:      key.Namespace,
+			Collection:     key.Collection,
+			Key:            k,
+			EndorsedAtTxID: key.EndorsedAtTxID,
+		})
+	}
+
+	return &gproto.GossipMessage{
+		Tag:     gproto.GossipMessage_CHAN_ONLY,
+		Channel: []byte(r.channelID),
+		Content: &gproto.GossipMessage_CollDataReq{
+			CollDataReq: &gproto.RemoteCollDataRequest{
+				Nonce:   req.ID(),
+				Digests: digests,
+			},
+		},
+	}
+}
+
+func asRemotePeers(members []*discovery.Member) []*comm.RemotePeer {
+	var peers []*comm.RemotePeer
+	for _, m := range members {
+		peers = append(peers, &comm.RemotePeer{
+			Endpoint: m.Endpoint,
+			PKIID:    m.PKIid,
+		})
+	}
+	return peers
+}
+
+// getLocalMSPID returns the MSP ID of the local peer. This variable may be overridden by unit tests.
+var getLocalMSPID = func() (string, error) {
+	return mspmgmt.GetLocalMSP().GetIdentifier()
+}
+
+func asExpiringValues(cv common.Values) storeapi.ExpiringValues {
+	vals := make(storeapi.ExpiringValues, len(cv))
+	for i, v := range cv {
+		if common.IsNil(v) {
+			vals[i] = nil
+		} else {
+			vals[i] = v.(*storeapi.ExpiringValue)
+		}
+	}
+	return vals
+}

--- a/pkg/collections/offledger/retriever/olprovider_test.go
+++ b/pkg/collections/offledger/retriever/olprovider_test.go
@@ -1,0 +1,359 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package retriever
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	gcommon "github.com/hyperledger/fabric/gossip/common"
+	cb "github.com/hyperledger/fabric/protos/common"
+	gproto "github.com/hyperledger/fabric/protos/gossip"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+	spmocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/storeprovider/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/requestmgr"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	ledgerconfig "github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+const (
+	channelID = "testchannel"
+	ns1       = "chaincode1"
+	coll1     = "collection1"
+
+	org1MSPID = "Org1MSP"
+	org2MSPID = "Org2MSP"
+	org3MSPID = "Org3MSP"
+
+	p1Org1Endpoint = "p1.org1.com"
+	p2Org1Endpoint = "p2.org1.com"
+	p3Org1Endpoint = "p3.org1.com"
+	p1Org2Endpoint = "p1.org2.com"
+	p2Org2Endpoint = "p2.org2.com"
+	p3Org2Endpoint = "p3.org2.com"
+	p1Org3Endpoint = "p1.org3.com"
+	p2Org3Endpoint = "p2.org3.com"
+	p3Org3Endpoint = "p3.org3.com"
+
+	key1 = "key1"
+	key2 = "key2"
+	key3 = "key3"
+	key4 = "key4"
+)
+
+var (
+	p1Org1PKIID = gcommon.PKIidType("pkiid_P1O1")
+	p2Org1PKIID = gcommon.PKIidType("pkiid_P2O1")
+	p3Org1PKIID = gcommon.PKIidType("pkiid_P3O1")
+
+	p1Org2PKIID = gcommon.PKIidType("pkiid_P1O2")
+	p2Org2PKIID = gcommon.PKIidType("pkiid_P2O2")
+	p3Org2PKIID = gcommon.PKIidType("pkiid_P3O2")
+
+	p1Org3PKIID = gcommon.PKIidType("pkiid_P1O3")
+	p2Org3PKIID = gcommon.PKIidType("pkiid_P2O3")
+	p3Org3PKIID = gcommon.PKIidType("pkiid_P3O3")
+
+	committerRole = string(ledgerconfig.CommitterRole)
+	endorserRole  = string(ledgerconfig.EndorserRole)
+
+	respTimeout = 100 * time.Millisecond
+
+	value1 = &storeapi.ExpiringValue{Value: []byte("value1")}
+	value2 = &storeapi.ExpiringValue{Value: []byte("value2")}
+	value3 = &storeapi.ExpiringValue{Value: []byte("value3")}
+	value4 = &storeapi.ExpiringValue{Value: []byte("value4")}
+
+	txID = "tx1"
+)
+
+func TestProvider(t *testing.T) {
+	support := mocks.NewMockSupport().
+		CollectionPolicy(&mocks.MockAccessPolicy{
+			MaxPeerCount: 2,
+			Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+		}).
+		CollectionConfig(&cb.StaticCollectionConfig{
+			Type: cb.CollectionType_COL_OFFLEDGER,
+			Name: coll1,
+		})
+
+	getLocalMSPID = func() (string, error) { return org1MSPID, nil }
+
+	gossip := mocks.NewMockGossipAdapter()
+	gossip.Self(org1MSPID, mocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+		Member(org1MSPID, mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, committerRole)).
+		Member(org1MSPID, mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, committerRole)).
+		Member(org2MSPID, mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)).
+		Member(org2MSPID, mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, committerRole)).
+		Member(org2MSPID, mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p1Org3Endpoint, p1Org3PKIID, endorserRole)).
+		Member(org3MSPID, mocks.NewMember(p2Org3Endpoint, p2Org3PKIID, committerRole)).
+		Member(org3MSPID, mocks.NewMember(p3Org3Endpoint, p3Org3PKIID, endorserRole))
+
+	localStore := spmocks.NewStore().
+		Data(storeapi.NewKey(txID, ns1, coll1, key1), value1)
+
+	storeProvider := func(channelID string) olapi.Store { return localStore }
+	gossipProvider := func() supportapi.GossipAdapter { return gossip }
+
+	p := NewProvider(storeProvider, support, gossipProvider)
+
+	retriever := p.RetrieverForChannel(channelID)
+	require.NotNil(t, retriever)
+
+	t.Run("GetData - From local peer", func(t *testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key1))
+		require.NoError(t, err)
+		require.NotNil(t, value)
+		require.Equal(t, value1, value)
+	})
+
+	t.Run("GetData - From remote peer", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key2, value2).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key2))
+		require.NoError(t, err)
+		require.NotNil(t, value)
+		require.Equal(t, value2, value)
+	})
+
+	t.Run("GetData - No response from remote peer", func(t *testing.T) {
+		gossip.MessageHandler(func(msg *gproto.GossipMessage) {})
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key4))
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetData - Cancel request from remote peer", func(t *testing.T) {
+		gossip.MessageHandler(func(msg *gproto.GossipMessage) {})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		value, err := retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key4))
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetDataMultipleKeys -> success", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key2, value2).
+				Value(key3, value3).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, key1, key2, key3))
+		require.NoError(t, err)
+		require.Equal(t, 3, len(values))
+		assert.Equal(t, value1, values[0])
+		assert.Equal(t, value2, values[1])
+		assert.Equal(t, value3, values[2])
+	})
+
+	t.Run("GetDataMultipleKeys - Key not found -> success", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key1, value1).
+				Value(key2, value2).
+				Value(key3, value3).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, "xxx", key2, key3))
+		require.NoError(t, err)
+		require.Equal(t, 3, len(values))
+		assert.Nil(t, values[0])
+		assert.Equal(t, value2, values[1])
+		assert.Equal(t, value3, values[2])
+	})
+
+	t.Run("GetDataMultipleKeys - Timeout -> fail", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key1, value1).
+				Value(key2, value2).
+				Value(key3, value3).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), time.Microsecond)
+		values, err := retriever.GetDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, key1, key2, key3))
+		assert.NoError(t, err)
+		assert.Empty(t, values.Values().IsEmpty())
+	})
+
+	t.Run("GetDataMultipleKeys with store provider error -> fail", func(t *testing.T) {
+		expectedErr := errors.New("store provider error")
+		localStore.Error(expectedErr)
+		defer localStore.Error(nil)
+
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key2, value2).
+				Value(key3, value3).
+				Handle)
+
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, key1, key2, key3))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), expectedErr.Error())
+		require.Nil(t, values)
+	})
+
+	t.Run("Persist Missing -> success", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).Handle)
+
+		// Should not exist in local store
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key4))
+		require.NoError(t, err)
+		require.Nil(t, value)
+
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key4, value4).
+				Handle)
+
+		// Should retrieve from other peer and then persist to local store
+		value, err = retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key4))
+		require.NoError(t, err)
+		require.NotNil(t, value)
+
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).Handle)
+
+		// Should retrieve from local store
+		value, err = retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key4))
+		require.NoError(t, err)
+		require.NotNil(t, value)
+	})
+}
+
+func TestProvider_AccessDenied(t *testing.T) {
+	support := mocks.NewMockSupport().
+		CollectionPolicy(&mocks.MockAccessPolicy{
+			MaxPeerCount: 2,
+			Orgs:         []string{org1MSPID, org2MSPID},
+		})
+
+	getLocalMSPID = func() (string, error) { return org3MSPID, nil }
+
+	gossip := mocks.NewMockGossipAdapter()
+	gossip.Self(org3MSPID, mocks.NewMember(p1Org3Endpoint, p1Org3PKIID)).
+		Member(org1MSPID, mocks.NewMember(p2Org1Endpoint, p2Org1PKIID, committerRole)).
+		Member(org1MSPID, mocks.NewMember(p3Org1Endpoint, p3Org1PKIID, committerRole)).
+		Member(org2MSPID, mocks.NewMember(p1Org2Endpoint, p1Org2PKIID, endorserRole)).
+		Member(org2MSPID, mocks.NewMember(p2Org2Endpoint, p2Org2PKIID, committerRole)).
+		Member(org2MSPID, mocks.NewMember(p3Org2Endpoint, p3Org2PKIID, endorserRole))
+
+	localStore := spmocks.NewStore().
+		Data(storeapi.NewKey(txID, ns1, coll1, key1), value1)
+
+	storeProvider := func(channelID string) olapi.Store { return localStore }
+	gossipProvider := func() supportapi.GossipAdapter { return gossip }
+
+	p := NewProvider(storeProvider, support, gossipProvider)
+
+	retriever := p.RetrieverForChannel(channelID)
+	require.NotNil(t, retriever)
+
+	gossip.MessageHandler(
+		newMockGossipMsgHandler(channelID).
+			Value(key2, value2).
+			Handle)
+
+	t.Run("GetData - From remote peer -> nil", func(t *testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key2))
+		assert.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("GetDataMultipleKeys - From remote peer -> nil", func(t *testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		values, err := retriever.GetDataMultipleKeys(ctx, storeapi.NewMultiKey(txID, ns1, coll1, "xxx", key2, key3))
+		assert.NoError(t, err)
+		assert.Nil(t, values)
+	})
+
+	t.Run("Missing from local", func(t *testing.T) {
+		gossip.MessageHandler(
+			newMockGossipMsgHandler(channelID).
+				Value(key4, value4).
+				Handle)
+
+		// Shouldn't be authorized to retrieve from other peer
+		ctx, _ := context.WithTimeout(context.Background(), respTimeout)
+		value, err := retriever.GetData(ctx, storeapi.NewKey(txID, ns1, coll1, key4))
+		require.NoError(t, err)
+		require.Nil(t, value)
+	})
+}
+
+type mockGossipMsgHandler struct {
+	channelID string
+	values    map[string]*storeapi.ExpiringValue
+}
+
+func newMockGossipMsgHandler(channelID string) *mockGossipMsgHandler {
+	return &mockGossipMsgHandler{
+		channelID: channelID,
+		values:    make(map[string]*storeapi.ExpiringValue),
+	}
+}
+
+func (m *mockGossipMsgHandler) Value(key string, value *storeapi.ExpiringValue) *mockGossipMsgHandler {
+	m.values[key] = value
+	return m
+}
+
+func (m *mockGossipMsgHandler) Handle(msg *gproto.GossipMessage) {
+	req := msg.GetCollDataReq()
+
+	res := &requestmgr.Response{
+		Endpoint:  "p1.org1",
+		MSPID:     "org1",
+		Identity:  []byte("p1.org1"),
+		Signature: []byte("sig"),
+	}
+
+	for _, d := range req.Digests {
+		e := &requestmgr.Element{
+			Namespace:  d.Namespace,
+			Collection: d.Collection,
+			Key:        d.Key,
+		}
+
+		v := m.values[d.Key]
+		if v != nil {
+			e.Value = v.Value
+			e.Expiry = v.Expiry
+		}
+
+		res.Data = append(res.Data, e)
+	}
+
+	requestmgr.Get(m.channelID).Respond(req.Nonce, res)
+}

--- a/pkg/collections/offledger/storeprovider/olstore.go
+++ b/pkg/collections/offledger/storeprovider/olstore.go
@@ -23,7 +23,7 @@ import (
 	"github.com/trustbloc/fabric-peer-ext/pkg/config"
 )
 
-var logger = flogging.MustGetLogger("offledgerstore")
+var logger = flogging.MustGetLogger("ext_offledger")
 
 type store struct {
 	channelID   string

--- a/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore.go
+++ b/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	logger          = flogging.MustGetLogger("offledgerstore")
+	logger          = flogging.MustGetLogger("ext_offledger")
 	compositeKeySep = "!"
 )
 

--- a/pkg/collections/offledger/storeprovider/store/leveldbstore/dbstore.go
+++ b/pkg/collections/offledger/storeprovider/store/leveldbstore/dbstore.go
@@ -18,7 +18,7 @@ import (
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
 )
 
-var logger = flogging.MustGetLogger("offledgerstore")
+var logger = flogging.MustGetLogger("ext_offledger")
 
 var compositeKeySep = "!"
 

--- a/pkg/collections/pvtdatahandler/pvtdatahandler_test.go
+++ b/pkg/collections/pvtdatahandler/pvtdatahandler_test.go
@@ -9,7 +9,9 @@ package pvtdatahandler
 import (
 	"testing"
 
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	"github.com/hyperledger/fabric/protos/common"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
@@ -19,42 +21,126 @@ const (
 	channelID = "testchannel"
 	tx1       = "tx1"
 	ns1       = "ns1"
+	coll1     = "coll1"
 	key1      = "key1"
 	key2      = "key2"
 )
 
 func TestHandler_HandleGetPrivateData(t *testing.T) {
-	storeProvider := mocks.NewDataProvider()
+	t.Run("Unhandled collection", func(t *testing.T) {
+		config := &common.StaticCollectionConfig{}
 
-	h := New(channelID, storeProvider)
-	require.NotNil(t, h)
-
-	t.Run("Transient Data", func(t *testing.T) {
-		config := &common.StaticCollectionConfig{
-			Type: common.CollectionType_COL_TRANSIENT,
-		}
+		h := New(channelID, mocks.NewDataProvider())
+		require.NotNil(t, h)
 
 		value, handled, err := h.HandleGetPrivateData(tx1, ns1, config, key1)
 		assert.NoError(t, err)
-		assert.True(t, handled)
-		assert.NotNil(t, value)
+		assert.False(t, handled)
+		assert.Nil(t, value)
+	})
+
+	t.Run("Transient Data", func(t *testing.T) {
+		testHandleGetPrivateData(t, &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_TRANSIENT,
+			Name: coll1,
+		})
+	})
+
+	t.Run("Off-ledger Data", func(t *testing.T) {
+		testHandleGetPrivateData(t, &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_OFFLEDGER,
+			Name: coll1,
+		})
 	})
 }
 
 func TestHandler_HandleGetPrivateDataMultipleKeys(t *testing.T) {
-	storeProvider := mocks.NewDataProvider()
+	t.Run("Unhandled collection", func(t *testing.T) {
+		config := &common.StaticCollectionConfig{}
 
-	h := New(channelID, storeProvider)
-	require.NotNil(t, h)
-
-	t.Run("Transient Data", func(t *testing.T) {
-		config := &common.StaticCollectionConfig{
-			Type: common.CollectionType_COL_TRANSIENT,
-		}
+		dataProvider := mocks.NewDataProvider()
+		h := New(channelID, dataProvider)
+		require.NotNil(t, h)
 
 		value, handled, err := h.HandleGetPrivateDataMultipleKeys(tx1, ns1, config, []string{key1, key2})
 		assert.NoError(t, err)
-		assert.True(t, handled)
-		assert.NotNil(t, value)
+		assert.False(t, handled)
+		assert.Nil(t, value)
 	})
+
+	t.Run("Transient Data", func(t *testing.T) {
+		testHandleGetPrivateDataMultipleKeys(t, &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_TRANSIENT,
+			Name: coll1,
+		})
+	})
+
+	t.Run("Off-ledger Data", func(t *testing.T) {
+		testHandleGetPrivateDataMultipleKeys(t, &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_OFFLEDGER,
+			Name: coll1,
+		})
+	})
+}
+
+func testHandleGetPrivateData(t *testing.T, config *common.StaticCollectionConfig) {
+	dataProvider := mocks.NewDataProvider()
+	h := New(channelID, dataProvider)
+	require.NotNil(t, h)
+
+	value, handled, err := h.HandleGetPrivateData(tx1, ns1, config, key1)
+	assert.NoError(t, err)
+	assert.True(t, handled)
+	assert.Nil(t, value)
+
+	key := storeapi.NewKey(tx1, ns1, coll1, key1)
+	exValue := &storeapi.ExpiringValue{Value: []byte("value1")}
+	dataProvider.WithData(key, exValue)
+
+	value, handled, err = h.HandleGetPrivateData(tx1, ns1, config, key1)
+	assert.NoError(t, err)
+	assert.True(t, handled)
+	assert.Equal(t, exValue.Value, value)
+
+	expectedErr := errors.New("data provider error")
+	dataProvider.WithError(expectedErr)
+
+	value, handled, err = h.HandleGetPrivateData(tx1, ns1, config, key1)
+	assert.Error(t, err)
+	assert.True(t, handled)
+	assert.Nil(t, value)
+}
+
+func testHandleGetPrivateDataMultipleKeys(t *testing.T, config *common.StaticCollectionConfig) {
+	dataProvider := mocks.NewDataProvider()
+	h := New(channelID, dataProvider)
+	require.NotNil(t, h)
+
+	values, handled, err := h.HandleGetPrivateDataMultipleKeys(tx1, ns1, config, []string{key1, key2})
+	assert.NoError(t, err)
+	assert.True(t, handled)
+	require.Equal(t, 2, len(values))
+	assert.Nil(t, values[0])
+	assert.Nil(t, values[1])
+
+	k1 := storeapi.NewKey(tx1, ns1, coll1, key1)
+	k2 := storeapi.NewKey(tx1, ns1, coll1, key2)
+	exValue1 := &storeapi.ExpiringValue{Value: []byte("value1")}
+	exValue2 := &storeapi.ExpiringValue{Value: []byte("value2")}
+	dataProvider.WithData(k1, exValue1).WithData(k2, exValue2)
+
+	values, handled, err = h.HandleGetPrivateDataMultipleKeys(tx1, ns1, config, []string{key1, key2})
+	assert.NoError(t, err)
+	assert.True(t, handled)
+	require.Equal(t, 2, len(values))
+	assert.Equal(t, exValue1.Value, values[0])
+	assert.Equal(t, exValue2.Value, values[1])
+
+	expectedErr := errors.New("data provider error")
+	dataProvider.WithError(expectedErr)
+
+	values, handled, err = h.HandleGetPrivateDataMultipleKeys(tx1, ns1, config, []string{key1, key2})
+	assert.Error(t, err)
+	assert.True(t, handled)
+	assert.Nil(t, values)
 }

--- a/pkg/collections/retriever/retriever_test.go
+++ b/pkg/collections/retriever/retriever_test.go
@@ -14,6 +14,8 @@ import (
 	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+	olmocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/mocks"
 	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
 	tdatamocks "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/mocks"
 )
@@ -27,21 +29,52 @@ func TestRetriever(t *testing.T) {
 		return &tdatamocks.TransientDataProvider{}
 	}
 
+	getOffLedgerProvider = func(storeProvider func(channelID string) olapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) olapi.Provider {
+		return &olmocks.Provider{}
+	}
+
 	p := NewProvider(nil, nil, nil, nil)
 	require.NotNil(t, p)
 
-	retriever := p.RetrieverForChannel(channelID)
-	require.NotNil(t, retriever)
-
 	const key1 = "key1"
 
-	v, err := retriever.GetTransientData(context.Background(), &storeapi.Key{Key: key1})
-	assert.NoError(t, err)
-	require.NotNil(t, v)
-	assert.Equal(t, []byte(key1), v.Value)
+	t.Run("GetTransientData", func(t *testing.T) {
+		retriever := p.RetrieverForChannel(channelID)
+		require.NotNil(t, retriever)
 
-	vals, err := retriever.GetTransientDataMultipleKeys(context.Background(), &storeapi.MultiKey{Keys: []string{key1}})
-	assert.NoError(t, err)
-	require.Equal(t, 1, len(vals))
-	assert.Equal(t, []byte(key1), vals[0].Value)
+		v, err := retriever.GetTransientData(context.Background(), &storeapi.Key{Key: key1})
+		assert.NoError(t, err)
+		require.NotNil(t, v)
+		assert.Equal(t, []byte(key1), v.Value)
+	})
+
+	t.Run("GetTransientDataMultipleKeys", func(t *testing.T) {
+		retriever := p.RetrieverForChannel(channelID)
+		require.NotNil(t, retriever)
+
+		vals, err := retriever.GetTransientDataMultipleKeys(context.Background(), &storeapi.MultiKey{Keys: []string{key1}})
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(vals))
+		assert.Equal(t, []byte(key1), vals[0].Value)
+	})
+
+	t.Run("GetData", func(t *testing.T) {
+		retriever := p.RetrieverForChannel(channelID)
+		require.NotNil(t, retriever)
+
+		v, err := retriever.GetData(context.Background(), &storeapi.Key{Key: key1})
+		assert.NoError(t, err)
+		require.NotNil(t, v)
+		assert.Equal(t, []byte(key1), v.Value)
+	})
+
+	t.Run("GetDataMultipleKeys", func(t *testing.T) {
+		retriever := p.RetrieverForChannel(channelID)
+		require.NotNil(t, retriever)
+
+		vals, err := retriever.GetDataMultipleKeys(context.Background(), &storeapi.MultiKey{Keys: []string{key1}})
+		assert.NoError(t, err)
+		require.Equal(t, 1, len(vals))
+		assert.Equal(t, []byte(key1), vals[0].Value)
+	})
 }

--- a/pkg/collections/retriever/test_exports.go
+++ b/pkg/collections/retriever/test_exports.go
@@ -10,10 +10,16 @@ package retriever
 
 import (
 	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
+	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
 	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
 )
 
 // SetTransientDataProvider sets the transient data Retriever provider for unit tests
 func SetTransientDataProvider(provider func(storeProvider func(channelID string) tdataapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) tdataapi.Provider) {
 	getTransientDataProvider = provider
+}
+
+// SetOffLedgerProvider sets the off-ledger Retriever provider for unit tests
+func SetOffLedgerProvider(provider func(storeProvider func(channelID string) olapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) olapi.Provider) {
+	getOffLedgerProvider = provider
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ const (
 	confOLCollCleanupIntervalTime  = "coll.offledger.cleanupExpired.Interval"
 	confOLCollMaxPeersForRetrieval = "coll.offledger.maxpeers"
 	confOLCollCacheSize            = "coll.offledger.cacheSize"
+	confOLCollPullTimeout          = "coll.offledger.gossip.pullTimeout"
 
 	confBlockPublisherBufferSize = "blockpublisher.buffersize"
 
@@ -37,6 +38,7 @@ const (
 	defaultOLCollCleanupIntervalTime  = 5 * time.Second
 	defaultOLCollMaxPeersForRetrieval = 2
 	defaultOLCollCacheSize            = 10000
+	defaultOLCollPullTimeout          = 5 * time.Second
 
 	defaultBlockPublisherBufferSize = 100
 )
@@ -127,4 +129,13 @@ func GetOLCollCacheSize() int {
 		return defaultOLCollCacheSize
 	}
 	return size
+}
+
+// GetOLCollPullTimeout is the amount of time a peer waits for a response from another peer for transient data.
+func GetOLCollPullTimeout() time.Duration {
+	timeout := viper.GetDuration(confOLCollPullTimeout)
+	if timeout == 0 {
+		timeout = defaultOLCollPullTimeout
+	}
+	return timeout
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -120,7 +120,7 @@ func TestGetBlockPublisherBufferSize(t *testing.T) {
 	assert.Equal(t, 1234, GetBlockPublisherBufferSize())
 }
 
-func TestGetCollMaxPeersForRetrieval(t *testing.T) {
+func TestGetOLCollMaxPeersForRetrieval(t *testing.T) {
 	oldVal := viper.Get(confOLCollMaxPeersForRetrieval)
 	defer viper.Set(confOLCollMaxPeersForRetrieval, oldVal)
 
@@ -129,4 +129,15 @@ func TestGetCollMaxPeersForRetrieval(t *testing.T) {
 
 	viper.Set(confOLCollMaxPeersForRetrieval, 7)
 	assert.Equal(t, 7, GetOLCollMaxPeersForRetrieval())
+}
+
+func TestGetOLCollPullTimeout(t *testing.T) {
+	oldVal := viper.Get(confOLCollPullTimeout)
+	defer viper.Set(confOLCollPullTimeout, oldVal)
+
+	viper.Set(confOLCollPullTimeout, "")
+	assert.Equal(t, defaultOLCollPullTimeout, GetOLCollPullTimeout())
+
+	viper.Set(confOLCollPullTimeout, 111*time.Second)
+	assert.Equal(t, 111*time.Second, GetOLCollPullTimeout())
 }

--- a/pkg/mocks/mockdataprovider.go
+++ b/pkg/mocks/mockdataprovider.go
@@ -14,45 +14,78 @@ import (
 
 // DataProvider is a mock transient data provider
 type DataProvider struct {
+	data map[storeapi.Key]*storeapi.ExpiringValue
+	err  error
 }
 
 // NewDataProvider returns a new Data Provider
 func NewDataProvider() *DataProvider {
-	return &DataProvider{}
+	return &DataProvider{
+		data: make(map[storeapi.Key]*storeapi.ExpiringValue),
+	}
+}
+
+// WithData sets the data to be returned by the retriever
+func (p *DataProvider) WithData(key *storeapi.Key, value *storeapi.ExpiringValue) *DataProvider {
+	p.data[*key] = value
+	return p
+}
+
+// WithError sets the error to be returned by the retriever
+func (p *DataProvider) WithError(err error) *DataProvider {
+	p.err = err
+	return p
 }
 
 // RetrieverForChannel returns the retriever for the given channel
 func (p *DataProvider) RetrieverForChannel(channel string) storeapi.Retriever {
-	return &dataRetriever{}
+	return &dataRetriever{
+		err:  p.err,
+		data: p.data,
+	}
 }
 
 type dataRetriever struct {
+	err  error
+	data map[storeapi.Key]*storeapi.ExpiringValue
 }
 
 // GetTransientData returns the transient data for the given context and key
 func (m *dataRetriever) GetTransientData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
-	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.data[*key], nil
 }
 
 // GetTransientDataMultipleKeys returns the transient data with multiple keys for the given context and key
 func (m *dataRetriever) GetTransientDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	values := make(storeapi.ExpiringValues, len(key.Keys))
 	for i, k := range key.Keys {
-		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+		values[i] = m.data[*storeapi.NewKey(key.EndorsedAtTxID, key.Namespace, key.Collection, k)]
 	}
 	return values, nil
 }
 
 // GetData returns the data for the given context and key
 func (m *dataRetriever) GetData(ctxt context.Context, key *storeapi.Key) (*storeapi.ExpiringValue, error) {
-	return &storeapi.ExpiringValue{Value: []byte(key.Key)}, nil
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.data[*key], nil
 }
 
 // GetDataMultipleKeys returns the  data with multiple keys for the given context and key
 func (m *dataRetriever) GetDataMultipleKeys(ctxt context.Context, key *storeapi.MultiKey) (storeapi.ExpiringValues, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	values := make(storeapi.ExpiringValues, len(key.Keys))
 	for i, k := range key.Keys {
-		values[i] = &storeapi.ExpiringValue{Value: []byte(k)}
+		values[i] = m.data[*storeapi.NewKey(key.EndorsedAtTxID, key.Namespace, key.Collection, k)]
 	}
 	return values, nil
 }


### PR DESCRIPTION
Retrieve Off-Ledger data from the current peer. If the data does not exist
then a Gossip message is sent to other peers requesting the data. Once the
data is successfully retrieved, it is stored on the current peer.

Note that before retrieving the data, a check is made to see if the current
peer has access to the data (according to collection policy). If the peer
does not have access, then nil is returned.

closes #63

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>