### PR TITLE
fix: Dispatch Off-Ledger and DCAS collections

### DIFF
--- a/pkg/gossip/dispatcher/dispatcher.go
+++ b/pkg/gossip/dispatcher/dispatcher.go
@@ -241,6 +241,11 @@ func (s *Dispatcher) getDataForKey(key *storeapi.Key) (*storeapi.ExpiringValue, 
 	case cb.CollectionType_COL_TRANSIENT:
 		logger.Debugf("[%s] Getting transient data for key [%s]", s.channelID, key)
 		return s.dataStore.GetTransientData(key)
+	case cb.CollectionType_COL_DCAS:
+		fallthrough
+	case cb.CollectionType_COL_OFFLEDGER:
+		logger.Debugf("[%s] Getting off-ledger data for key [%s]", s.channelID, key)
+		return s.dataStore.GetData(key)
 	default:
 		return nil, errors.Errorf("unsupported collection type: [%s]", config.Type)
 	}


### PR DESCRIPTION
DCAS and Off-Ledger collections were not being handled by the Gossip dispatcher.
This fix adds handling for those collection types.

closes #125

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>