### PR TITLE
feat: CC upgrade Handler in statedb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -209,11 +209,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457 h1:jSbBmrzEAGQjIzn67KqiZAbo2bPgBsxH/2JgqBt/vX4=
-github.com/trustbloc/fabric-mod v0.0.0-20190702181614-af971efb8457/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
-github.com/trustbloc/fabric-mod v0.0.0-20190704190346-af352517c4b2/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
-github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a h1:YiPeNIhYoXaW6w9PhqEiLxSZeAZyp/EuPy+jd87Zs8I=
-github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9 h1:WgJUZxe2Wcm0DHgKD1xYKh1lTKqNXMWC9ZOYPiktjQM=
+github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -198,8 +198,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a h1:YiPeNIhYoXaW6w9PhqEiLxSZeAZyp/EuPy+jd87Zs8I=
-github.com/trustbloc/fabric-mod v0.0.0-20190709140030-ec45e50f7e8a/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9 h1:WgJUZxe2Wcm0DHgKD1xYKh1lTKqNXMWC9ZOYPiktjQM=
+github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/gossip/blockpublisher/blockpublisher.go
+++ b/mod/peer/gossip/blockpublisher/blockpublisher.go
@@ -7,10 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 package blockpublisher
 
 import (
+	"sync"
+
 	extblockpublisher "github.com/trustbloc/fabric-peer-ext/pkg/gossip/blockpublisher"
 )
 
-// NewProvider returns a new block publisher provider
-func NewProvider() *extblockpublisher.Provider {
-	return extblockpublisher.NewProvider()
+var blockPublisherProvider *extblockpublisher.Provider
+var once sync.Once
+
+// GetProvider returns block publisher provider
+func GetProvider() *extblockpublisher.Provider {
+	once.Do(func() {
+		blockPublisherProvider = extblockpublisher.NewProvider()
+	})
+	return blockPublisherProvider
 }

--- a/mod/peer/gossip/blockpublisher/blockpublisher_test.go
+++ b/mod/peer/gossip/blockpublisher/blockpublisher_test.go
@@ -35,7 +35,7 @@ func TestProvider(t *testing.T) {
 		}
 	)
 
-	p := NewProvider()
+	p := GetProvider()
 	require.NotNil(t, p)
 
 	publisher := p.ForChannel(channelID)

--- a/mod/peer/storage/statedb/statedb.go
+++ b/mod/peer/storage/statedb/statedb.go
@@ -1,0 +1,20 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statedb
+
+import (
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	"github.com/hyperledger/fabric/extensions/gossip/blockpublisher"
+	"github.com/hyperledger/fabric/extensions/roles"
+)
+
+//AddCCUpgradeHandler adds chaincode upgrade handler to blockpublisher
+func AddCCUpgradeHandler(chainName string, handler gossipapi.ChaincodeUpgradeHandler) {
+	if !roles.IsCommitter() {
+		blockpublisher.GetProvider().ForChannel(chainName).AddCCUpgradeHandler(handler)
+	}
+}

