### PR TITLE
test: Added test for Chaincode-to-Chaincode Transient Data

### DIFF
--- a/scripts/generate_channeltx.sh
+++ b/scripts/generate_channeltx.sh
@@ -15,7 +15,7 @@ if [ -z "$FABRIC_VERSION_DIR" ]; then
   exit 1
 fi
 
-declare -a twoOrgChannels=("mychannel")
+declare -a twoOrgChannels=("mychannel" "yourchannel")
 declare -a orgs=("Org1MSP" "Org2MSP")
 
 FIXTURES_CHANNEL_PATH=${FIXTURES_PATH}${FABRIC_VERSION_DIR}${CHANNEL_DIR}

--- a/test/bddtests/fixtures/config/sdk-client/config.yaml
+++ b/test/bddtests/fixtures/config/sdk-client/config.yaml
@@ -12,6 +12,11 @@ bddtest:
       anchorTxPath:
         peerorg1: "./fixtures/fabric/channel/mychannelOrg1MSPanchors.tx"
         peerorg2: "./fixtures/fabric/channel/mychannelOrg2MSPanchors.tx"
+    yourchannel:
+      txPath: "./fixtures/fabric/channel/yourchannel.tx"
+      anchorTxPath:
+        peerorg1: "./fixtures/fabric/channel/yourchannelOrg1MSPanchors.tx"
+        peerorg2: "./fixtures/fabric/channel/yourchannelOrg2MSPanchors.tx"
 
 client:
 
@@ -93,6 +98,35 @@ client:
 channels:
   # name of the channel
   mychannel:
+    orderers:
+      - orderer.example.com
+    # Required. list of peers from participating orgs
+    peers:
+      peer0.org1.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+
+      peer1.org1.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+
+      peer0.org2.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+
+      peer1.org2.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+
+  yourchannel:
     orderers:
       - orderer.example.com
     # Required. list of peers from participating orgs

--- a/test/bddtests/fixtures/testdata/src/github.com/trustbloc/e2e_cc/e2e_cc.go
+++ b/test/bddtests/fixtures/testdata/src/github.com/trustbloc/e2e_cc/e2e_cc.go
@@ -343,23 +343,21 @@ func asBytes(args []string) [][]byte {
 }
 
 func (cc *ExampleCC) invokeCC(stub shim.ChaincodeStubInterface, args []string) pb.Response {
-	if len(args) < 2 {
-		return shim.Error(`Invalid args. Expecting name of chaincode to invoke and chaincode args in the format {"Args":["arg1","arg2",...]}`)
+	if len(args) < 3 {
+		return shim.Error(`Invalid args. Expecting target chaincode, target channel (blank if same channel), and chaincode args in the format {"Args":["arg1","arg2",...]}`)
 	}
 
 	ccName := args[0]
-	invokeArgsJSON := strings.Replace(args[1], "`", `"`, -1)
+	channelID := args[1]
+	invokeArgsJSON := strings.Replace(args[2], "`", `"`, -1)
+	invokeArgsJSON = strings.Replace(invokeArgsJSON, "|", `,`, -1)
 
 	argStruct := argStruct{}
 	if err := json.Unmarshal([]byte(invokeArgsJSON), &argStruct); err != nil {
 		return shim.Error(fmt.Sprintf("Invalid invoke args: %s", err))
 	}
 
-	if err := stub.PutState(stub.GetTxID()+"_invokedcc", []byte(ccName)); err != nil {
-		return shim.Error(fmt.Sprintf("Error putting state: %s", err))
-	}
-
-	return stub.InvokeChaincode(ccName, asBytes(argStruct.Args), "")
+	return stub.InvokeChaincode(ccName, asBytes(argStruct.Args), channelID)
 }
 
 func (cc *ExampleCC) initRegistry() {


### PR DESCRIPTION
Added a BDD test to ensure that a chaincode is able to read and write transient data
from another chaincode using the stub function, InvokeChaincode. Both reads and writes
should work if invoking chaincode on the same channel as the source chaincode. Reads
should work if invoking chaincode on a different channel.

closes #119

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>