### PR TITLE
refactor: Defer the creation of the CouchDB instance

### DIFF
--- a/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore_test.go
+++ b/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore_test.go
@@ -57,6 +57,19 @@ func testMain(m *testing.M) int {
 	return code
 }
 
+func TestCreateCouchInstance(t *testing.T) {
+	provider := NewDBProvider()
+	defer provider.Close()
+
+	ci, err := provider.createCouchInstance()
+	require.NoError(t, err)
+	require.NotNil(t, ci)
+
+	ci2, err := provider.createCouchInstance()
+	require.NoError(t, err)
+	require.True(t, ci == ci2)
+}
+
 func TestGetKeysFromDB(t *testing.T) {
 	provider := NewDBProvider()
 	defer provider.Close()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,8 +12,6 @@ import (
 
 	"github.com/hyperledger/fabric/core/config"
 
-	"github.com/hyperledger/fabric/core/transientstore"
-
 	"github.com/spf13/viper"
 )
 
@@ -65,7 +63,7 @@ func GetPvtDataCacheSize() int {
 
 // GetTransientDataLevelDBPath returns the filesystem path that is used to maintain the transient data level db
 func GetTransientDataLevelDBPath() string {
-	return filepath.Join(transientstore.GetTransientStorePath(), confTransientDataLeveldb)
+	return filepath.Join(filepath.Clean(config.GetPath(confPeerFileSystemPath)), confTransientDataLeveldb)
 }
 
 // GetTransientDataExpiredIntervalTime is time when background routine check expired transient data in db to cleanup.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -42,7 +42,7 @@ func TestGetTransientDataLevelDBPath(t *testing.T) {
 
 	viper.Set("peer.fileSystemPath", "/tmp123")
 
-	assert.Equal(t, "/tmp123/transientStore/transientDataLeveldb", GetTransientDataLevelDBPath())
+	assert.Equal(t, "/tmp123/transientDataLeveldb", GetTransientDataLevelDBPath())
 }
 
 func TestGetTransientDataExpiredIntervalTime(t *testing.T) {


### PR DESCRIPTION
Defer the creation of the CouchDB instance until first use. Also, don't start the purge Go routine until the first DB has been created.

closes #160

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>