--- a/mod/peer/storage/statedb/statedb_test.go
+++ b/mod/peer/storage/statedb/statedb_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package statedb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+
+	"github.com/hyperledger/fabric/extensions/gossip/blockpublisher"
+
+	"github.com/golang/protobuf/proto"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+const (
+	lsccID       = "lscc"
+	upgradeEvent = "upgrade"
+
+	txID = "tx123"
+	ccID = "cc123"
+
+	channelID = "sample-chain-name"
+)
+
+func TestAddCCUpgradeHandlerAsEndorser(t *testing.T) {
+	//make sure roles is endorser not committer
+	if roles.IsCommitter() {
+		rolesValue := make(map[roles.Role]struct{})
+		rolesValue[roles.EndorserRole] = struct{}{}
+		roles.SetRoles(rolesValue)
+		defer func() { roles.SetRoles(nil) }()
+	}
+
+	handler3 := mocks.NewMockBlockHandler()
+	AddCCUpgradeHandler(channelID, handler3.HandleChaincodeUpgradeEvent)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+
+	lceBytes, err := proto.Marshal(&pb.LifecycleEvent{ChaincodeName: ccID})
+	require.NoError(t, err)
+	require.NotNil(t, lceBytes)
+
+	b.Transaction(txID, pb.TxValidationCode_VALID).
+		ChaincodeAction(lsccID).
+		ChaincodeEvent(upgradeEvent, lceBytes)
+
+	blockpublisher.GetProvider().ForChannel(channelID).Publish(b.Build())
+
+	// Wait a bit for the events to be published
+	time.Sleep(500 * time.Millisecond)
+	require.Equal(t, 1, handler3.NumCCUpgradeEvents())
+}
+
+func TestAddCCUpgradeHandlerAsCommitter(t *testing.T) {
+
+	//make sure roles is committer not endorser
+	if roles.IsEndorser() {
+		rolesValue := make(map[roles.Role]struct{})
+		rolesValue[roles.CommitterRole] = struct{}{}
+		roles.SetRoles(rolesValue)
+		defer func() { roles.SetRoles(nil) }()
+	}
+
+	handler3 := mocks.NewMockBlockHandler()
+	AddCCUpgradeHandler(channelID, handler3.HandleChaincodeUpgradeEvent)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+
+	lceBytes, err := proto.Marshal(&pb.LifecycleEvent{ChaincodeName: ccID})
+	require.NoError(t, err)
+	require.NotNil(t, lceBytes)
+
+	b.Transaction(txID, pb.TxValidationCode_VALID).
+		ChaincodeAction(lsccID).
+		ChaincodeEvent(upgradeEvent, lceBytes)
+
+	blockpublisher.GetProvider().ForChannel(channelID).Publish(b.Build())
+
+	// Wait a bit for the events to be published
+	time.Sleep(500 * time.Millisecond)
+	//cc upgrade event will not get published
+	require.Equal(t, 0, handler3.NumCCUpgradeEvents())
+
+}

