### PR TITLE
feat: Extended System Chaincodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190617203614-83c67efef785
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190619130918-b8a914a3359e
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1 h1:GeocPOaMh5
 github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-mod v0.0.0-20190617203614-83c67efef785 h1:cQhS81kWw2XC4BOL3fr9vE4SAXzIU+qlXcdhE67iCJM=
 github.com/trustbloc/fabric-mod v0.0.0-20190617203614-83c67efef785/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190619130918-b8a914a3359e h1:pvEV/+99CjK9NUIb2389BDSRcaZPGj3+xAXgWsoAX0w=
+github.com/trustbloc/fabric-mod v0.0.0-20190619130918-b8a914a3359e/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20190606010932-60cd4152d74a h1:sqK266AVuCHDxPFquMTQ0B3mYgS7K2o98uUamoMOcwg=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20190606010932-60cd4152d74a/go.mod h1:oiGoyxEPMoOfCgINSH3eWmiEVzs99k27Paxs0RN3PaE=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/mod/peer/chaincode/scc.go
+++ b/mod/peer/chaincode/scc.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"github.com/hyperledger/fabric/core/scc"
+	extscc "github.com/trustbloc/fabric-peer-ext/pkg/chaincode/scc"
+)
+
+// CreateSCC returns list of System ChainCodes provided by extensions
+func CreateSCC(providers ...interface{}) []scc.SelfDescribingSysCC {
+	return extscc.Create(providers...)
+}

--- a/mod/peer/chaincode/scc_test.go
+++ b/mod/peer/chaincode/scc_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+func TestCreateSCC(t *testing.T) {
+	require.Empty(t, CreateSCC(mocks.NewQueryExecutorProvider()))
+}

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190617203614-83c67efef785
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190619130918-b8a914a3359e
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -202,6 +202,8 @@ github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756 h1:JZkuLrLxXJ
 github.com/trustbloc/fabric-mod v0.0.0-20190611161450-80e53db71756/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-mod v0.0.0-20190612161459-dc5ee1e1e6b1/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-mod v0.0.0-20190617203614-83c67efef785/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190619130918-b8a914a3359e h1:pvEV/+99CjK9NUIb2389BDSRcaZPGj3+xAXgWsoAX0w=
+github.com/trustbloc/fabric-mod v0.0.0-20190619130918-b8a914a3359e/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20190606010932-60cd4152d74a/go.mod h1:oiGoyxEPMoOfCgINSH3eWmiEVzs99k27Paxs0RN3PaE=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/chaincode/scc/builder/sccbuilder.go
+++ b/pkg/chaincode/scc/builder/sccbuilder.go
@@ -1,0 +1,74 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package builder
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/hyperledger/fabric/core/scc"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/injectinvoker"
+)
+
+var sdSysSccType = reflect.TypeOf((*scc.SelfDescribingSysCC)(nil)).Elem()
+
+// SCCBuilder builds a slice of SelfDescribingSysCC
+type SCCBuilder struct {
+	mutex    sync.Mutex
+	creators []interface{}
+}
+
+// New returns a new SCCBuilder
+func New() *SCCBuilder {
+	return &SCCBuilder{}
+}
+
+// Add adds a new SCC creator function. The function has zero or more args
+// that define dependencies and a single return value of type scc.SelfDescribingSysCC.
+// Note: The args must all be interfaces.
+func (b *SCCBuilder) Add(creator interface{}) *SCCBuilder {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.creators = append(b.creators, creator)
+	return b
+}
+
+// Build returns a slice of SelfDescribingSysCC using the given set of providers
+func (b *SCCBuilder) Build(providers ...interface{}) ([]scc.SelfDescribingSysCC, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	invoker := injectinvoker.New(providers...)
+	descs := make([]scc.SelfDescribingSysCC, len(b.creators))
+	for i, creator := range b.creators {
+		desc, err := create(invoker, creator)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "Error creating system chaincode [%s]", reflect.TypeOf(creator))
+		}
+		descs[i] = desc
+	}
+	return descs, nil
+}
+
+func create(invoker *injectinvoker.Invoker, fctn interface{}) (scc.SelfDescribingSysCC, error) {
+	retVals, err := invoker.Invoke(fctn)
+	if err != nil {
+		return nil, err
+	}
+
+	// The function must return exactly one value, which is the SelfDescribingSysCC
+	if len(retVals) != 1 {
+		return nil, errors.New("invalid number of return values - expecting return value [scc.SelfDescribingSysCC]")
+	}
+	retVal := retVals[0]
+	if !retVal.Type().Implements(sdSysSccType) {
+		return nil, errors.New("invalid return value - expecting return value [scc.SelfDescribingSysCC]")
+	}
+	return retVal.Interface().(scc.SelfDescribingSysCC), nil
+}

