### PR TITLE
feat: Add support for rich queries in off-ledger and DCAS

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756 h1:JZkuLrLxXJC3RDtSV4mmdZUNNgDXx2HmUGJUbS6wwUk=
 github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1 h1:GeocPOaMh5maA25myA/llWoQFxSS6GzPtyUZqMz8ZLA=
 github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20190606010932-60cd4152d74a h1:sqK266AVuCHDxPFquMTQ0B3mYgS7K2o98uUamoMOcwg=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20190606010932-60cd4152d74a/go.mod h1:oiGoyxEPMoOfCgINSH3eWmiEVzs99k27Paxs0RN3PaE=

--- a/pkg/collections/offledger/storeprovider/olstore.go
+++ b/pkg/collections/offledger/storeprovider/olstore.go
@@ -88,7 +88,7 @@ func (s *store) PutData(config *cb.StaticCollectionConfig, key *storeapi.Key, va
 		}
 	}
 
-	db, err := s.dbProvider.GetDB(key.Namespace, key.Collection)
+	db, err := s.dbProvider.GetDB(s.channelID, key.Collection, key.Namespace)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (s *store) persistColl(txID string, ns string, collConfigPkgs map[string]*c
 		return err
 	}
 
-	db, err := s.dbProvider.GetDB(ns, collRWSet.CollectionName)
+	db, err := s.dbProvider.GetDB(s.channelID, collRWSet.CollectionName, ns)
 	if err != nil {
 		return err
 	}

--- a/pkg/collections/offledger/storeprovider/store/api/api.go
+++ b/pkg/collections/offledger/storeprovider/store/api/api.go
@@ -15,6 +15,7 @@ type Value struct {
 	Value      []byte
 	TxID       string
 	ExpiryTime time.Time
+	Revision   string
 }
 
 // KeyValue is a struct to store a key value pair
