### PR TITLE
fix: CAS keys should be base64 encoded

### DIFF
--- a/pkg/collections/offledger/dcas/cas.go
+++ b/pkg/collections/offledger/dcas/cas.go
@@ -15,20 +15,16 @@ import (
 
 // GetCASKey returns the content-addressable key for the given content.
 func GetCASKey(content []byte) string {
-	address := calculateAddress(content)
-
-	// Address above is as per CAS spec(sha256 hash + base64 URL encoding),
-	// however since fabric/couchdb doesn't support keys that start with _
-	// we have to do additional transformation
-	return base58.Encode(address)
-}
-
-func calculateAddress(content []byte) []byte {
 	hash := getHash(content)
 	buf := make([]byte, base64.URLEncoding.EncodedLen(len(hash)))
 	base64.URLEncoding.Encode(buf, hash)
+	return string(buf)
+}
 
-	return buf
+// GetFabricCASKey returns the content-addressable key for the given content,
+// encoded in base58 so that it may be used as a key in Fabric.
+func GetFabricCASKey(content []byte) string {
+	return Base58Encode(GetCASKey(content))
 }
 
 // getHash will compute the hash for the supplied bytes using SHA256
@@ -38,4 +34,9 @@ func getHash(bytes []byte) []byte {
 	// error cannot be produced, checked google source
 	h.Write(bytes) //nolint
 	return h.Sum(nil)
+}
+
+// Base58Encode encodes the given string in base 58
+func Base58Encode(s string) string {
+	return base58.Encode([]byte(s))
 }

--- a/pkg/collections/offledger/dcas/cas_test.go
+++ b/pkg/collections/offledger/dcas/cas_test.go
@@ -16,3 +16,8 @@ func TestGetCASKey(t *testing.T) {
 	k := GetCASKey([]byte("value1"))
 	assert.NotEmpty(t, k)
 }
+
+func TestGetFabricCASKey(t *testing.T) {
+	k := GetFabricCASKey([]byte("value1"))
+	assert.NotEmpty(t, k)
+}

--- a/pkg/collections/offledger/dcas/dcas.go
+++ b/pkg/collections/offledger/dcas/dcas.go
@@ -31,13 +31,27 @@ func Decorator(key *storeapi.Key, value *storeapi.ExpiringValue) (*storeapi.Key,
 		return nil, nil, err
 	}
 
-	if dcasKey == key.Key {
-		return key, value, nil
+	// The key needs to be base58 encoded since Fabric doesn't allow
+	// certain characters to be used in the key.
+	newKey := &storeapi.Key{
+		EndorsedAtTxID: key.EndorsedAtTxID,
+		Namespace:      key.Namespace,
+		Collection:     key.Collection,
+		Key:            Base58Encode(dcasKey),
 	}
 
-	newKey := *key
-	newKey.Key = dcasKey
-	return &newKey, value, nil
+	return newKey, value, nil
+}
+
+// KeyDecorator is an off-ledger decorator that ensures the given key is base58 encoded
+// since Fabric doesn't allow certain characters to be used in the key.
+func KeyDecorator(key *storeapi.Key) (*storeapi.Key, error) {
+	return &storeapi.Key{
+		EndorsedAtTxID: key.EndorsedAtTxID,
+		Namespace:      key.Namespace,
+		Collection:     key.Collection,
+		Key:            Base58Encode(key.Key),
+	}, nil
 }
 
 func validateCASKey(key string, value []byte) (string, error) {

--- a/pkg/collections/offledger/dcas/dcas_test.go
+++ b/pkg/collections/offledger/dcas/dcas_test.go
@@ -51,7 +51,7 @@ func TestDecorator(t *testing.T) {
 		key := storeapi.NewKey(txID1, ns1, coll1, GetCASKey(value1_1))
 		k, v, err := Decorator(key, value)
 		assert.NoError(t, err)
-		assert.Equal(t, key, k)
+		assert.Equal(t, Base58Encode(key.Key), k.Key)
 		assert.Equal(t, value, v)
 	})
 
@@ -59,7 +59,7 @@ func TestDecorator(t *testing.T) {
 		key := storeapi.NewKey(txID1, ns1, coll1, "")
 		k, v, err := Decorator(key, value)
 		assert.NoError(t, err)
-		assert.Equal(t, GetCASKey(value1_1), k.Key)
+		assert.Equal(t, GetFabricCASKey(value1_1), k.Key)
 		assert.Equal(t, value, v)
 	})
 

--- a/pkg/collections/offledger/storeprovider/olstore_test.go
+++ b/pkg/collections/offledger/storeprovider/olstore_test.go
@@ -220,12 +220,12 @@ func TestStore_PutAndGet_DCAS(t *testing.T) {
 		err := s.Persist(txID1, b.Build())
 		require.NoError(t, err)
 
-		value, err := s.GetData(storeapi.NewKey(txID2, ns1, coll1, casKey1_1))
+		value, err := s.GetData(storeapi.NewKey(txID2, ns1, coll1, dcas.GetFabricCASKey(value1_1)))
 		assert.NoError(t, err)
 		require.NotNil(t, value)
 		assert.Equal(t, value1_1, value.Value)
 
-		value, err = s.GetData(storeapi.NewKey(txID2, ns1, coll1, casKey1_2))
+		value, err = s.GetData(storeapi.NewKey(txID2, ns1, coll1, dcas.GetFabricCASKey(value1_2)))
 		assert.NoError(t, err)
 		require.NotNil(t, value)
 		assert.Equal(t, value1_2, value.Value)

--- a/pkg/collections/retriever/retriever.go
+++ b/pkg/collections/retriever/retriever.go
@@ -119,5 +119,6 @@ var getTransientDataProvider = func(storeProvider func(channelID string) tdataap
 var getOffLedgerProvider = func(storeProvider func(channelID string) olapi.Store, support Support, gossipProvider func() supportapi.GossipAdapter) olapi.Provider {
 	return olretriever.NewProvider(storeProvider, support, gossipProvider,
 		olretriever.WithValidator(cb.CollectionType_COL_DCAS, dcas.Validator),
+		olretriever.WithKeyDecorator(cb.CollectionType_COL_DCAS, dcas.KeyDecorator),
 	)
 }


### PR DESCRIPTION
This change hides the fact that the CAS key is encoded in base58 when storing
to the DB. Clients can now use base64 encoded keys when storing/retrieving DCAS
data and the base58 encoding is performed internally.

closes #130

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>