### PR TITLE
feat: pvtdata reconciller for committer and checkpoint block in blockstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,9 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457 h1:jSbBmrzEAGQjIzn67KqiZAbo2bPgBsxH/2JgqBt/vX4=
 github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190704190346-af352517c4b2/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a h1:YiPeNIhYoXaW6w9PhqEiLxSZeAZyp/EuPy+jd87Zs8I=
+github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -198,8 +198,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457 h1:jSbBmrzEAGQjIzn67KqiZAbo2bPgBsxH/2JgqBt/vX4=
-github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a h1:YiPeNIhYoXaW6w9PhqEiLxSZeAZyp/EuPy+jd87Zs8I=
+github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/gossip/service/service.go
+++ b/mod/peer/gossip/service/service.go
@@ -23,3 +23,8 @@ func HandleGossip(handle func(msg *gossip.GossipMessage)) func(msg *gossip.Gossi
 		logger.Debugf("Gossip from service adaptor skipped for non-endorsers")
 	}
 }
+
+//IsPvtDataReconcilerEnabled can be used to override private data reconciller enable/disable
+func IsPvtDataReconcilerEnabled(isEnabled bool) bool {
+	return roles.IsCommitter() && isEnabled
+}

--- a/mod/peer/gossip/service/service_test.go
+++ b/mod/peer/gossip/service/service_test.go
@@ -63,3 +63,31 @@ func TestHandleGossipByEndorser(t *testing.T) {
 		t.Fatal("handler supposed to be executed for endorser")
 	}
 }
+
+func TestIsPvtDataReconcilerEnabledByCommitter(t *testing.T) {
+
+	//make sure roles is committer not endorser
+	if roles.IsEndorser() {
+		rolesValue := make(map[roles.Role]struct{})
+		rolesValue[roles.CommitterRole] = struct{}{}
+		roles.SetRoles(rolesValue)
+		defer func() { roles.SetRoles(nil) }()
+	}
+
+	require.True(t, IsPvtDataReconcilerEnabled(true))
+	require.False(t, IsPvtDataReconcilerEnabled(false))
+}
+
+func TestIsPvtDataReconcilerEnabledByEndorser(t *testing.T) {
+
+	//make sure roles is endorser not committer
+	if roles.IsCommitter() {
+		rolesValue := make(map[roles.Role]struct{})
+		rolesValue[roles.EndorserRole] = struct{}{}
+		roles.SetRoles(rolesValue)
+		defer func() { roles.SetRoles(nil) }()
+	}
+
+	require.False(t, IsPvtDataReconcilerEnabled(true))
+	require.False(t, IsPvtDataReconcilerEnabled(false))
+}

--- a/mod/peer/gossip/state/state_test.go
+++ b/mod/peer/gossip/state/state_test.go
@@ -43,7 +43,7 @@ func TestProviderExtension(t *testing.T) {
 		return sampleError
 	}
 
-	extension := NewGossipStateProviderExtension("test", nil, &api.Support{})
+	extension := NewGossipStateProviderExtension("test", nil, &api.Support{}, false)
 
 	//test extension.AddPayload
 	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(nil, false))
@@ -114,10 +114,10 @@ func TestProviderByEndorser(t *testing.T) {
 
 	extension := NewGossipStateProviderExtension("test", nil, &api.Support{
 		Ledger: &mockPeerLedger{&mocks.Ledger{}},
-	})
+	}, false)
 
 	//test extension.AddPayload
-	require.Nil(t, extension.AddPayload(handleAddPayload)(nil, false))
+	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(nil, false))
 
 	//test extension.StoreBlock
 	require.Nil(t, extension.StoreBlock(handleStoreBlock)(nil, util.PvtDataCollections{}))
