### PR TITLE
docs: Update Go dependency Version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ make unit-test
 
 ## Build dependencies
 
-* Go `1.11.5`
+* Go `1.12.5`
 * Docker `18.09.x` or above
 
 # Contributing


### PR DESCRIPTION
The Go version was updated as part of PR #124 to 1.12.x. Updated ReadMe file with new Go version.

Closes #138

Signed-off-by: Rolson Quadras <rolson.quadras@securekey.com>