### PR TITLE
feat: bddtests to use couchdb cluster

### DIFF
--- a/test/bddtests/fixtures/config/sdk-client/config.yaml
+++ b/test/bddtests/fixtures/config/sdk-client/config.yaml
@@ -96,35 +96,46 @@ client:
         path: ${GOPATH}/src/github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/client.crt
 
 channels:
+  _default:
+    policies:
+      discovery:
+        maxTargets: 3
+        retryOpts:
+          attempts: 4
+          initialBackoff: 500ms
+          maxBackoff: 5s
+          backoffFactor: 2.0
+
   # name of the channel
+  #TODO channel.eventSource is set to false for endorser peers temporarily, will be enabled once event delivery issue with endorsers are resolved
   mychannel:
     orderers:
       - orderer.example.com
     # Required. list of peers from participating orgs
     peers:
       peer0.org1.example.com:
-        endorsingPeer: true
+        endorsingPeer: false
         chaincodeQuery: true
-        ledgerQuery: true
+        ledgerQuery: false
         eventSource: true
 
       peer1.org1.example.com:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: true
+        eventSource: false
 
       peer0.org2.example.com:
-        endorsingPeer: true
+        endorsingPeer: false
         chaincodeQuery: true
-        ledgerQuery: true
+        ledgerQuery: false
         eventSource: true
 
       peer1.org2.example.com:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: true
+        eventSource: false
 
   yourchannel:
     orderers:
@@ -141,7 +152,7 @@ channels:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: true
+        eventSource: false
 
       peer0.org2.example.com:
         endorsingPeer: true
@@ -153,7 +164,7 @@ channels:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: true
+        eventSource: false
 
 
 orderers:

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -75,7 +75,10 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer0-org1.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org1.couchdb.com:5984
+      - CORE_LEDGER_ROLES=committer
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=true
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -90,6 +93,9 @@ services:
     depends_on:
       - builder
       - orderer.example.com
+      - org1.couchdb.com
+#    logging:
+#      driver: none
   peer1.org1.example.com:
     container_name: peer1.org1.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -128,7 +134,11 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer1-org1.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org1.couchdb.com:5984
+      - CORE_LEDGER_ROLES=endorser
+      - CORE_PEER_GOSSIP_PVTDATA_RECONCILIATIONENABLED=false
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=false
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -143,6 +153,8 @@ services:
     depends_on:
       - builder
       - orderer.example.com
+      - org1.couchdb.com
+
 
   peer0.org2.example.com:
     container_name: peer0.org2.example.com
@@ -181,7 +193,10 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer0-org2.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org2.couchdb.com:5984
+      - CORE_LEDGER_ROLES=committer
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=true
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -195,6 +210,9 @@ services:
     depends_on:
       - builder
       - orderer.example.com
+      - org2.couchdb.com
+#    logging:
+#      driver: none
   peer1.org2.example.com:
     container_name: peer1.org2.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -233,7 +251,11 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer1-org2.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org2.couchdb.com:5984
+      - CORE_LEDGER_ROLES=endorser
+      - CORE_PEER_GOSSIP_PVTDATA_RECONCILIATIONENABLED=false
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=false
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -247,9 +269,12 @@ services:
     depends_on:
       - builder
       - orderer.example.com
+      - org2.couchdb.com
+#    logging:
+#      driver: none
 
-  peer0-org1.couchdb:
-    container_name: peer0-org1.couchdb
+  org1.couchdb.com:
+    container_name: org1.couchdb.com
     image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
     ports:
       - 5984:5984
@@ -260,20 +285,8 @@ services:
     volumes:
       - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
-  peer1-org1.couchdb:
-    container_name: peer1-org1.couchdb
-    image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
-    ports:
-      - 5985:5984
-    environment:
-      - DB_URL=http://localhost:5984/member_db
-      - COUCHDB_USER=cdbadmin
-      - COUCHDB_PASSWORD=secret
-    volumes:
-      - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
-
-  peer0-org2.couchdb:
-    container_name: peer0-org2.couchdb
+  org2.couchdb.com:
+    container_name: org2.couchdb.com
     image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
     ports:
       - 5986:5984
@@ -284,17 +297,6 @@ services:
     volumes:
       - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
-  peer1-org2.couchdb:
-    container_name: peer1-org2.couchdb
-    image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
-    ports:
-      - 5987:5984
-    environment:
-      - DB_URL=http://localhost:5984/member_db
-      - COUCHDB_USER=cdbadmin
-      - COUCHDB_PASSWORD=secret
-    volumes:
-      - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
  # builder is only here to create a dependency on the image (not used as part of compose)
   builder:


### PR DESCRIPTION
- each org will use same couchdb for block, private data, config history
and transient storage
- each peers will have specific roles - ENDORSER or COMMITTER
- in bdd tests client config, event source for endorserer peers are
disabled since endorser are still having issues with event delivery
-related #141 
Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>