@@ -165,7 +165,7 @@ func TestPredicate(t *testing.T) {
 	predicate := func(peer discovery.NetworkMember) bool {
 		return true
 	}
-	extension := NewGossipStateProviderExtension("test", nil, &api.Support{})
+	extension := NewGossipStateProviderExtension("test", nil, &api.Support{}, false)
 	require.True(t, extension.Predicate(predicate)(discovery.NetworkMember{Properties: &proto.Properties{Roles: []string{"endorser"}}}))
 	require.False(t, extension.Predicate(predicate)(discovery.NetworkMember{Properties: &proto.Properties{Roles: []string{"committer"}}}))
 	require.True(t, extension.Predicate(predicate)(discovery.NetworkMember{Properties: &proto.Properties{Roles: []string{}}}))
@@ -194,7 +194,7 @@ func TestProviderByCommitter(t *testing.T) {
 		return sampleError
 	}
 
-	extension := NewGossipStateProviderExtension("test", nil, &api.Support{})
+	extension := NewGossipStateProviderExtension("test", nil, &api.Support{}, false)
 
 	//test extension.AddPayload
 	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(nil, false))

--- a/mod/peer/ledger/api/ledgerapi.go
+++ b/mod/peer/ledger/api/ledgerapi.go
@@ -1,0 +1,15 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import "github.com/hyperledger/fabric/protos/common"
+
+//PeerLedgerExtension is an extension to PeerLedger interface which can be used to extend existing peer ledger features.
+type PeerLedgerExtension interface {
+	//CheckpointBlock updates check point info in underlying store
+	CheckpointBlock(block *common.Block) error
+}

--- a/mod/peer/ledger/kvledger.go
+++ b/mod/peer/ledger/kvledger.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ledger
+
+import (
+	"github.com/hyperledger/fabric/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric/extensions/ledger/api"
+	"github.com/hyperledger/fabric/protos/common"
+)
+
+//NewKVLedgerExtension returns peer ledger extension implementation using block store provided
+func NewKVLedgerExtension(store blkstorage.BlockStore) api.PeerLedgerExtension {
+	return &kvLedger{store}
+}
+
+//kvLedger is implementation of Peer Ledger extension
+type kvLedger struct {
+	blockStore blkstorage.BlockStore
+}
+
+// CheckpointBlock updates checkpoint info of underlying blockstore with given block
+func (l *kvLedger) CheckpointBlock(block *common.Block) error {
+	return l.blockStore.CheckpointBlock(block)
+}

--- a/mod/peer/ledger/kvledger_test.go
+++ b/mod/peer/ledger/kvledger_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ledger
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hyperledger/fabric/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric/protos/common"
+	"github.com/stretchr/testify/require"
+)
+
+const errMsg = "not implemented"
+
+func TestKVLedgerExtension(t *testing.T) {
+	xtn := NewKVLedgerExtension(&mockBlockStore{})
+	require.NotNil(t, xtn)
+	require.Error(t, xtn.CheckpointBlock(nil), errMsg)
+}
+
+type mockBlockStore struct {
+	blkstorage.BlockStore
+}
+
+func (mbs *mockBlockStore) CheckpointBlock(block *common.Block) error {
+	return errors.New(errMsg)
+}

--- a/mod/peer/storage/blkstorage/api/blkstorageapi.go
+++ b/mod/peer/storage/blkstorage/api/blkstorageapi.go
@@ -1,0 +1,17 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blkstorage
+
+import (
+	"github.com/hyperledger/fabric/protos/common"
+)
+
+//BlockStoreExtension is an extension to blkstorage.BlockStore interface which can be used to extend existing block store features.
+type BlockStoreExtension interface {
+	//CheckpointBlock updates checkpoint info of blockstore with given block
+	CheckpointBlock(block *common.Block) error
+}

--- a/pkg/blkstorage/cdbblkstorage/cdb_blockstorage_test.go
+++ b/pkg/blkstorage/cdbblkstorage/cdb_blockstorage_test.go
@@ -1,7 +1,15 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package cdbblkstorage
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric/common/ledger/testutil"
 	"github.com/stretchr/testify/assert"
@@ -22,4 +30,34 @@ func TestWrongBlockNumber(t *testing.T) {
 	}
 	err := store.AddBlock(blocks[4])
 	assert.Error(t, err, "Error should have been thrown when adding block number 4 while block number 3 is expected")