--- a/pkg/chaincode/scc/builder/sccbuilder_test.go
+++ b/pkg/chaincode/scc/builder/sccbuilder_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/core/scc"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ccName1 = "cc1"
+	ccPath1 = "/scc/cc1"
+	arg1    = "arg1"
+	arg2    = "arg2"
+)
+
+func TestSCCBuilder_Build(t *testing.T) {
+	b := New().Add(creator1).Add(creator2)
+
+	sccDescs, err := b.Build(
+		&nameAndPathProviderImpl{
+			name: ccName1,
+			path: ccPath1,
+		},
+		&argsProviderImpl{
+			args: [][]byte{
+				[]byte(arg1),
+				[]byte(arg2),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(sccDescs))
+
+	sccDesc := sccDescs[0]
+	require.Equal(t, ccName1, sccDesc.Name())
+	require.Equal(t, ccPath1, sccDesc.Path())
+	require.Equal(t, 2, len(sccDesc.InitArgs()))
+	require.Equal(t, arg1, string(sccDesc.InitArgs()[0]))
+	require.Equal(t, arg2, string(sccDesc.InitArgs()[1]))
+
+	sccDesc2 := sccDescs[1]
+	require.Equal(t, ccName1, sccDesc2.Name())
+	require.Empty(t, sccDesc2.Path())
+	require.Empty(t, sccDesc2.InitArgs())
+}
+
+func TestBuilder_BuildError(t *testing.T) {
+	t.Run("Invalid number of return args -> error", func(t *testing.T) {
+		_, err := New().Add(NoRetArgs).Build(&nameAndPathProviderImpl{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid number of return values")
+	})
+
+	t.Run("Invalid return arg type -> error", func(t *testing.T) {
+		_, err := New().Add(InvalidRetArgs).Build(&nameAndPathProviderImpl{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid return value")
+	})
+
+	t.Run("Dependency not found -> error", func(t *testing.T) {
+		_, err := New().Add(UnknownProvider).Build(&nameAndPathProviderImpl{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "No provider found that satisfies interface")
+	})
+}
+
+type nameAndPathProviderImpl struct {
+	name string
+	path string
+}
+
+func (s *nameAndPathProviderImpl) GetName() string {
+	return s.name
+}
+
+func (s *nameAndPathProviderImpl) GetPath() string {
+	return s.path
+}
+
+type argsProviderImpl struct {
+	args [][]byte
+}
+
+func (s *argsProviderImpl) GetArgs() [][]byte {
+	return s.args
+}
+
+type nameProvider interface {
+	GetName() string
+}
+
+type pathProvider interface {
+	GetPath() string
+}
+
+type argsProvider interface {
+	GetArgs() [][]byte
+}
+
+type st2 interface {
+	Func4(arg int64) string
+}
+
+func creator1(np nameProvider, pp pathProvider, argsp argsProvider) scc.SelfDescribingSysCC {
+	return &sysCC{
+		name:     np.GetName(),
+		path:     pp.GetPath(),
+		initArgs: argsp.GetArgs(),
+	}
+}
+
+func creator2(np nameProvider) scc.SelfDescribingSysCC {
+	return &sysCC{
+		name: np.GetName(),
+	}
+}
+
+func NoRetArgs() {
+}
+
+func InvalidRetArgs() error {
+	return nil
+}
+
+type customProvider interface {
+	GetData(arg int) string
+}
+
+func UnknownProvider(customProvider) scc.SelfDescribingSysCC {
+	return &sysCC{}
+}
+
+type sysCC struct {
+	name              string
+	path              string
+	initArgs          [][]byte
+	chaincode         shim.Chaincode
+	invokableExternal bool
+	invokableCC2CC    bool
+	enabled           bool
+}
+
+//Unique name of the system chaincode
+func (s *sysCC) Name() string {
+	return s.name
+}
+
+//Path to the system chaincode; currently not used
+func (s *sysCC) Path() string {
+	return s.path
+}
+
+//InitArgs initialization arguments to startup the system chaincode
+func (s *sysCC) InitArgs() [][]byte {
+	return s.initArgs
+}
+
+// Chaincode returns the underlying chaincode
+func (s *sysCC) Chaincode() shim.Chaincode {
+	return s.chaincode
+}
+
+// InvokableExternal keeps track of whether
+// this system chaincode can be invoked
+// through a proposal sent to this peer
+func (s *sysCC) InvokableExternal() bool {
+	return s.invokableExternal
+}
+
+// InvokableCC2CC keeps track of whether
+// this system chaincode can be invoked
+// by way of a chaincode-to-chaincode
+// invocation
+func (s *sysCC) InvokableCC2CC() bool {
+	return s.invokableCC2CC
+}
+
+// Enabled a convenient switch to enable/disable system chaincode without
+// having to remove entry from importsysccs.go
+func (s *sysCC) Enabled() bool {
+	return s.enabled
+}

--- a/pkg/chaincode/scc/scc.go
+++ b/pkg/chaincode/scc/scc.go
@@ -1,0 +1,31 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scc
+
+import (
+	"github.com/hyperledger/fabric/core/scc"
+	"github.com/trustbloc/fabric-peer-ext/pkg/chaincode/scc/builder"
+)
+
+var sccBuilder = builder.New()
+
+type creator interface{}
+
+// Register registers a System Chaincode creator function. The system chaincode
+// will be initialized during peer startup with all of its declared dependencies.
+func Register(c creator) {
+	sccBuilder.Add(c)
+}
+
+// Create returns a list of system chain codes, initialized with the given providers.
+func Create(providers ...interface{}) []scc.SelfDescribingSysCC {
+	descs, err := sccBuilder.Build(providers...)
+	if err != nil {
+		panic(err.Error())
+	}
+	return descs
+}

--- a/pkg/chaincode/scc/scc_test.go
+++ b/pkg/chaincode/scc/scc_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scc
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/core/ledger"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/chaincode/scc/builder"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+func TestCreateSCC(t *testing.T) {
+	t.Run("No dependencies -> Success", func(t *testing.T) {
+		sccBuilder = builder.New()
+		Register(newSCCWithNoDependencies)
+
+		descs := Create()
+		require.NotNil(t, descs)
+	})
+
+	t.Run("Dependencies not satisfied -> panic", func(t *testing.T) {
+		sccBuilder = builder.New()
+		Register(newSCCWithDependencies)
+
+		require.Panics(t, func() {
+			Create()
+		})
+	})
+	t.Run("Dependencies satisfied -> Success", func(t *testing.T) {
+		sccBuilder = builder.New()
+		Register(newSCCWithDependencies)
+
+		descs := Create(mocks.NewQueryExecutorProvider())
+		require.NotNil(t, descs)
+	})
+}
+
+type testSCC struct {
+}
+
+func newSCCWithNoDependencies() *testSCC {
+	return &testSCC{}
+}
+
+type queryExecutorProvider interface {
+	GetQueryExecutorForLedger(cid string) (ledger.QueryExecutor, error)
+}
+
+func newSCCWithDependencies(qeProvider queryExecutorProvider) *testSCC {
+	return &testSCC{}
+}
+
+func (scc *testSCC) Name() string              { return "testscc" }
+func (scc *testSCC) Path() string              { return "/testpath" }
+func (scc *testSCC) InitArgs() [][]byte        { return nil }
+func (scc *testSCC) Chaincode() shim.Chaincode { return scc }
+func (scc *testSCC) InvokableExternal() bool   { return true }
+func (scc *testSCC) InvokableCC2CC() bool      { return true }
+func (scc *testSCC) Enabled() bool             { return true }
+
+func (scc *testSCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}
+
+func (scc *testSCC) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	return shim.Success(nil)
+}

--- a/pkg/common/injectinvoker/injectinvoker.go
+++ b/pkg/common/injectinvoker/injectinvoker.go
@@ -1,0 +1,89 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package injectinvoker
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/pkg/errors"
+)
+
+var logger = flogging.MustGetLogger("injectinvoker")
+
+// Invoker is a dependency injecting function invoker that calls a given function,
+// providing it with all required args.
+type Invoker struct {
+	providers []interface{}
+}
+
+// New returns a dependency injecting function invoker with the given set of providers.
+func New(providers ...interface{}) *Invoker {
+	return &Invoker{
+		providers: providers,
+	}
+}
+
+// AddProvider adds a provider to the set of providers
+func (inv *Invoker) AddProvider(provider interface{}) {
+	inv.providers = append(inv.providers, provider)
+}
+
+// Invoke calls the given function, providing it with the required providers.
+// Each of the interface arguments specified in the given function is injected with a provider
+// that implements that interface. An error is returned if no suitable provider is found for
+// any of the supplied arguments.
+// Note: All of the arguments in the provided function must be interfaces.
+func (inv *Invoker) Invoke(fctn interface{}) ([]reflect.Value, error) {
+	// Get the args required by the function
+	args, err := inv.getArgValues(fctn)
+	if err != nil {
+		return nil, err
+	}
+
+	// Invoke the function with the provider args
+	return reflect.ValueOf(fctn).Call(args), nil
+}
+
+func (inv *Invoker) getArgValues(fctn interface{}) ([]reflect.Value, error) {
+	argTypes := getArgTypes(fctn)
+	args := make([]reflect.Value, len(argTypes))
+	for i, argType := range argTypes {
+		if argType.Kind() != reflect.Interface {
+			return nil, errors.Errorf("argument [%s] is not an interface", argType)
+		}
+		p, err := inv.getProviderForType(argType)
+		if err != nil {
+			return nil, err
+		}
+		args[i] = p
+	}
+	return args, nil
+}
+
+func (inv *Invoker) getProviderForType(t reflect.Type) (reflect.Value, error) {
+	for _, d := range inv.providers {
+		pType := reflect.TypeOf(d)
+		logger.Infof("Checking if %s implements %s ...", pType, t)
+		if pType.Implements(t) {
+			logger.Infof("... %s does implement %s", pType, t)
+			return reflect.ValueOf(d), nil
+		}
+		logger.Infof("... %s does NOT implement %s", pType, t)
+	}
+	return reflect.Value{}, fmt.Errorf("No provider found that satisfies interface [%s]", t.String())
+}
+
+func getArgTypes(fctn interface{}) []reflect.Type {
+	fctnType := reflect.TypeOf(fctn)
+	args := make([]reflect.Type, fctnType.NumIn())
+	for i := 0; i < fctnType.NumIn(); i++ {
+		args[i] = fctnType.In(i)
+	}
+	return args
+}

--- a/pkg/common/injectinvoker/injectinvoker_test.go
+++ b/pkg/common/injectinvoker/injectinvoker_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package injectinvoker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ccName1 = "cc1"
+	ccPath1 = "/scc/cc1"
+	arg1    = "arg1"
+	arg2    = "arg2"
+)
+
+func TestInvoker_Invoke(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		inj := New(
+			&nameAndPathProviderImpl{
+				name: ccName1,
+				path: ccPath1,
+			},
+			&argsProviderImpl{
+				args: [][]byte{
+					[]byte(arg1),
+					[]byte(arg2),
+				},
+			},
+		)
+		retVals, err := inj.Invoke(ValidFunc)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(retVals))
+		retVal := retVals[0]
+		r, ok := retVal.Interface().(someIface)
+		require.True(t, ok)
+		require.NotNil(t, r)
+		require.Equal(t, ccName1, r.GetValue1())
+		require.Equal(t, ccPath1, r.GetValue2())
+		require.Equal(t, 2, len(r.GetValue3()))
+		require.Equal(t, arg1, string(r.GetValue3()[0]))
+		require.Equal(t, arg2, string(r.GetValue3()[1]))
+	})
+
+	t.Run("Invalid arg -> error", func(t *testing.T) {
+		inj := New(&nameAndPathProviderImpl{})
+		sccDesc, err := inj.Invoke(InvalidArg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not an interface")
+		require.Nil(t, sccDesc)
+	})
+
+	t.Run("Dependency not found -> error", func(t *testing.T) {
+		inj := New(&nameAndPathProviderImpl{})
+		sccDesc, err := inj.Invoke(InvalidProvider)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "No provider found that satisfies interface")
+		require.Nil(t, sccDesc)
+	})
+}
+
+type nameAndPathProviderImpl struct {
+	name string
+	path string
+}
+
+func (s *nameAndPathProviderImpl) GetValue1() string {
+	return s.name
+}
+
+func (s *nameAndPathProviderImpl) GetValue2() string {
+	return s.path
+}
+
+type argsProviderImpl struct {
+	args [][]byte
+}
+
+func (s *argsProviderImpl) GetValue3() [][]byte {
+	return s.args
+}
+
+type nameProvider interface {
+	GetValue1() string
+}
+
+type pathProvider interface {
+	GetValue2() string
+}
+
+type argsProvider interface {
+	GetValue3() [][]byte
+}
+
+func ValidFunc(np nameProvider, pp pathProvider, argsp argsProvider) someIface {
+	return &someImpl{
+		name:     np.GetValue1(),
+		path:     pp.GetValue2(),
+		initArgs: argsp.GetValue3(),
+	}
+}
+
+type customProvider interface {
+	GetData(arg int) string
+}
+
+type someIface interface {
+	GetValue1() string
+	GetValue2() string
+	GetValue3() [][]byte
+}
+
+func InvalidProvider(customProvider) someIface {
+	return &someImpl{}
+}
+
+func InvalidArg(string) someIface {
+	return &someImpl{}
+}
+
+type someImpl struct {
+	name     string
+	path     string
+	initArgs [][]byte
+}
+
+func (s *someImpl) GetValue1() string {
+	return s.name
+}
+
+func (s *someImpl) GetValue2() string {
+	return s.path
+}
+
+func (s *someImpl) GetValue3() [][]byte {
+	return s.initArgs
+}

--- a/pkg/mocks/mockqueryexecutor.go
+++ b/pkg/mocks/mockqueryexecutor.go
@@ -171,3 +171,17 @@ func queryResultsKey(namespace, query string) string {
 func privateQueryResultsKey(namespace, coll, query string) string {
 	return privateNamespace(namespace, coll) + "~" + query
 }
+
+// QueryExecutorProvider is a mock query executor provider
+type QueryExecutorProvider struct {
+}
+
+// NewQueryExecutorProvider returns a mock query executor provider
+func NewQueryExecutorProvider() *QueryExecutorProvider {
+	return &QueryExecutorProvider{}
+}
+
+// GetQueryExecutorForLedger returns the query executor for the given channel ID
+func (m *QueryExecutorProvider) GetQueryExecutorForLedger(channelID string) (ledger.QueryExecutor, error) {
+	return NewQueryExecutor(), nil
+}

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -11,8 +11,8 @@ git clone https://github.com/trustbloc/fabric-mod.git $GOPATH/src/github.com/hyp
 cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
-# fabric-mod (Jun 12, 2019)
-git checkout 83c67efef785a9b90608e003315edb70602144ac
+# fabric-mod (Jun 19, 2019)
+git checkout b8a914a3359ee9a937c801f815f18f3cf61f9ade
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod


### PR DESCRIPTION
Allow extensions to register custom system chaincodes. The system chaincode should be provided with all required dependencies, e.g. ledger, gossip, etc.

closes #171

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>