--- a/pkg/collections/client/client.go
+++ b/pkg/collections/client/client.go
@@ -10,6 +10,8 @@ import (
 	"encoding/hex"
 	"sync"
 
+	"github.com/hyperledger/fabric/extensions/gossip/blockpublisher"
+
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/common/crypto"
@@ -273,7 +275,7 @@ var getLedger = func(channelID string) PeerLedger {
 
 // getLedger returns the peer ledger. This var may be overridden in unit tests
 var getBlockPublisher = func(channelID string) gossipapi.BlockPublisher {
-	return peer.BlockPublisher.ForChannel(channelID)
+	return blockpublisher.GetProvider().ForChannel(channelID)
 }
 
 // getGossipAdapter returns the gossip adapter. This var may be overridden in unit tests

--- a/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
+++ b/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
@@ -78,6 +78,7 @@ func testMain(m *testing.M) int {
 	flogging.ActivateSpec("couchdb=debug")
 
 	viper.Set("coll.offledger.cleanupExpired.Interval", "500ms")
+	viper.Set("coll.offledger.cache.enable", "true")
 
 	//run the tests
 	code := m.Run()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,8 @@ const (
 	confOLCollLeveldb              = "offLedgerLeveldb"
 	confOLCollCleanupIntervalTime  = "coll.offledger.cleanupExpired.Interval"
 	confOLCollMaxPeersForRetrieval = "coll.offledger.maxpeers"
-	confOLCollCacheSize            = "coll.offledger.cacheSize"
+	confOLCollCacheEnabled         = "coll.offledger.cache.enable"
+	confOLCollCacheSize            = "coll.offledger.cache.size"
 	confOLCollPullTimeout          = "coll.offledger.gossip.pullTimeout"
 
 	confBlockPublisherBufferSize = "blockpublisher.buffersize"
@@ -133,6 +134,12 @@ func GetOLCollCacheSize() int {
 		return defaultOLCollCacheSize
 	}
 	return size
+}
+
+// GetOLCollCacheEnabled returns if off-ledger cache is enabled
+func GetOLCollCacheEnabled() bool {
+	enabled := viper.GetBool(confOLCollCacheEnabled)
+	return enabled
 }
 
 // GetOLCollPullTimeout is the amount of time a peer waits for a response from another peer for transient data.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -98,6 +98,19 @@ func TestGetOLCacheSize(t *testing.T) {
 	assert.Equal(t, 10, GetOLCollCacheSize())
 }
 
+func TestGetOLCacheEnabled(t *testing.T) {
+	oldVal := viper.Get(confOLCollCacheEnabled)
+	defer viper.Set(confOLCollCacheEnabled, oldVal)
+
+	assert.False(t, GetOLCollCacheEnabled())
+
+	viper.Set(confOLCollCacheEnabled, true)
+	assert.True(t, GetOLCollCacheEnabled())
+
+	viper.Set(confOLCollCacheEnabled, false)
+	assert.False(t, GetOLCollCacheEnabled())
+}
+
 func TestGetTransientDataPullTimeout(t *testing.T) {
 	oldVal := viper.Get(confTransientDataPullTimeout)
 	defer viper.Set(confTransientDataPullTimeout, oldVal)

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -11,8 +11,8 @@ git clone https://github.com/trustbloc/fabric-mod.git $GOPATH/src/github.com/hyp
 cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
-# fabric-mod (July 9, 2019)
-git checkout ec45e50f7e8a0c2b570c302066ac698f7c1f1a6e
+# fabric-mod (July 12, 2019)
+git checkout 29cb9ff43ce9d43b8a0b6f620e444e3ca104cfe1
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod

--- a/test/bddtests/features/off_ledger.feature
+++ b/test/bddtests/features/off_ledger.feature
@@ -12,7 +12,7 @@ Feature: off-ledger
     Given the channel "mychannel" is created and all peers have joined
     And the channel "yourchannel" is created and all peers have joined
 
-    And off-ledger collection config "ol_coll1" is defined for collection "collection1" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=5s
+    And off-ledger collection config "ol_coll1" is defined for collection "collection1" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=10s
     And DCAS collection config "dcas_coll2" is defined for collection "collection2" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=10m
     And collection config "coll3" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and blocksToLive=10
     And DCAS collection config "dcas_accounts" is defined for collection "accounts" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=3, and timeToLive=30m
@@ -66,7 +66,7 @@ Feature: off-ledger
     When client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on the "mychannel" channel
     Then response from "ol_examplecc" to client equal value "value2"
 
-    # Delete the data on one peer - should be deleted from both peers
+    # Delete the data on one peer - should be deleted from both peers (TODO: need to be tested with cache enabled)
     When client queries chaincode "ol_examplecc" with args "delprivate,collection2,${key2}" on a single peer in the "peerorg1" org on the "mychannel" channel
     And client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on a single peer in the "peerorg1" org on the "mychannel" channel
     Then response from "ol_examplecc" to client equal value ""

--- a/test/bddtests/fixtures/config/sdk-client/config.yaml
+++ b/test/bddtests/fixtures/config/sdk-client/config.yaml
@@ -96,6 +96,15 @@ client:
         path: ${GOPATH}/src/github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/client.crt
 
 channels:
+  _default:
+    queryChannelConfig:
+      minResponses: 1
+      maxTargets: 1
+      retryOpts:
+        attempts: 5
+        initialBackoff: 500ms
+        maxBackoff: 5s
+        backoffFactor: 2.0
   # name of the channel
   mychannel:
     orderers:

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -34,10 +34,10 @@ services:
     ports:
       - 7050:7050
     volumes:
-      - ./fabric/channel:/etc/hyperledger/configtx
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/etc/hyperledger/msp/orderer
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/etc/hyperledger/tls/orderer
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/ca.crt:/etc/hyperledger/mutual_tls/orderer/ca.crt
+        - ./fabric/channel:/etc/hyperledger/configtx
+        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/etc/hyperledger/msp/orderer
+        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/etc/hyperledger/tls/orderer
+        - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/ca.crt:/etc/hyperledger/mutual_tls/orderer/ca.crt
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -75,21 +75,27 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer0-org1.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org1.couchdb.com:5984
+      - CORE_LEDGER_ROLES=committer
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=true
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
       - 7051:7051
     volumes:
-      - /var/run/:/host/var/run/
-      - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
-      - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
-      # Give Snap the orderer CA
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
+        - /var/run/:/host/var/run/
+        - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
+        - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
+        # Give Snap the orderer CA
+        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
+        - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
     depends_on:
       - builder
       - orderer.example.com
+      - org1.couchdb.com
+#    logging:
+#      driver: none
   peer1.org1.example.com:
     container_name: peer1.org1.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -128,7 +134,10 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer1-org1.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org1.couchdb.com:5984
+      - CORE_LEDGER_ROLES=endorser
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=false
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -143,6 +152,8 @@ services:
     depends_on:
       - builder
       - orderer.example.com
+      - org1.couchdb.com
+
 
   peer0.org2.example.com:
     container_name: peer0.org2.example.com
@@ -181,7 +192,10 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer0-org2.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org2.couchdb.com:5984
+      - CORE_LEDGER_ROLES=committer
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=true
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -195,6 +209,9 @@ services:
     depends_on:
       - builder
       - orderer.example.com
+      - org2.couchdb.com
+#    logging:
+#      driver: none
   peer1.org2.example.com:
     container_name: peer1.org2.example.com
     image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
@@ -233,7 +250,10 @@ services:
       - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
       - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
       - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=peer1-org2.couchdb:5984
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=org2.couchdb.com:5984
+      - CORE_LEDGER_ROLES=endorser
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+      - CORE_PEER_GOSSIP_ORGLEADER=false
     working_dir: /opt/gopath/src/github.com/hyperledger/fabric
     tty: true
     ports:
@@ -247,9 +267,12 @@ services:
     depends_on:
       - builder
       - orderer.example.com
+      - org2.couchdb.com
+#    logging:
+#      driver: none
 
-  peer0-org1.couchdb:
-    container_name: peer0-org1.couchdb
+  org1.couchdb.com:
+    container_name: org1.couchdb.com
     image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
     ports:
       - 5984:5984
@@ -260,20 +283,8 @@ services:
     volumes:
       - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
-  peer1-org1.couchdb:
-    container_name: peer1-org1.couchdb
-    image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
-    ports:
-      - 5985:5984
-    environment:
-      - DB_URL=http://localhost:5984/member_db
-      - COUCHDB_USER=cdbadmin
-      - COUCHDB_PASSWORD=secret
-    volumes:
-      - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
-
-  peer0-org2.couchdb:
-    container_name: peer0-org2.couchdb
+  org2.couchdb.com:
+    container_name: org2.couchdb.com
     image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
     ports:
       - 5986:5984
@@ -284,18 +295,7 @@ services:
     volumes:
       - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
-  peer1-org2.couchdb:
-    container_name: peer1-org2.couchdb
-    image: ${COUCHDB_FIXTURE_IMAGE}:${COUCHDB_FIXTURE_TAG}
-    ports:
-      - 5987:5984
-    environment:
-      - DB_URL=http://localhost:5984/member_db
-      - COUCHDB_USER=cdbadmin
-      - COUCHDB_PASSWORD=secret
-    volumes:
-      - ${COMPOSE_DIR}/config/couchDB/config.ini:/opt/couchdb/etc/local.d/config.ini
 
-  # builder is only here to create a dependency on the image (not used as part of compose)
+ # builder is only here to create a dependency on the image (not used as part of compose)
   builder:
     image: ${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:latest


### PR DESCRIPTION
- added CC upgrade hanlder in statedb which will be used to update lscc
state cache whenever CC upgrade takes place in case of endorsers
- re -enabled roles in bddtests docker
- related to #141

Signed-off-by: sudesh.shetty <sudesh.shetty@securekey.com>