### PR TITLE
feat: DCAS Collection Type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ module github.com/trustbloc/fabric-peer-ext
 
 require (
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
+	github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a
 	github.com/golang/protobuf v1.2.0
 	github.com/hyperledger/fabric v1.4.1
 	github.com/hyperledger/fabric/extensions v0.0.0
@@ -14,7 +15,6 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/willf/bitset v1.1.9
 	go.uber.org/zap v1.9.1
-
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190522001819-bbf763a5c881

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680 h1:jk2k2FUNIg9ogv9yFIzjA5NTrJeaAkHev4AFspbmyvo=
 github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680/go.mod h1:8c4/i2VlovMO2gBnHGQPN5EJw+H0lx1u/5p+cgsXtCk=
+github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a h1:UwuNC3d8iGIAwMyAO92ZGuVQYmdGkWXtQEGZdiIrJQs=
+github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.0.0-20180814194400-c7c5070e6f6e/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20181003075958-be9bd761db19 h1:HSgjWPBWohO3kHDPwCPUGSLqJjXCjA7ad5057beR2ZU=

--- a/mod/peer/collections/dissemination/disseminationplan.go
+++ b/mod/peer/collections/dissemination/disseminationplan.go
@@ -62,6 +62,8 @@ func ComputeDisseminationPlan(
 	switch collConfig.Type {
 	case cb.CollectionType_COL_TRANSIENT:
 		return computeTransientDataDisseminationPlan(channelID, ns, rwSet, colAP, pvtDataMsg, gossipAdapter)
+	case cb.CollectionType_COL_DCAS:
+		fallthrough
 	case cb.CollectionType_COL_OFFLEDGER:
 		return computeOffLedgerDisseminationPlan(channelID, ns, rwSet, collConfig, colAP, pvtDataMsg, gossipAdapter)
 	default:

--- a/mod/peer/collections/dissemination/disseminationplan_test.go
+++ b/mod/peer/collections/dissemination/disseminationplan_test.go
@@ -74,10 +74,23 @@ func TestDisseminationPlan(t *testing.T) {
 	})
 
 	t.Run("Off-Ledger config", func(t *testing.T) {
-		dcasConfig := &common.CollectionConfig{
+		olConfig := &common.CollectionConfig{
 			Payload: &common.CollectionConfig_StaticCollectionConfig{
 				StaticCollectionConfig: &common.StaticCollectionConfig{
 					Type: common.CollectionType_COL_OFFLEDGER,
+				},
+			},
+		}
+		_, _, err := ComputeDisseminationPlan(
+			channelID, ns, nil, olConfig, nil, nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("DCAS config", func(t *testing.T) {
+		dcasConfig := &common.CollectionConfig{
+			Payload: &common.CollectionConfig_StaticCollectionConfig{
+				StaticCollectionConfig: &common.StaticCollectionConfig{
+					Type: common.CollectionType_COL_DCAS,
 				},
 			},
 		}

--- a/mod/peer/collections/policy/validator.go
+++ b/mod/peer/collections/policy/validator.go
@@ -34,6 +34,8 @@ func (v *Validator) Validate(collConfig *common.CollectionConfig) error {
 	switch config.Type {
 	case common.CollectionType_COL_TRANSIENT:
 		return tdatapolicy.ValidateConfig(config)
+	case common.CollectionType_COL_DCAS:
+		fallthrough
 	case common.CollectionType_COL_OFFLEDGER:
 		return olpolicy.ValidateConfig(config)
 	default:
@@ -77,6 +79,8 @@ func getCollType(config *common.StaticCollectionConfig) common.CollectionType {
 		return common.CollectionType_COL_TRANSIENT
 	case common.CollectionType_COL_OFFLEDGER:
 		return common.CollectionType_COL_OFFLEDGER
+	case common.CollectionType_COL_DCAS:
+		return common.CollectionType_COL_DCAS
 	case common.CollectionType_COL_PRIVATE:
 		fallthrough
 	default:

--- a/mod/peer/collections/policy/validator_test.go
+++ b/mod/peer/collections/policy/validator_test.go
@@ -98,6 +98,60 @@ func TestValidateOffLedgerCollectionConfig(t *testing.T) {
 	})
 }
 
+func TestValidateDCASCollectionConfig(t *testing.T) {
+	coll1 := "mycollection"
+
+	var signers = [][]byte{[]byte("signer0"), []byte("signer1")}
+
+	v := NewValidator()
+
+	t.Run("DCAS collection -> success", func(t *testing.T) {
+		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
+		err := v.Validate(createDCASCollectionConfig(coll1, policyEnvelope, 1, 2, "1m"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("DCAS req == 0 -> error", func(t *testing.T) {
+		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
+		err := v.Validate(createDCASCollectionConfig(coll1, policyEnvelope, 0, 2, "1m"))
+		require.Error(t, err)
+		expectedErr := "required peer count must be greater than 0"
+		assert.Truef(t, strings.Contains(err.Error(), expectedErr), "Expected error to contain '%s' but got '%s'", expectedErr, err)
+	})
+
+	t.Run("transient collection req > max -> error", func(t *testing.T) {
+		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
+		err := v.Validate(createTransientCollectionConfig(coll1, policyEnvelope, 3, 2, "1m"))
+		require.Error(t, err)
+		expectedErr := "maximum peer count (2) must be greater than or equal to required peer count (3)"
+		assert.Truef(t, strings.Contains(err.Error(), expectedErr), "Expected error to contain '%s' but got '%s'", expectedErr, err)
+	})
+
+	t.Run("DCAS no time-to-live -> success", func(t *testing.T) {
+		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
+		err := v.Validate(createDCASCollectionConfig(coll1, policyEnvelope, 1, 2, ""))
+		require.NoError(t, err)
+	})
+
+	t.Run("DCAS invalid time-to-live -> error", func(t *testing.T) {
+		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
+		err := v.Validate(createDCASCollectionConfig(coll1, policyEnvelope, 1, 2, "1k"))
+		require.Error(t, err)
+		expectedErr := "invalid time format for time to live"
+		assert.Truef(t, strings.Contains(err.Error(), expectedErr), "Expected error to contain '%s' but got '%s'", expectedErr, err)
+	})
+
+	t.Run("DCAS with blocks-to-live -> error", func(t *testing.T) {
+		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
+		config := createTransientCollectionConfig(coll1, policyEnvelope, 1, 2, "1m")
+		config.GetStaticCollectionConfig().BlockToLive = 100
+		err := v.Validate(config)
+		require.Error(t, err)
+		expectedErr := "block-to-live not supported"
+		assert.Truef(t, strings.Contains(err.Error(), expectedErr), "Expected error to contain '%s' but got '%s'", expectedErr, err)
+	})
+}
+
 func TestValidateNewCollectionConfigAgainstOld(t *testing.T) {
 	coll1 := "mycollection"
 
@@ -187,6 +241,26 @@ func createOffLedgerCollectionConfig(collectionName string, signaturePolicyEnvel
 			StaticCollectionConfig: &common.StaticCollectionConfig{
 				Name:              collectionName,
 				Type:              common.CollectionType_COL_OFFLEDGER,
+				MemberOrgsPolicy:  &common.CollectionPolicyConfig{Payload: signaturePolicy},
+				RequiredPeerCount: requiredPeerCount,
+				MaximumPeerCount:  maximumPeerCount,
+				TimeToLive:        ttl,
+			},
+		},
+	}
+}
+
+func createDCASCollectionConfig(collectionName string, signaturePolicyEnvelope *common.SignaturePolicyEnvelope,
+	requiredPeerCount int32, maximumPeerCount int32, ttl string) *common.CollectionConfig {
+	signaturePolicy := &common.CollectionPolicyConfig_SignaturePolicy{
+		SignaturePolicy: signaturePolicyEnvelope,
+	}
+
+	return &common.CollectionConfig{
+		Payload: &common.CollectionConfig_StaticCollectionConfig{
+			StaticCollectionConfig: &common.StaticCollectionConfig{
+				Name:              collectionName,
+				Type:              common.CollectionType_COL_DCAS,
 				MemberOrgsPolicy:  &common.CollectionPolicyConfig{Payload: signaturePolicy},
 				RequiredPeerCount: requiredPeerCount,
 				MaximumPeerCount:  maximumPeerCount,

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -22,6 +22,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680 h1:jk2k2FUNIg9ogv9yFIzjA5NTrJeaAkHev4AFspbmyvo=
 github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680/go.mod h1:8c4/i2VlovMO2gBnHGQPN5EJw+H0lx1u/5p+cgsXtCk=
+github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a h1:UwuNC3d8iGIAwMyAO92ZGuVQYmdGkWXtQEGZdiIrJQs=
+github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/continuity v0.0.0-20180814194400-c7c5070e6f6e/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20181003075958-be9bd761db19 h1:HSgjWPBWohO3kHDPwCPUGSLqJjXCjA7ad5057beR2ZU=

--- a/pkg/collections/offledger/dcas/cas.go
+++ b/pkg/collections/offledger/dcas/cas.go
@@ -1,0 +1,41 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dcas
+
+import (
+	"crypto"
+	"encoding/base64"
+
+	"github.com/btcsuite/btcutil/base58"
+)
+
+// GetCASKey returns the content-addressable key for the given content.
+func GetCASKey(content []byte) string {
+	address := calculateAddress(content)
+
+	// Address above is as per CAS spec(sha256 hash + base64 URL encoding),
+	// however since fabric/couchdb doesn't support keys that start with _
+	// we have to do additional transformation
+	return base58.Encode(address)
+}
+
+func calculateAddress(content []byte) []byte {
+	hash := getHash(content)
+	buf := make([]byte, base64.URLEncoding.EncodedLen(len(hash)))
+	base64.URLEncoding.Encode(buf, hash)
+
+	return buf
+}
+
+// getHash will compute the hash for the supplied bytes using SHA256
+func getHash(bytes []byte) []byte {
+	h := crypto.SHA256.New()
+	// added no lint directive because there's no error from source code
+	// error cannot be produced, checked google source
+	h.Write(bytes) //nolint
+	return h.Sum(nil)
+}

--- a/pkg/collections/offledger/dcas/cas_test.go
+++ b/pkg/collections/offledger/dcas/cas_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dcas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCASKey(t *testing.T) {
+	k := GetCASKey([]byte("value1"))
+	assert.NotEmpty(t, k)
+}

--- a/pkg/collections/offledger/dcas/dcas.go
+++ b/pkg/collections/offledger/dcas/dcas.go
@@ -1,0 +1,53 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dcas
+
+import (
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	"github.com/pkg/errors"
+)
+
+// Validator is an off-ledger validator that validates the CAS key against the value
+func Validator(_, _, _, key string, value []byte) error {
+	if value == nil {
+		return errors.Errorf("nil value for key [%s]", key)
+	}
+	expectedKey := GetCASKey(value)
+	if key != expectedKey {
+		return errors.Errorf("Invalid CAS key [%s] - the key should be the hash of the value", key)
+	}
+	return nil
+}
+
+// Decorator is an off-ledger decorator that ensures the given key is the hash of the value. If the key is not
+// specified then it is generated. If the key is provided then it is validated against the value.
+func Decorator(key *storeapi.Key, value *storeapi.ExpiringValue) (*storeapi.Key, *storeapi.ExpiringValue, error) {
+	dcasKey, err := validateCASKey(key.Key, value.Value)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if dcasKey == key.Key {
+		return key, value, nil
+	}
+
+	newKey := *key
+	newKey.Key = dcasKey
+	return &newKey, value, nil
+}
+
+func validateCASKey(key string, value []byte) (string, error) {
+	if value == nil {
+		return "", errors.Errorf("attempt to put nil value for key [%s]", key)
+	}
+
+	casKey := GetCASKey(value)
+	if key != "" && key != casKey {
+		return casKey, errors.New("invalid CAS key - the key should be the hash of the value")
+	}
+	return casKey, nil
+}

--- a/pkg/collections/offledger/dcas/dcas_test.go
+++ b/pkg/collections/offledger/dcas/dcas_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dcas
+
+import (
+	"testing"
+
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ns1   = "chaincode1"
+	coll1 = "coll1"
+	txID1 = "txid1"
+)
+
+func TestValidator(t *testing.T) {
+	value := []byte("value1")
+
+	t.Run("Valid key/value -> success", func(t *testing.T) {
+		err := Validator("", "", "", GetCASKey(value), value)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Invalid key -> error", func(t *testing.T) {
+		err := Validator("", "", "", "key1", value)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "the key should be the hash of the value")
+	})
+
+	t.Run("Nil value -> error", func(t *testing.T) {
+		err := Validator("", "", "", "key1", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil value for key")
+	})
+}
+
+func TestDecorator(t *testing.T) {
+	value1_1 := []byte("value1_1")
+	value := &storeapi.ExpiringValue{
+		Value: value1_1,
+	}
+
+	t.Run("CAS key -> success", func(t *testing.T) {
+		key := storeapi.NewKey(txID1, ns1, coll1, GetCASKey(value1_1))
+		k, v, err := Decorator(key, value)
+		assert.NoError(t, err)
+		assert.Equal(t, key, k)
+		assert.Equal(t, value, v)
+	})
+
+	t.Run("Empty key -> success", func(t *testing.T) {
+		key := storeapi.NewKey(txID1, ns1, coll1, "")
+		k, v, err := Decorator(key, value)
+		assert.NoError(t, err)
+		assert.Equal(t, GetCASKey(value1_1), k.Key)
+		assert.Equal(t, value, v)
+	})
+
+	t.Run("Invalid key -> error", func(t *testing.T) {
+		key := storeapi.NewKey(txID1, ns1, coll1, "key1")
+		k, v, err := Decorator(key, value)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "the key should be the hash of the value")
+		assert.Nil(t, k)
+		assert.Nil(t, v)
+	})
+
+	t.Run("Nil value -> error", func(t *testing.T) {
+		k, v, err := Decorator(storeapi.NewKey(txID1, ns1, coll1, "key1"), &storeapi.ExpiringValue{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil value for key")
+		assert.Nil(t, k)
+		assert.Nil(t, v)
+	})
+}

--- a/pkg/collections/offledger/dissemination/disseminationplan.go
+++ b/pkg/collections/offledger/dissemination/disseminationplan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas"
 )
 
 type gossipAdapter interface {
@@ -84,9 +85,15 @@ func validateAll(collType cb.CollectionType, kvRWSet *kvrwset.KVRWSet) error {
 	return nil
 }
 
-func validate(_ cb.CollectionType, ws *kvrwset.KVWrite) error {
+func validate(collType cb.CollectionType, ws *kvrwset.KVWrite) error {
 	if ws.Value == nil {
 		return errors.Errorf("attempt to store nil value for key [%s]", ws.Key)
+	}
+	if collType == cb.CollectionType_COL_DCAS {
+		expectedKey := dcas.GetCASKey(ws.Value)
+		if ws.Key != expectedKey {
+			return errors.Errorf("invalid CAS key [%s] - the key should be the hash of the value", ws.Key)
+		}
 	}
 	return nil
 }

--- a/pkg/collections/offledger/policy/validator.go
+++ b/pkg/collections/offledger/policy/validator.go
@@ -15,6 +15,10 @@ import (
 
 // ValidateConfig validates the Off-Ledger Collection configuration
 func ValidateConfig(config *common.StaticCollectionConfig) error {
+	if config.Type != common.CollectionType_COL_OFFLEDGER && config.Type != common.CollectionType_COL_DCAS {
+		return errors.Errorf("unsupported off-ledger collection type: %s", config.Type)
+	}
+
 	if config.RequiredPeerCount <= 0 {
 		return errors.Errorf("collection-name: %s -- required peer count must be greater than 0", config.Name)
 	}

--- a/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
+++ b/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
@@ -12,13 +12,15 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric/common/flogging"
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	"github.com/hyperledger/fabric/extensions/testutil"
+	"github.com/hyperledger/fabric/protos/common"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStore(t *testing.T) {
+func TestStoreProvider_OpenStore(t *testing.T) {
 	channel1 := "channel1"
 	channel2 := "channel2"
 
@@ -40,6 +42,20 @@ func TestStore(t *testing.T) {
 	assert.NotPanics(t, func() {
 		f.Close()
 	})
+}
+
+func TestStoreProvider_WithDecorator(t *testing.T) {
+	f := New(
+		WithCollectionType(
+			common.CollectionType_COL_DCAS,
+			WithDecorator(func(key *storeapi.Key, value *storeapi.ExpiringValue) (*storeapi.Key, *storeapi.ExpiringValue, error) {
+				return key, value, nil
+			}),
+		))
+	require.NotNil(t, f)
+	config, ok := f.collConfigs[common.CollectionType_COL_DCAS]
+	assert.True(t, ok)
+	assert.NotNil(t, config)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/collections/pvtdatahandler/pvtdatahandler.go
+++ b/pkg/collections/pvtdatahandler/pvtdatahandler.go
@@ -41,6 +41,8 @@ func (h *Handler) HandleGetPrivateData(txID, ns string, config *common.StaticCol
 			return nil, true, err
 		}
 		return value, true, nil
+	case common.CollectionType_COL_DCAS:
+		fallthrough
 	case common.CollectionType_COL_OFFLEDGER:
 		logger.Debugf("Collection [%s:%s] is an off-ledger store. Returning data for key [%s]", ns, config.Name, key)
 		value, err := h.getData(txID, ns, config.Name, key)
@@ -63,6 +65,8 @@ func (h *Handler) HandleGetPrivateDataMultipleKeys(txID, ns string, config *comm
 			return nil, true, err
 		}
 		return values, true, nil
+	case common.CollectionType_COL_DCAS:
+		fallthrough
 	case common.CollectionType_COL_OFFLEDGER:
 		logger.Debugf("Collection [%s:%s] is of an off-ledger store. Returning data for keys [%s]", ns, config.Name, keys)
 		values, err := h.getDataMultipleKeys(txID, ns, config.Name, keys)

--- a/pkg/collections/pvtdatahandler/pvtdatahandler_test.go
+++ b/pkg/collections/pvtdatahandler/pvtdatahandler_test.go
@@ -52,6 +52,13 @@ func TestHandler_HandleGetPrivateData(t *testing.T) {
 			Name: coll1,
 		})
 	})
+
+	t.Run("DCAS Data", func(t *testing.T) {
+		testHandleGetPrivateData(t, &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_DCAS,
+			Name: coll1,
+		})
+	})
 }
 
 func TestHandler_HandleGetPrivateDataMultipleKeys(t *testing.T) {
@@ -78,6 +85,13 @@ func TestHandler_HandleGetPrivateDataMultipleKeys(t *testing.T) {
 	t.Run("Off-ledger Data", func(t *testing.T) {
 		testHandleGetPrivateDataMultipleKeys(t, &common.StaticCollectionConfig{
 			Type: common.CollectionType_COL_OFFLEDGER,
+			Name: coll1,
+		})
+	})
+
+	t.Run("DCAS Data", func(t *testing.T) {
+		testHandleGetPrivateDataMultipleKeys(t, &common.StaticCollectionConfig{
+			Type: common.CollectionType_COL_DCAS,
 			Name: coll1,
 		})
 	})

--- a/pkg/collections/retriever/retriever.go
+++ b/pkg/collections/retriever/retriever.go
@@ -17,6 +17,7 @@ import (
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	cb "github.com/hyperledger/fabric/protos/common"
 	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas"
 	olretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/retriever"
 	tdataapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
 	tretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/retriever"
@@ -116,5 +117,7 @@ var getTransientDataProvider = func(storeProvider func(channelID string) tdataap
 }
 
 var getOffLedgerProvider = func(storeProvider func(channelID string) olapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) olapi.Provider {
-	return olretriever.NewProvider(storeProvider, support, gossipProvider)
+	return olretriever.NewProvider(storeProvider, support, gossipProvider,
+		olretriever.WithValidator(cb.CollectionType_COL_DCAS, dcas.Validator),
+	)
 }

--- a/pkg/collections/storeprovider/storeprovider.go
+++ b/pkg/collections/storeprovider/storeprovider.go
@@ -10,7 +10,9 @@ import (
 	"sync"
 
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	cb "github.com/hyperledger/fabric/protos/common"
 	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas"
 	olstoreprovider "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider"
 	tdapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/storeprovider"
@@ -80,7 +82,11 @@ var newTransientDataProvider = func() tdapi.StoreProvider {
 	return storeprovider.New()
 }
 
-// newOffLedgerProviderFactory may be overridden in unit tests
+// newOffLedgerProvider may be overridden in unit tests
 var newOffLedgerProvider = func() olapi.StoreProvider {
-	return olstoreprovider.New()
+	return olstoreprovider.New(
+		olstoreprovider.WithCollectionType(
+			cb.CollectionType_COL_DCAS, olstoreprovider.WithDecorator(dcas.Decorator),
+		),
+	)
 }

--- a/pkg/endorser/endorser.go
+++ b/pkg/endorser/endorser.go
@@ -107,5 +107,6 @@ func (f *collRWSetFilter) isOffLedger(ns, coll string) (bool, error) {
 
 func isCollOffLedger(collConfig *common.StaticCollectionConfig) bool {
 	return collConfig.Type == common.CollectionType_COL_TRANSIENT ||
-		collConfig.Type == common.CollectionType_COL_OFFLEDGER
+		collConfig.Type == common.CollectionType_COL_OFFLEDGER ||
+		collConfig.Type == common.CollectionType_COL_DCAS
 }

--- a/pkg/endorser/endorser_test.go
+++ b/pkg/endorser/endorser_test.go
@@ -23,6 +23,7 @@ const (
 
 	coll1 = "coll1"
 	coll2 = "coll2"
+	coll3 = "coll3"
 )
 
 func TestFilterPubSimulationResults(t *testing.T) {
@@ -32,6 +33,7 @@ func TestFilterPubSimulationResults(t *testing.T) {
 	pvtNSBuilder1.Collection(coll2).TransientConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
 	pvtNSBuilder3 := pvtBuilder.Namespace(ns3)
 	pvtNSBuilder3.Collection(coll2).OffLedgerConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
+	pvtNSBuilder3.Collection(coll3).DCASConfig("OR('Org1.member','Org2.member')", 2, 3, "1m")
 
 	builder := mocks.NewReadWriteSetBuilder()
 	nsBuilder1 := builder.Namespace(ns1)
@@ -44,6 +46,7 @@ func TestFilterPubSimulationResults(t *testing.T) {
 
 	nsBuilder3 := builder.Namespace(ns3)
 	nsBuilder3.Collection(coll2)
+	nsBuilder3.Collection(coll3)
 
 	results := builder.Build()
 	require.NotNil(t, results)
@@ -65,7 +68,7 @@ func TestFilterPubSimulationResults(t *testing.T) {
 
 	// ns3 should have no rw-set and 1 coll-hashed rw-sets
 	assert.Equal(t, ns3, results.NsRwset[2].Namespace)
-	require.Equal(t, 1, len(results.NsRwset[2].CollectionHashedRwset))
+	require.Equal(t, 2, len(results.NsRwset[2].CollectionHashedRwset))
 	assert.Empty(t, len(results.NsRwset[2].Rwset))
 
 	filteredResults, err := FilterPubSimulationResults(pvtBuilder.BuildCollectionConfigs(), results)


### PR DESCRIPTION
Added a Distributed Content Addressable Store (DCAS) collection which uses the existing,
off-ledger implementation with additional validation. The DCAS collection behaves exactly
the same as Off-Ledger except that when a DCAS key/value is stored then:

- If the key is specified then the key should be validated to be the hash of the value
- If the key is empty ("") then the key should be generated to be the hash of the value

closes #66 

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>