### PR TITLE
feat: Add LSCC write events to BlockPublisher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9 h1:WgJUZxe2Wcm0DHgKD1xYKh1lTKqNXMWC9ZOYPiktjQM=
-github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b h1:OU0x44qAbe40hZbcn6PTQT7TvzIshOkeYDKBz0njAQA=
+github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -198,8 +198,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9 h1:WgJUZxe2Wcm0DHgKD1xYKh1lTKqNXMWC9ZOYPiktjQM=
-github.com/trustbloc/fabric-mod v0.0.0-20190712185837-29cb9ff43ce9/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b h1:OU0x44qAbe40hZbcn6PTQT7TvzIshOkeYDKBz0njAQA=
+github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/gossip/api/gossipapi.go
+++ b/mod/peer/gossip/api/gossipapi.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
+	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/core/ledger"
 	cb "github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
@@ -28,6 +29,9 @@ type ChaincodeEventHandler func(txMetadata TxMetadata, event *pb.ChaincodeEvent)
 // ChaincodeUpgradeHandler handles chaincode upgrade events
 type ChaincodeUpgradeHandler func(txMetadata TxMetadata, chaincodeName string) error
 
+// LSCCWriteHandler handles chaincode instantiation/upgrade events
+type LSCCWriteHandler func(txMetadata TxMetadata, chaincodeName string, ccData *ccprovider.ChaincodeData, ccp *cb.CollectionConfigPackage) error
+
 // BlockPublisher allows clients to add handlers for various block events
 type BlockPublisher interface {
 	// AddCCUpgradeHandler adds a handler for chaincode upgrades
@@ -38,6 +42,8 @@ type BlockPublisher interface {
 	AddWriteHandler(handler WriteHandler)
 	// AddReadHandler adds a handler for KV reads
 	AddReadHandler(handler ReadHandler)
+	// AddLSCCWriteHandler adds a handler for LSCC writes (for chaincode instantiate/upgrade)
+	AddLSCCWriteHandler(handler LSCCWriteHandler)
 	// AddCCEventHandler adds a handler for chaincode events
 	AddCCEventHandler(handler ChaincodeEventHandler)
 	// Publish traverses the block and invokes all applicable handlers

--- a/mod/peer/gossip/mocks/blockpublisher.go
+++ b/mod/peer/gossip/mocks/blockpublisher.go
@@ -35,6 +35,11 @@ func (m *BlockPublisher) AddWriteHandler(handler api.WriteHandler) {
 	// Not implemented
 }
 
+// AddLSCCWriteHandler adds a handler for KV writes
+func (m *BlockPublisher) AddLSCCWriteHandler(handler api.LSCCWriteHandler) {
+	// Not implemented
+}
+
 // AddReadHandler adds a handler for KV reads
 func (m *BlockPublisher) AddReadHandler(handler api.ReadHandler) {
 	// Not implemented

--- a/pkg/mocks/mockblockhandler.go
+++ b/pkg/mocks/mockblockhandler.go
@@ -9,6 +9,7 @@ package mocks
 import (
 	"sync/atomic"
 
+	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/extensions/gossip/api"
 	cb "github.com/hyperledger/fabric/protos/common"
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
@@ -22,6 +23,7 @@ type MockBlockHandler struct {
 	numCCEvents        int32
 	numCCUpgradeEvents int32
 	numConfigUpdates   int32
+	numLSCCWrites      int32
 	err                error
 }
 
@@ -44,6 +46,11 @@ func (m *MockBlockHandler) NumReads() int {
 // NumWrites returns the number of writes handled
 func (m *MockBlockHandler) NumWrites() int {
 	return int(atomic.LoadInt32(&m.numWrites))
+}
+
+// NumLSCCWrites returns the number of LSCC writes handled
+func (m *MockBlockHandler) NumLSCCWrites() int {
+	return int(atomic.LoadInt32(&m.numLSCCWrites))
 }
 
 // NumCCEvents returns the number of chaincode events handled
@@ -88,5 +95,11 @@ func (m *MockBlockHandler) HandleChaincodeUpgradeEvent(txMetadata api.TxMetadata
 // HandleConfigUpdate handles a config update by incrementing the config update counter
 func (m *MockBlockHandler) HandleConfigUpdate(blockNum uint64, configUpdate *cb.ConfigUpdate) error {
 	atomic.AddInt32(&m.numConfigUpdates, 1)
+	return m.err
+}
+
+// HandleLSCCWrite handles an LSCC write by incrementing the LSCC write counter
+func (m *MockBlockHandler) HandleLSCCWrite(txMetadata api.TxMetadata, chaincodeName string, ccData *ccprovider.ChaincodeData, ccp *cb.CollectionConfigPackage) error {
+	atomic.AddInt32(&m.numLSCCWrites, 1)
 	return m.err
 }

--- a/pkg/mocks/mockblockpublisher.go
+++ b/pkg/mocks/mockblockpublisher.go
@@ -17,6 +17,7 @@ type MockBlockPublisher struct {
 	HandleConfigUpdate gossipapi.ConfigUpdateHandler
 	HandleWrite        gossipapi.WriteHandler
 	HandleRead         gossipapi.ReadHandler
+	HandleLSCCWrite    gossipapi.LSCCWriteHandler
 	HandleCCEvent      gossipapi.ChaincodeEventHandler
 }
 
@@ -43,6 +44,11 @@ func (m *MockBlockPublisher) AddWriteHandler(handler gossipapi.WriteHandler) {
 // AddReadHandler adds a read handler
 func (m *MockBlockPublisher) AddReadHandler(handler gossipapi.ReadHandler) {
 	m.HandleRead = handler
+}
+
+// AddLSCCWriteHandler adds a write handler
+func (m *MockBlockPublisher) AddLSCCWriteHandler(handler gossipapi.LSCCWriteHandler) {
+	m.HandleLSCCWrite = handler
 }
 
 // AddCCEventHandler adds a chaincode event handler

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -11,8 +11,8 @@ git clone https://github.com/trustbloc/fabric-mod.git $GOPATH/src/github.com/hyp
 cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
-# fabric-mod (July 12, 2019)
-git checkout 29cb9ff43ce9d43b8a0b6f620e444e3ca104cfe1
+# fabric-mod (July 31, 2019)
+git checkout 7300f8108f4b1a79e0302e9dc2451d75e608b760
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod


### PR DESCRIPTION
Added the function, AddLSCCWriteHandler, to BlockPublisher so that clients can register for chaincode instantiation and upgrade events. The handler is provided the chaincode data and collection config package.

closes #203

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>