+}
+
+func TestCheckpointBlock(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.Cleanup()
+
+	provider := env.provider
+	store, _ := provider.OpenBlockStore("testLedger-2")
+	defer store.Shutdown()
+
+	blocks := testutil.ConstructTestBlocks(t, 1)
+	err := store.CheckpointBlock(blocks[0])
+	assert.NoError(t, err)
+	assert.Equal(t, blocks[0].Header.Number, store.(*cdbBlockStore).cpInfo.lastBlockNumber)
+
+}
+
+func TestCheckpointBlockFailure(t *testing.T) {
+	env := newTestEnv(t)
+	defer env.Cleanup()
+
+	provider := env.provider
+	store, _ := provider.OpenBlockStore("testLedger-2")
+	defer store.Shutdown()
+
+	blocks := testutil.ConstructTestBlocks(t, 1)
+
+	store.(*cdbBlockStore).cp.db.DBName = ""
+	err := store.CheckpointBlock(blocks[0])
+	require.Error(t, err, "adding cpInfo to couchDB failed")
 }

--- a/pkg/mocks/mockledger.go
+++ b/pkg/mocks/mockledger.go
@@ -105,3 +105,8 @@ func (m *Ledger) CommitPvtDataOfOldBlocks(blockPvtData []*ledger2.BlockPvtData) 
 func (m *Ledger) GetMissingPvtDataTracker() (ledger2.MissingPvtDataTracker, error) {
 	panic("not implemented")
 }
+
+//CheckpointBlock updates checkpoint info to given block
+func (m *Ledger) CheckpointBlock(block *common.Block) error {
+	panic("not implemented")
+}

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -11,8 +11,8 @@ git clone https://github.com/trustbloc/fabric-mod.git $GOPATH/src/github.com/hyp
 cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
-# fabric-mod (Jun 25, 2019)
-git checkout af971efb8457e0d45519e8c7baf9205e3502f4a8
+# fabric-mod (July 9, 2019)
+git checkout ec45e50f7e8a0c2b570c302066ac698f7c1f1a6e
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod

--- a/test/bddtests/fixtures/config/sdk-client/config.yaml
+++ b/test/bddtests/fixtures/config/sdk-client/config.yaml
@@ -96,46 +96,35 @@ client:
         path: ${GOPATH}/src/github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/client.crt
 
 channels:
-  _default:
-    policies:
-      discovery:
-        maxTargets: 3
-        retryOpts:
-          attempts: 4
-          initialBackoff: 500ms
-          maxBackoff: 5s
-          backoffFactor: 2.0
-
   # name of the channel
-  #TODO channel.eventSource is set to false for endorser peers temporarily, will be enabled once event delivery issue with endorsers are resolved
   mychannel:
     orderers:
       - orderer.example.com
     # Required. list of peers from participating orgs
     peers:
       peer0.org1.example.com:
-        endorsingPeer: false
+        endorsingPeer: true
         chaincodeQuery: true
-        ledgerQuery: false
+        ledgerQuery: true
         eventSource: true
 
       peer1.org1.example.com:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: false
+        eventSource: true
 
       peer0.org2.example.com:
-        endorsingPeer: false
+        endorsingPeer: true
         chaincodeQuery: true
-        ledgerQuery: false
+        ledgerQuery: true
         eventSource: true
 
       peer1.org2.example.com:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: false
+        eventSource: true
 
   yourchannel:
     orderers:
@@ -152,7 +141,7 @@ channels:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: false
+        eventSource: true
 
       peer0.org2.example.com:
         endorsingPeer: true
@@ -164,7 +153,7 @@ channels:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
-        eventSource: false
+        eventSource: true
 
 
 orderers:

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -34,10 +34,10 @@ services:
     ports:
       - 7050:7050
     volumes:
