### PR TITLE
fix: Fix for collection config not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756 h1:JZkuLrLxXJC3RDtSV4mmdZUNNgDXx2HmUGJUbS6wwUk=
 github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20190606010932-60cd4152d74a h1:sqK266AVuCHDxPFquMTQ0B3mYgS7K2o98uUamoMOcwg=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20190606010932-60cd4152d74a/go.mod h1:oiGoyxEPMoOfCgINSH3eWmiEVzs99k27Paxs0RN3PaE=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/mod/peer/endorser/api/endorser.go
+++ b/mod/peer/endorser/api/endorser.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"github.com/hyperledger/fabric/core/ledger"
+	xgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+)
+
+// QueryExecutorProvider returns a query executor
+type QueryExecutorProvider interface {
+	NewQueryExecutor() (ledger.QueryExecutor, error)
+}
+
+// QueryExecutorProviderFactory returns a query executor provider for a given channel
+type QueryExecutorProviderFactory interface {
+	GetQueryExecutorProvider(channelID string) QueryExecutorProvider
+}
+
+// BlockPublisherProvider returns a block publisher for a given channel
+type BlockPublisherProvider interface {
+	ForChannel(channelID string) xgossipapi.BlockPublisher
+}

--- a/mod/peer/endorser/endorser.go
+++ b/mod/peer/endorser/endorser.go
@@ -7,12 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 package endorser
 
 import (
-	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/extensions/endorser/api"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	extendorser "github.com/trustbloc/fabric-peer-ext/pkg/endorser"
 )
 
-// FilterPubSimulationResults filters the public simulation results and returns the filtered results or error.
-func FilterPubSimulationResults(collConfigs map[string]*common.CollectionConfigPackage, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error) {
-	return extendorser.FilterPubSimulationResults(collConfigs, pubSimulationResults)
+// CollRWSetFilter filters out all off-ledger (including transient data) read-write sets from the simulation results
+// so that they won't be included in the block.
+type CollRWSetFilter interface {
+	Filter(channelID string, pubSimulationResults *rwset.TxReadWriteSet) (*rwset.TxReadWriteSet, error)
+}
+
+// NewCollRWSetFilter returns a new collection RW set filter
+func NewCollRWSetFilter(qepf api.QueryExecutorProviderFactory, bpp api.BlockPublisherProvider) CollRWSetFilter {
+	return extendorser.NewCollRWSetFilter(qepf, bpp)
 }

--- a/mod/peer/endorser/endorser_test.go
+++ b/mod/peer/endorser/endorser_test.go
@@ -9,14 +9,37 @@ package endorser
 import (
 	"testing"
 
-	"github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/extensions/endorser/api"
+	xgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	channelID = "testchannel"
 )
 
 func TestFilterPubSimulationResults(t *testing.T) {
+	f := NewCollRWSetFilter(&mockQueryExecutorProviderFactory{}, &mockBlockPublisherProvider{})
+	require.NotNil(t, f)
+
 	pubSimulationResults := &rwset.TxReadWriteSet{}
-	p, err := FilterPubSimulationResults(map[string]*common.CollectionConfigPackage{}, pubSimulationResults)
+	p, err := f.Filter(channelID, pubSimulationResults)
 	assert.NoError(t, err)
 	assert.Equal(t, pubSimulationResults, p)
+}
+
+type mockQueryExecutorProviderFactory struct {
+}
+
+func (m *mockQueryExecutorProviderFactory) GetQueryExecutorProvider(channelID string) api.QueryExecutorProvider {
+	return nil
+}
+
+type mockBlockPublisherProvider struct {
+}
+
+func (m *mockBlockPublisherProvider) ForChannel(channelID string) xgossipapi.BlockPublisher {
+	return nil
 }

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -200,6 +200,7 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756 h1:JZkuLrLxXJC3RDtSV4mmdZUNNgDXx2HmUGJUbS6wwUk=
 github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -11,8 +11,8 @@ git clone https://github.com/trustbloc/fabric-mod.git $GOPATH/src/github.com/hyp
 cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
-# fabric-mod (Jun 10, 2019)
-git checkout 80e53db71756ab0f848ec9aaf77865783b564002
+# fabric-mod (Jun 12, 2019)
+git checkout dc5ee1e1e6b1e301a5e88c6bd9ab6aa714b43f58
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod

--- a/test/bddtests/features/transient_data.feature
+++ b/test/bddtests/features/transient_data.feature
@@ -69,6 +69,10 @@ Feature:
     And we wait 2 seconds
     And client queries chaincode "tdata_examplecc" with args "getprivatemultiple,collection1,pvtKey1,collection2,pvtKey2,collection3,pvtKey3" on a single peer in the "peerorg1" org on the "mychannel" channel
     Then response from "tdata_examplecc" to client equal value "pvtVal1,pvtVal2,pvtVal3"
+    # Ensure that a write to one collection and read from another works (issue #158)
+    When client invokes chaincode "tdata_examplecc" with args "putprivate,collection3,keyC,valueA" on the "mychannel" channel
+    And we wait 5 seconds
+    When client invokes chaincode "tdata_examplecc" with args "putprivatemultiple,collection1,key1,value1,collection3,keyC," on the "mychannel" channel
 
     # Test Chaincode Upgrade and Cache Expiration
     #   When the chaincode is upgraded with a new policy, all caches should be refreshed


### PR DESCRIPTION
The collection config package that is assembled by the endorser removes
configs for collections in which there was no write set and therefore
the error 'config for collection [xxx] not found' results. Thes commit
removes the dependency on the collection config package and uses the
collection config retriever to manage collection configs.

closes #158

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>