@@ -53,8 +54,8 @@ type DB interface {
 
 // DBProvider returns the persister for the given namespace/collection
 type DBProvider interface {
-	// GetDB return the DB for the given namespace/collection
-	GetDB(ns, coll string) (DB, error)
+	// GetDB return the DB for the given channel, namespace. and collection
+	GetDB(channelID string, coll string, ns string) (DB, error)
 
 	// Close closes the DB provider
 	Close()

--- a/pkg/collections/offledger/storeprovider/store/cache/cache.go
+++ b/pkg/collections/offledger/storeprovider/store/cache/cache.go
@@ -135,7 +135,7 @@ func (c *Cache) GetMultiple(ns, coll string, keys ...string) ([]*api.Value, erro
 }
 
 func (c *Cache) load(key cacheKey) (*api.Value, *time.Duration, error) {
-	db, err := c.dbProvider.GetDB(key.namespace, key.collection)
+	db, err := c.dbProvider.GetDB(c.channelID, key.collection, key.namespace)
 	if err != nil {
 		return nil, nil, errors.WithMessage(err, "error getting database")
 	}

--- a/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore_provider.go
+++ b/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore_provider.go
@@ -20,10 +20,17 @@ import (
 )
 
 const (
-	expiryField     = "expiry"
-	expiryIndexName = "by_expiry"
-	expiryIndexDoc  = "indexExpiry"
-	expiryIndexDef  = `
+	idField            = "_id"
+	revField           = "_rev"
+	deletedField       = "_deleted"
+	txnIDField         = "~txnID"
+	expiryField        = "~expiry"
+	versionField       = "~version"
+	binaryWrapperField = "valueBytes"
+	expiryIndexName    = "by_expiry"
+	expiryIndexDoc     = "indexExpiry"
+
+	expiryIndexDef = `
 	{
 		"index": {
 			"fields": ["` + expiryField + `"]
@@ -53,8 +60,8 @@ func NewDBProvider() *CouchDBProvider {
 }
 
 //GetDB based on ns%coll
-func (p *CouchDBProvider) GetDB(ns, coll string) (api.DB, error) {
-	dbName := dbName(ns, coll)
+func (p *CouchDBProvider) GetDB(channelID string, coll string, ns string) (api.DB, error) {
+	dbName := dbName(channelID, ns, coll)
 
 	p.mutex.RLock()
 	s, ok := p.stores[dbName]
@@ -166,8 +173,8 @@ func (p *CouchDBProvider) getStores() []*dbstore {
 	return stores
 }
 
-func dbName(ns, coll string) string {
-	return fmt.Sprintf("%s$%s", ns, coll)
+func dbName(channelID, ns, coll string) string {
+	return fmt.Sprintf("%s_%s$$p%s", channelID, ns, coll)
 }
 
 // getCouchDBConfig return the couchdb config

--- a/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore_test.go
+++ b/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package couchdbstore
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -74,7 +75,7 @@ func TestGetKeysFromDB(t *testing.T) {
 	provider := NewDBProvider()
 	defer provider.Close()
 
-	db1, err := provider.GetDB(ns1, coll1)
+	db1, err := provider.GetDB("testchannel", ns1, coll1)
 	require.NoError(t, err)
 	require.NotNil(t, db1)
 
@@ -96,7 +97,7 @@ func TestGetKeysFromDB(t *testing.T) {
 	require.Equal(t, txID1, v.TxID)
 	require.Equal(t, value2, v.Value)
 
-	db2, err := provider.GetDB(ns1, coll2)
+	db2, err := provider.GetDB("testchannel", coll2, ns1)
 	require.NoError(t, err)
 	require.NotNil(t, db2)
 
@@ -130,11 +131,101 @@ func TestGetKeysFromDB(t *testing.T) {
 	require.Nil(t, v)
 }
 
+type testValue struct {
+	Field1 string
+	Field2 int
+}
+
+type invalidTestValue1 struct {
+	ID string `json:"_id"`
+}
+
+type invalidTestValue2 struct {
+	TxID string `json:"~txnID"`
+}
+
+func TestJSONValues(t *testing.T) {
+	provider := NewDBProvider()
+	defer provider.Close()
+
+	db1, err := provider.GetDB("testchannel", ns1, coll1)
+	require.NoError(t, err)
+	require.NotNil(t, db1)
+
+	t.Run("Valid JSON", func(t *testing.T) {
+		v1 := &testValue{
+			Field1: "value1",
+			Field2: 12345,
+		}
+
+		v1Bytes, err := json.Marshal(v1)
+		require.NoError(t, err)
+
+		err = db1.Put(api.NewKeyValue(key1, v1Bytes, txID1, time.Now().UTC().Add(1*time.Minute)))
+		require.NoError(t, err)
+
+		val1, err := db1.Get(key1)
+		require.NoError(t, err)
+		require.NotNil(t, val1)
+		require.Equal(t, txID1, val1.TxID)
+
+		rv1 := &testValue{}
+		err = json.Unmarshal(val1.Value, rv1)
+		require.NoError(t, err)
+		require.Equal(t, v1, rv1)
+		require.NotEmpty(t, val1.Revision)
+
+		// Update the value for key1
+		v2 := *v1
+		v2.Field1 = "new value"
+		v2Bytes, err := json.Marshal(v2)
+		require.NoError(t, err)
+
+		val1.Value = v2Bytes
+		err = db1.Put(&api.KeyValue{Key: key1, Value: val1})
+		require.NoError(t, err)
+
+		val2, err := db1.Get(key1)
+		require.NoError(t, err)
+		require.NotNil(t, val2)
+		require.Equal(t, txID1, val2.TxID)
+		require.NotEmpty(t, val2.Revision)
+		require.NotEqual(t, val1.Revision, val2.Revision)
+
+		rv2 := &testValue{}
+		err = json.Unmarshal(val2.Value, rv2)
+		require.NoError(t, err)
+		require.Equal(t, &v2, rv2)
+	})
+
+	t.Run("Invalid JSON", func(t *testing.T) {
+		v1 := &invalidTestValue1{
+			ID: "some_id",
+		}
+
+		v1Bytes, err := json.Marshal(v1)
+		require.NoError(t, err)
+
+		err = db1.Put(api.NewKeyValue(key1, v1Bytes, txID1, time.Now().UTC().Add(1*time.Minute)))
+		require.EqualError(t, err, "field [_id] is not valid for the CouchDB state database")
+
+		v2 := &invalidTestValue2{
+			TxID: "some_tx_id",
+		}
+
+		v2Bytes, err := json.Marshal(v2)
+		require.NoError(t, err)
+
+		err = db1.Put(api.NewKeyValue(key1, v2Bytes, txID1, time.Now().UTC().Add(1*time.Minute)))
+		require.EqualError(t, err, "field [~txnID] is not valid for the CouchDB state database")
+	})
+}
+
 func TestDeleteExpiredKeysFromDB(t *testing.T) {
 	provider := NewDBProvider()
 	defer provider.Close()
 
-	db, err := provider.GetDB(ns1, coll3)
+	db, err := provider.GetDB("testchannel", coll3, ns1)
 	require.NoError(t, err)
 
 	err = db.Put(

--- a/pkg/collections/offledger/storeprovider/store/leveldbstore/dbstore_provider.go
+++ b/pkg/collections/offledger/storeprovider/store/leveldbstore/dbstore_provider.go
@@ -44,7 +44,7 @@ func NewDBProvider() *LevelDBProvider {
 }
 
 // GetDB opens the db store
-func (p *LevelDBProvider) GetDB(ns, coll string) (api.DB, error) {
+func (p *LevelDBProvider) GetDB(channelID string, coll string, ns string) (api.DB, error) {
 	dbName := dbName(ns, coll)
 
 	p.mutex.RLock()

--- a/pkg/collections/offledger/storeprovider/store/leveldbstore/dbstore_test.go
+++ b/pkg/collections/offledger/storeprovider/store/leveldbstore/dbstore_test.go
@@ -38,7 +38,7 @@ func TestDeleteExpiredKeysFromDB(t *testing.T) {
 	provider := NewDBProvider()
 	defer provider.Close()
 
-	db, err := provider.GetDB(ns1, coll1)
+	db, err := provider.GetDB(ns1, "", coll1)
 	require.NoError(t, err)
 
 	err = db.Put(
@@ -66,7 +66,7 @@ func TestGetKeysFromDB(t *testing.T) {
 	provider := NewDBProvider()
 	defer provider.Close()
 
-	db1, err := provider.GetDB(ns1, coll1)
+	db1, err := provider.GetDB(ns1, "", coll1)
 	require.NoError(t, err)
 	require.NotNil(t, db1)
 
@@ -88,7 +88,7 @@ func TestGetKeysFromDB(t *testing.T) {
 	require.Equal(t, txID1, v.TxID)
 	require.Equal(t, value2, v.Value)
 
-	db2, err := provider.GetDB(ns1, coll2)
+	db2, err := provider.GetDB(ns1, "", coll2)
 	require.NoError(t, err)
 	require.NotNil(t, db2)
 

--- a/pkg/collections/offledger/storeprovider/store/mocks/mockdbprovider.go
+++ b/pkg/collections/offledger/storeprovider/store/mocks/mockdbprovider.go
@@ -56,7 +56,7 @@ func (m *DBProvider) MockDB(ns, coll string) *DB {
 }
 
 // GetDB returns a mock DB for the given namespace/collection
-func (m *DBProvider) GetDB(ns, coll string) (api.DB, error) {
+func (m *DBProvider) GetDB(channelID string, coll string, ns string) (api.DB, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/test/bddtests/features/step_definitions/offledger_steps.ts
+++ b/test/bddtests/features/step_definitions/offledger_steps.ts
@@ -16,4 +16,13 @@ defineSupportCode(function ({And, But, Given, Then, When}) {
     Given(/^variable "([^"]*)" is assigned the CAS key of value "([^"]*)"$/, function (arg1, arg2, callback) {
         callback.pending();
     });
+    Given(/^the account with ID "([^"]*)", owner "([^"]*)" and a balance of (\d+) is created and stored to variable "([^"]*)"$/, function (arg1, arg2, arg3, arg4, callback) {
+        callback.pending();
+    });
+    Given(/^the account stored in variable "([^"]*)" is updated with a balance of (\d+)$/, function (arg1, arg2, arg3, arg4, callback) {
+        callback.pending();
+    });
+    Then(/^the variable "([^"]*)" contains (\d+) accounts$/, function (arg1, callback) {
+        callback.pending();
+    });
 });

--- a/test/bddtests/fixtures/testdata/src/github.com/trustbloc/e2e_cc/META-INF/statedb/couchdb/collections/accounts/indexes/indexID.json
+++ b/test/bddtests/fixtures/testdata/src/github.com/trustbloc/e2e_cc/META-INF/statedb/couchdb/collections/accounts/indexes/indexID.json
@@ -1,0 +1,8 @@
+{
+  "index": {
+    "fields": ["id"]
+  },
+  "ddoc": "indexIDDoc",
+  "name": "indexID",
+  "type": "json"
+}

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -110,6 +110,7 @@ github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce h1:xdsDDbiBDQTKASoGE
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/hyperledger/fabric v1.4.1/go.mod h1:tGFAOCT696D3rG0Vofd2dyWYLySHlh0aQjf7Q1HAju0=
 github.com/hyperledger/fabric-amcl v0.0.0-20181230093703-5ccba6eab8d6/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=


### PR DESCRIPTION
Refactored the CouchDB store so that JSON documents are stored as first-class
fields in the Couch document. This way, the standard rich-query API,
GetPrivateDataQueryResult, may be used to retrieved data from DCAS and off-ledger
stores.

closes #155

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>