### PR TITLE
fix: Use base64-encoded keys in DCAS client API

### DIFF
--- a/pkg/collections/offledger/dcas/cas.go
+++ b/pkg/collections/offledger/dcas/cas.go
@@ -16,13 +16,24 @@ import (
 
 // GetCASKeyAndValue first normalizes the content (i.e. if the content is a JSON doc then the fields
 // are marshaled in a deterministic order) and returns the content-addressable key
-// (encoded in base58 so that it may be used as a key in Fabric) along with the normalized value.
+// (encoded in base64) along with the normalized value.
 func GetCASKeyAndValue(content []byte) (string, []byte, error) {
 	bytes, err := getNormalizedContent(content)
 	if err != nil {
 		return "", nil, err
 	}
-	return getCASKey(bytes), bytes, nil
+	return string(getCASKey(bytes)), bytes, nil
+}
+
+// GetCASKeyAndValueBase58 first normalizes the content (i.e. if the content is a JSON doc then the fields
+// are marshaled in a deterministic order) and returns the content-addressable key
+// (first encoded in base64 and then in base58) along with the normalized value.
+func GetCASKeyAndValueBase58(content []byte) (string, []byte, error) {
+	bytes, err := getNormalizedContent(content)
+	if err != nil {
+		return "", nil, err
+	}
+	return base58.Encode(getCASKey(bytes)), bytes, nil
 }
 
 // getNormalizedContent ensures that, if the content is a JSON doc, then the fields are marshaled in a deterministic order
@@ -52,11 +63,11 @@ func getHash(bytes []byte) []byte {
 	return h.Sum(nil)
 }
 
-func getCASKey(content []byte) string {
+func getCASKey(content []byte) []byte {
 	hash := getHash(content)
 	buf := make([]byte, base64.URLEncoding.EncodedLen(len(hash)))
 	base64.URLEncoding.Encode(buf, hash)
-	return base58.Encode(buf)
+	return buf
 }
 
 // marshalJSONMap marshals a JSON map. This variable may be overridden by unit tests.

--- a/pkg/collections/offledger/dcas/cas_test.go
+++ b/pkg/collections/offledger/dcas/cas_test.go
@@ -10,16 +10,24 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetCASKeyAndValue(t *testing.T) {
 	t.Run("Binary value", func(t *testing.T) {
-		k, v, err := GetCASKeyAndValue([]byte("value1"))
+		v1 := []byte("value1")
+		k64, v, err := GetCASKeyAndValue(v1)
 		require.NoError(t, err)
-		assert.NotNil(t, k)
-		assert.NotNil(t, v)
+		assert.NotNil(t, k64)
+		assert.Equal(t, v1, v)
+
+		k58, v, err := GetCASKeyAndValueBase58(v1)
+		require.NoError(t, err)
+		require.NotNil(t, k58)
+		require.Equal(t, v1, v)
+		require.Equal(t, k64, string(base58.Decode(k58)))
 	})
 
 	t.Run("JSON value", func(t *testing.T) {
@@ -35,6 +43,12 @@ func TestGetCASKeyAndValue(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, k1, k2)
 		assert.Equal(t, v1, v2)
+
+		k1_58, v3, err := GetCASKeyAndValueBase58(value1)
+		require.NoError(t, err)
+		require.NotNil(t, k1_58)
+		require.Equal(t, v1, v3)
+		require.Equal(t, k1, string(base58.Decode(k1_58)))
 	})
 
 	t.Run("Marshal error", func(t *testing.T) {
@@ -46,6 +60,9 @@ func TestGetCASKeyAndValue(t *testing.T) {
 		defer reset()
 
 		_, _, err := GetCASKeyAndValue(value1)
+		require.Error(t, err)
+
+		_, _, err = GetCASKeyAndValueBase58(value1)
 		require.Error(t, err)
 	})
 }

--- a/pkg/collections/offledger/dcas/client/dcasclient.go
+++ b/pkg/collections/offledger/dcas/client/dcasclient.go
@@ -7,6 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package dcasclient
 
 import (
+	"github.com/btcsuite/btcutil/base58"
+	commonledger "github.com/hyperledger/fabric/common/ledger"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	olclient "github.com/trustbloc/fabric-peer-ext/pkg/collections/client"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas"
 )
@@ -43,7 +46,7 @@ func (d *DCASClient) PutMultipleValues(ns, coll string, values [][]byte) ([]stri
 		}
 		keys[i] = key
 		kvs[i] = &olclient.KeyValue{
-			Key:   key,
+			Key:   base58.Encode([]byte(key)), // Encode the key in base58 before saving to Fabric
 			Value: bytes,
 		}
 	}
@@ -51,4 +54,66 @@ func (d *DCASClient) PutMultipleValues(ns, coll string, values [][]byte) ([]stri
 		return nil, err
 	}
 	return keys, nil
+}
+
+// Delete deletes the given key(s). The key(s) must be the base64-encoded hash of the value.
+func (d *DCASClient) Delete(ns, coll string, keys ...string) error {
+	base58Keys := make([]string, len(keys))
+	for i, key := range keys {
+		base58Keys[i] = base58.Encode([]byte(key))
+	}
+	return d.Client.Delete(ns, coll, base58Keys...)
+}
+
+// Get retrieves the value for the given key. The key must be the base64-encoded hash of the value.
+func (d *DCASClient) Get(ns, coll, key string) ([]byte, error) {
+	return d.Client.Get(ns, coll, base58.Encode([]byte(key)))
+}
+
+// GetMultipleKeys retrieves the values for the given keys. The key(s) must be the base64-encoded hash of the value.
+func (d *DCASClient) GetMultipleKeys(ns, coll string, keys ...string) ([][]byte, error) {
+	base58Keys := make([]string, len(keys))
+	for i, key := range keys {
+		base58Keys[i] = base58.Encode([]byte(key))
+	}
+	return d.Client.GetMultipleKeys(ns, coll, base58Keys...)
+}
+
+// Query executes the given query and returns an iterator that contains results.
+// Only used for state databases that support query.
+// (Note that this function is not supported by transient data collections)
+// The returned ResultsIterator contains results of type *KV which is defined in protos/ledger/queryresult.
+func (d *DCASClient) Query(ns, coll, query string) (commonledger.ResultsIterator, error) {
+	it, err := d.Client.Query(ns, coll, query)
+	if err != nil {
+		return nil, err
+	}
+	return &decodingResultsIterator{
+		target: it,
+	}, nil
+}
+
+type decodingResultsIterator struct {
+	target commonledger.ResultsIterator
+}
+
+// Next returns the next item in the result set. The key is base58-decoded before it is returned.
+func (it *decodingResultsIterator) Next() (commonledger.QueryResult, error) {
+	qr, err := it.target.Next()
+	if err != nil {
+		return nil, err
+	}
+	if qr == nil {
+		return nil, nil
+	}
+
+	kv := qr.(*statedb.VersionedKV)
+	dkv := *kv
+	dkv.Key = string(base58.Decode(kv.Key))
+	return &dkv, nil
+}
+
+// Close releases resources occupied by the iterator
+func (it *decodingResultsIterator) Close() {
+	it.target.Close()
 }

--- a/pkg/collections/offledger/dcas/dcas.go
+++ b/pkg/collections/offledger/dcas/dcas.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package dcas
 
 import (
+	"github.com/btcsuite/btcutil/base58"
 	"github.com/hyperledger/fabric/common/flogging"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	"github.com/pkg/errors"
@@ -48,7 +49,7 @@ func validateCASKey(key string, value []byte) error {
 		return errors.Errorf("attempt to put nil value for key [%s]", key)
 	}
 
-	casKey := getCASKey(value)
+	casKey := base58.Encode(getCASKey(value))
 	logger.Debugf("Validating key [%s] against value [%s]", key, value)
 	if key != casKey {
 		return errors.Errorf("invalid CAS key - the key should be the hash of the value [%s]", casKey)

--- a/pkg/collections/offledger/dcas/dcas_test.go
+++ b/pkg/collections/offledger/dcas/dcas_test.go
@@ -9,6 +9,7 @@ package dcas
 import (
 	"testing"
 
+	"github.com/btcsuite/btcutil/base58"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ func TestValidator(t *testing.T) {
 	value := []byte("value1")
 
 	t.Run("Valid key/value -> success", func(t *testing.T) {
-		err := Validator("", "", "", getCASKey(value), value)
+		err := Validator("", "", "", base58.Encode(getCASKey(value)), value)
 		assert.NoError(t, err)
 	})
 
@@ -48,7 +49,7 @@ func TestDecorator_BeforeSave(t *testing.T) {
 	}
 
 	t.Run("CAS key -> success", func(t *testing.T) {
-		key := storeapi.NewKey(txID1, ns1, coll1, getCASKey(value1_1))
+		key := storeapi.NewKey(txID1, ns1, coll1, base58.Encode(getCASKey(value1_1)))
 		k, v, err := Decorator.BeforeSave(key, value)
 		require.NoError(t, err)
 		assert.Equal(t, key.Key, k.Key)
@@ -83,7 +84,7 @@ func TestDecorator_BeforeLoad(t *testing.T) {
 	value1_1 := []byte("value1_1")
 
 	t.Run("CAS key -> success", func(t *testing.T) {
-		key := storeapi.NewKey(txID1, ns1, coll1, getCASKey(value1_1))
+		key := storeapi.NewKey(txID1, ns1, coll1, base58.Encode(getCASKey(value1_1)))
 		k, err := Decorator.BeforeLoad(key)
 		require.NoError(t, err)
 		assert.Equal(t, key.Key, k.Key)
@@ -97,7 +98,7 @@ func TestDecorator_AfterQuery(t *testing.T) {
 	}
 
 	t.Run("CAS key -> success", func(t *testing.T) {
-		key := storeapi.NewKey(txID1, ns1, coll1, getCASKey(value1_1))
+		key := storeapi.NewKey(txID1, ns1, coll1, base58.Encode(getCASKey(value1_1)))
 		k, v, err := Decorator.AfterQuery(key, value)
 		require.NoError(t, err)
 		assert.Equal(t, key.Key, k.Key)

--- a/pkg/collections/offledger/dissemination/disseminationplan.go
+++ b/pkg/collections/offledger/dissemination/disseminationplan.go
@@ -87,7 +87,7 @@ func validateAll(collType cb.CollectionType, kvRWSet *kvrwset.KVRWSet) error {
 
 func validate(collType cb.CollectionType, ws *kvrwset.KVWrite) error {
 	if collType == cb.CollectionType_COL_DCAS && ws.Value != nil {
-		expectedKey, _, err := dcas.GetCASKeyAndValue(ws.Value)
+		expectedKey, _, err := dcas.GetCASKeyAndValueBase58(ws.Value)
 		if err != nil {
 			return err
 		}

--- a/pkg/collections/offledger/dissemination/disseminator_test.go
+++ b/pkg/collections/offledger/dissemination/disseminator_test.go
@@ -252,9 +252,9 @@ func TestComputeDisseminationPlan(t *testing.T) {
 	})
 
 	t.Run("Valid CAS Key", func(t *testing.T) {
-		key1, value1, err := dcas.GetCASKeyAndValue([]byte("value1"))
+		key1, value1, err := dcas.GetCASKeyAndValueBase58([]byte("value1"))
 		require.NoError(t, err)
-		key2, _, err := dcas.GetCASKeyAndValue([]byte("value2"))
+		key2, _, err := dcas.GetCASKeyAndValueBase58([]byte("value2"))
 		require.NoError(t, err)
 		rwSet := mocks.NewPvtReadWriteSetCollectionBuilder(coll1).
 			Write(key1, value1).
@@ -285,7 +285,7 @@ func TestComputeDisseminationPlan(t *testing.T) {
 	})
 
 	t.Run("Marshal error", func(t *testing.T) {
-		key1, value1, err := dcas.GetCASKeyAndValue([]byte(`{"field1":"value1"}`))
+		key1, value1, err := dcas.GetCASKeyAndValueBase58([]byte(`{"field1":"value1"}`))
 		require.NoError(t, err)
 		rwSet := mocks.NewPvtReadWriteSetCollectionBuilder(coll1).
 			Write(key1, value1).
@@ -305,7 +305,7 @@ func TestComputeDisseminationPlan(t *testing.T) {
 	})
 
 	t.Run("Unmarshal error", func(t *testing.T) {
-		key1, value1, err := dcas.GetCASKeyAndValue([]byte(`{"field1":"value1"}`))
+		key1, value1, err := dcas.GetCASKeyAndValueBase58([]byte(`{"field1":"value1"}`))
 		require.NoError(t, err)
 		rwSet := mocks.NewPvtReadWriteSetCollectionBuilder(coll1).
 			Write(key1, value1).

--- a/pkg/collections/offledger/retriever/olretriever_test.go
+++ b/pkg/collections/offledger/retriever/olretriever_test.go
@@ -113,7 +113,7 @@ func TestRetriever(t *testing.T) {
 		Member(org3MSPID, mocks.NewMember(p2Org3Endpoint, p2Org3PKIID, committerRole)).
 		Member(org3MSPID, mocks.NewMember(p3Org3Endpoint, p3Org3PKIID, endorserRole))
 
-	casKey1, casValue1, err := dcas.GetCASKeyAndValue([]byte(`{"id":"id1","value":"value1"}`))
+	casKey1, casValue1, err := dcas.GetCASKeyAndValueBase58([]byte(`{"id":"id1","value":"value1"}`))
 	require.NoError(t, err)
 
 	localStore := spmocks.NewStore().
@@ -301,9 +301,9 @@ func TestRetriever(t *testing.T) {
 }
 
 func TestRetriever_Query(t *testing.T) {
-	keyX, valueX, err := dcas.GetCASKeyAndValue([]byte(`{"id":"id3","value":"valueX"}`))
+	keyX, valueX, err := dcas.GetCASKeyAndValueBase58([]byte(`{"id":"id3","value":"valueX"}`))
 	require.NoError(t, err)
-	keyY, valueY, err := dcas.GetCASKeyAndValue([]byte(`{"id":"id4","value":"valueY"}`))
+	keyY, valueY, err := dcas.GetCASKeyAndValueBase58([]byte(`{"id":"id4","value":"valueY"}`))
 	require.NoError(t, err)
 
 	offLedgerQueryKey := storeapi.NewQueryKey(txID, ns1, coll1, "off-ledger query")

--- a/pkg/collections/offledger/storeprovider/olstore_test.go
+++ b/pkg/collections/offledger/storeprovider/olstore_test.go
@@ -218,10 +218,10 @@ func TestStore_PutAndGet_DCAS(t *testing.T) {
 	})
 
 	t.Run("GetData -> success", func(t *testing.T) {
-		casKey1, value1, err := dcas.GetCASKeyAndValue(value1_1)
+		casKey1, value1, err := dcas.GetCASKeyAndValueBase58(value1_1)
 		require.NoError(t, err)
 
-		casKey2, value2, err := dcas.GetCASKeyAndValue(value1_2)
+		casKey2, value2, err := dcas.GetCASKeyAndValueBase58(value1_2)
 		require.NoError(t, err)
 
 		b := mocks.NewPvtReadWriteSetBuilder()
@@ -246,7 +246,7 @@ func TestStore_PutAndGet_DCAS(t *testing.T) {
 	})
 
 	t.Run("Delete data", func(t *testing.T) {
-		casKey1, value1, err := dcas.GetCASKeyAndValue(value1_1)
+		casKey1, value1, err := dcas.GetCASKeyAndValueBase58(value1_1)
 		require.NoError(t, err)
 
 		b := mocks.NewPvtReadWriteSetBuilder()


### PR DESCRIPTION
Update the DCAS client to use only base64-encoded keys. The DCAS client encodes the key in base58 before storing it and decodes the key from base58 before returning the key to the caller.

closes #200

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>