-        - ./fabric/channel:/etc/hyperledger/configtx
-        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/etc/hyperledger/msp/orderer
-        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/etc/hyperledger/tls/orderer
-        - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/ca.crt:/etc/hyperledger/mutual_tls/orderer/ca.crt
+      - ./fabric/channel:/etc/hyperledger/configtx
+      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/etc/hyperledger/msp/orderer
+      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/etc/hyperledger/tls/orderer
+      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/ca.crt:/etc/hyperledger/mutual_tls/orderer/ca.crt
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -75,27 +75,21 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org1.couchdb.com:5984
-      - CORE_LEDGER_ROLES=committer
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
-      - CORE_PEER_GOSSIP_ORGLEADER=true
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer0-org1.couchdb:5984
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
       - 7051:7051
     volumes:
-        - /var/run/:/host/var/run/
-        - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
-        - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
-        # Give Snap the orderer CA
-        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-        - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
+      - /var/run/:/host/var/run/
+      - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
+      - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
+      # Give Snap the orderer CA
+      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
+      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
     depends_on:
       - builder
       - orderer.example.com
-      - org1.couchdb.com
-#    logging:
-#      driver: none
   peer1.org1.example.com:
     container_name: peer1.org1.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -134,11 +128,7 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org1.couchdb.com:5984
-      - CORE_LEDGER_ROLES=endorser
-      - CORE_PEER_GOSSIP_PVTDATA_RECONCILIATIONENABLED=false
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
-      - CORE_PEER_GOSSIP_ORGLEADER=false
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer1-org1.couchdb:5984
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -153,8 +143,6 @@ services:
     depends_on:
       - builder
       - orderer.example.com
-      - org1.couchdb.com
-
 
   peer0.org2.example.com:
     container_name: peer0.org2.example.com
@@ -193,10 +181,7 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org2.couchdb.com:5984
-      - CORE_LEDGER_ROLES=committer
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
-      - CORE_PEER_GOSSIP_ORGLEADER=true
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer0-org2.couchdb:5984
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -210,9 +195,6 @@ services:
     depends_on:
       - builder
       - orderer.example.com
-      - org2.couchdb.com
-#    logging:
-#      driver: none
   peer1.org2.example.com:
     container_name: peer1.org2.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -251,11 +233,7 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org2.couchdb.com:5984
-      - CORE_LEDGER_ROLES=endorser
-      - CORE_PEER_GOSSIP_PVTDATA_RECONCILIATIONENABLED=false
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
-      - CORE_PEER_GOSSIP_ORGLEADER=false
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer1-org2.couchdb:5984
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -269,12 +247,9 @@ services:
     depends_on:
       - builder
       - orderer.example.com
-      - org2.couchdb.com
-#    logging:
-#      driver: none
 
-  org1.couchdb.com:
-    container_name: org1.couchdb.com
+  peer0-org1.couchdb:
+    container_name: peer0-org1.couchdb
     image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
     ports:
       - 5984:5984
@@ -285,8 +260,20 @@ services:
     volumes:
       - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
-  org2.couchdb.com:
-    container_name: org2.couchdb.com
+  peer1-org1.couchdb:
+    container_name: peer1-org1.couchdb
+    image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
+    ports:
+      - 5985:5984
+    environment:
+      - DB_URL=http://localhost:5984/member_db
+      - COUCHDB_USER=cdbadmin
+      - COUCHDB_PASSWORD=secret
+    volumes:
+      - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
+
+  peer0-org2.couchdb:
+    container_name: peer0-org2.couchdb
     image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
     ports:
       - 5986:5984
@@ -297,7 +284,18 @@ services:
     volumes:
       - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
+  peer1-org2.couchdb:
+    container_name: peer1-org2.couchdb
+    image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
+    ports:
+      - 5987:5984
+    environment:
+      - DB_URL=http://localhost:5984/member_db
+      - COUCHDB_USER=cdbadmin
+      - COUCHDB_PASSWORD=secret
+    volumes:
+      - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
- # builder is only here to create a dependency on the image (not used as part of compose)
+  # builder is only here to create a dependency on the image (not used as part of compose)
   builder:
     image: ${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:latest


### PR DESCRIPTION
- added new extension function which can be used to extend private data
reconciler flag
- using blocking mode from gossip state in gossip state extensions
- added Checkpoint block feature in couchdb blockstore

related to #141

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>