### PR TITLE
fix: Deadlock retrieving transient data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190731181607-25f5996f1299
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b h1:OU0x44qAbe40hZbcn6PTQT7TvzIshOkeYDKBz0njAQA=
-github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190731181607-25f5996f1299 h1:9hm5YHrfRRMgOdJOf/QbvEKQZFV56wRkMoF6X/P9aKM=
+github.com/trustbloc/fabric-mod v0.0.0-20190731181607-25f5996f1299/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/endorser/endorser.go
+++ b/mod/peer/endorser/endorser.go
@@ -19,6 +19,6 @@ type CollRWSetFilter interface {
 }
 
 // NewCollRWSetFilter returns a new collection RW set filter
-func NewCollRWSetFilter(qepf api.QueryExecutorProviderFactory, bpp api.BlockPublisherProvider) CollRWSetFilter {
-	return extendorser.NewCollRWSetFilter(qepf, bpp)
+func NewCollRWSetFilter(api.QueryExecutorProviderFactory, api.BlockPublisherProvider) CollRWSetFilter {
+	return extendorser.NewCollRWSetFilter()
 }

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190731181607-25f5996f1299
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -198,8 +198,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b h1:OU0x44qAbe40hZbcn6PTQT7TvzIshOkeYDKBz0njAQA=
-github.com/trustbloc/fabric-mod v0.0.0-20190731170217-7300f8108f4b/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20190731181607-25f5996f1299 h1:9hm5YHrfRRMgOdJOf/QbvEKQZFV56wRkMoF6X/P9aKM=
+github.com/trustbloc/fabric-mod v0.0.0-20190731181607-25f5996f1299/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/gossip/dispatcher/dispatcher.go
+++ b/mod/peer/gossip/dispatcher/dispatcher.go
@@ -23,7 +23,7 @@ type gossipAdapter interface {
 }
 
 type blockPublisher interface {
-	AddCCUpgradeHandler(handler gossipapi.ChaincodeUpgradeHandler)
+	AddLSCCWriteHandler(handler gossipapi.LSCCWriteHandler)
 }
 
 // New returns a new Gossip message dispatcher
@@ -33,5 +33,5 @@ func New(
 	gossipAdapter gossipAdapter,
 	ledger ledger.PeerLedger,
 	blockPublisher blockPublisher) *extdispatcher.Dispatcher {
-	return extdispatcher.New(channelID, dataStore, gossipAdapter, ledger, blockPublisher)
+	return extdispatcher.New(channelID, dataStore, gossipAdapter)
 }

--- a/pkg/collections/client/client.go
+++ b/pkg/collections/client/client.go
@@ -284,7 +284,7 @@ var getGossipAdapter = func() GossipAdapter {
 }
 
 var getCollConfigRetriever = func(channelID string, ledger PeerLedger, blockPublisher gossipapi.BlockPublisher) CollectionConfigRetriever {
-	return support.NewCollectionConfigRetriever(channelID, ledger, blockPublisher)
+	return support.CollectionConfigRetrieverForChannel(channelID)
 }
 
 var newCreator = func() ([]byte, error) {

--- a/pkg/collections/retriever/retriever.go
+++ b/pkg/collections/retriever/retriever.go
@@ -39,7 +39,7 @@ func NewProvider(
 	gossipProvider func() supportapi.GossipAdapter,
 	blockPublisherProvider func(channelID string) gossipapi.BlockPublisher) storeapi.Provider {
 
-	support := supp.New(ledgerProvider, blockPublisherProvider)
+	support := supp.New(blockPublisherProvider)
 
 	tdataStoreProvider := func(channelID string) tdataapi.Store { return storeProvider(channelID) }
 	offLedgerStoreProvider := func(channelID string) olapi.Store { return storeProvider(channelID) }

--- a/pkg/collections/transientdata/storeprovider/tdstore.go
+++ b/pkg/collections/transientdata/storeprovider/tdstore.go
@@ -113,7 +113,7 @@ func (s *store) persistKVWrite(txID, ns, coll string, w *kvrwset.KVWrite, ttl ti
 	}
 
 	if s.cache.Get(key) != nil {
-		logger.Warningf("[%s] Attempt to update transient data key [%s] in collection [%s]", s.channelID, w.Key, coll)
+		logger.Debugf("[%s] Transient data key [%s] in collection [%s] already exists", s.channelID, w.Key, coll)
 		return
 	}
 

--- a/pkg/common/support/support.go
+++ b/pkg/common/support/support.go
@@ -7,57 +7,36 @@ SPDX-License-Identifier: Apache-2.0
 package support
 
 import (
-	"github.com/bluele/gcache"
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/common/privdata"
-	"github.com/hyperledger/fabric/core/ledger"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	"github.com/hyperledger/fabric/protos/common"
 )
 
 var logger = flogging.MustGetLogger("ext_support")
 
-type ledgerProvider func(channelID string) ledger.PeerLedger
 type blockPublisherProvider func(channelID string) gossipapi.BlockPublisher
 
 // Support holds the ledger provider and the cache
 type Support struct {
-	getLedger              ledgerProvider
-	configRetrieverCache   gcache.Cache
 	blockPublisherProvider blockPublisherProvider
 }
 
 // New creates a new Support using the ledger provider
-func New(ledgerProvider ledgerProvider, blockPublisherProvider blockPublisherProvider) *Support {
-	s := &Support{
-		getLedger:              ledgerProvider,
+func New(blockPublisherProvider blockPublisherProvider) *Support {
+	return &Support{
 		blockPublisherProvider: blockPublisherProvider,
 	}
-	s.configRetrieverCache = gcache.New(0).Simple().LoaderFunc(
-		func(key interface{}) (interface{}, error) {
-			channelID := key.(string)
-			logger.Debugf("[%s] Creating collection config retriever", channelID)
-			return NewCollectionConfigRetriever(channelID, s.getLedger(channelID), blockPublisherProvider(channelID)), nil
-		}).Build()
-	return s
 }
 
 // Config returns the configuration for the given collection
 func (s *Support) Config(channelID, ns, coll string) (*common.StaticCollectionConfig, error) {
-	ccRetriever, err := s.configRetrieverCache.Get(channelID)
-	if err != nil {
-		return nil, err
-	}
-	return ccRetriever.(*CollectionConfigRetriever).Config(ns, coll)
+	return CollectionConfigRetrieverForChannel(channelID).Config(ns, coll)
 }
 
 // Policy returns the collection access policy for the given collection
 func (s *Support) Policy(channelID, ns, coll string) (privdata.CollectionAccessPolicy, error) {
-	ccRetriever, err := s.configRetrieverCache.Get(channelID)
-	if err != nil {
-		return nil, err
-	}
-	return ccRetriever.(*CollectionConfigRetriever).Policy(ns, coll)
+	return CollectionConfigRetrieverForChannel(channelID).Policy(ns, coll)
 }
 
 // BlockPublisher returns the block publisher for the given channel

--- a/pkg/common/support/support_test.go
+++ b/pkg/common/support/support_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/common/privdata"
-	"github.com/hyperledger/fabric/core/ledger"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	"github.com/hyperledger/fabric/protos/common"
 	"github.com/stretchr/testify/assert"
@@ -36,18 +35,16 @@ func TestSupport(t *testing.T) {
 	configPkgBytes, err := proto.Marshal(nsBuilder.BuildCollectionConfig())
 	require.NoError(t, err)
 
-	ledgerProvider := func(channelID string) ledger.PeerLedger {
-		return &mocks.Ledger{
-			QueryExecutor: mocks.NewQueryExecutor().WithState(lscc, privdata.BuildCollectionKVSKey(ns1), configPkgBytes),
-		}
-	}
-
 	blockPublisherProvider := func(channelID string) gossipapi.BlockPublisher {
 		return mocks.NewBlockPublisher()
 	}
 
-	s := New(ledgerProvider, blockPublisherProvider)
+	s := New(blockPublisherProvider)
 	require.NotNil(t, s)
+
+	InitCollectionConfigRetriever(channelID, &mocks.Ledger{
+		QueryExecutor: mocks.NewQueryExecutor().WithState(lscc, privdata.BuildCollectionKVSKey(ns1), configPkgBytes),
+	}, mocks.NewBlockPublisher())
 
 	t.Run("Policy", func(t *testing.T) {
 		policy, err := s.Policy(channelID, ns1, coll2)

--- a/pkg/endorser/endorser_test.go
+++ b/pkg/endorser/endorser_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/support"
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
@@ -77,10 +78,9 @@ func TestFilterPubSimulationResults(t *testing.T) {
 	require.Equal(t, 2, len(results.NsRwset[2].CollectionHashedRwset))
 	assert.Empty(t, len(results.NsRwset[2].Rwset))
 
-	f := NewCollRWSetFilter(
-		newMockQEProviderFactory(pvtBuilder.BuildCollectionConfigs()),
-		newMockBlockPublisherProvider(),
-	)
+	support.InitCollectionConfigRetriever(channelID, newMockQEProviderFactory(pvtBuilder.BuildCollectionConfigs()).GetQueryExecutorProvider(channelID), mocks.NewBlockPublisher())
+
+	f := NewCollRWSetFilter()
 
 	filteredResults, err := f.Filter(channelID, results)
 	assert.NoError(t, err)
@@ -109,10 +109,8 @@ func TestFilterPubSimulationResults_NoCollections(t *testing.T) {
 		},
 	}
 
-	f := NewCollRWSetFilter(
-		newMockQEProviderFactory(pvtBuilder.BuildCollectionConfigs()),
-		newMockBlockPublisherProvider(),
-	)
+	support.InitCollectionConfigRetriever(channelID, newMockQEProviderFactory(pvtBuilder.BuildCollectionConfigs()).GetQueryExecutorProvider(channelID), mocks.NewBlockPublisher())
+	f := NewCollRWSetFilter()
 	filteredResults, err := f.Filter(channelID, results)
 	assert.NoError(t, err)
 	assert.Equal(t, results, filteredResults)

--- a/pkg/gossip/dispatcher/dispatcher.go
+++ b/pkg/gossip/dispatcher/dispatcher.go
@@ -11,10 +11,8 @@ import (
 
 	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/common/privdata"
-	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/extensions/collections/api/store"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
-	extgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	ledgerconfig "github.com/hyperledger/fabric/extensions/roles"
 	gossipapi "github.com/hyperledger/fabric/gossip/api"
 	gcommon "github.com/hyperledger/fabric/gossip/common"
@@ -38,10 +36,6 @@ type gossipAdapter interface {
 	IdentityInfo() gossipapi.PeerIdentitySet
 }
 
-type blockPublisher interface {
-	AddCCUpgradeHandler(handler extgossipapi.ChaincodeUpgradeHandler)
-}
-
 type ccRetriever interface {
 	Config(ns, coll string) (*cb.StaticCollectionConfig, error)
 	Policy(ns, coll string) (privdata.CollectionAccessPolicy, error)
@@ -56,11 +50,9 @@ var isEndorser = func() bool {
 func New(
 	channelID string,
 	dataStore storeapi.Store,
-	gossipAdapter gossipAdapter,
-	ledger ledger.PeerLedger,
-	blockPublisher blockPublisher) *Dispatcher {
+	gossipAdapter gossipAdapter) *Dispatcher {
 	return &Dispatcher{
-		ccRetriever: supp.NewCollectionConfigRetriever(channelID, ledger, blockPublisher),
+		ccRetriever: supp.CollectionConfigRetrieverForChannel(channelID),
 		channelID:   channelID,
 		reqMgr:      requestmgr.Get(channelID),
 		dataStore:   dataStore,

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -12,7 +12,7 @@ cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
 # fabric-mod (July 31, 2019)
-git checkout 7300f8108f4b1a79e0302e9dc2451d75e608b760
+git checkout 25f5996f12991e64e365c2b5cd9655eae4c53b8a
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod


### PR DESCRIPTION
Intermittent deadlocks occur attempting to retrieve transient data. When a block is being committed, the committer attempts to acquire a write lock while the chaincode already has a read-lock. Then GetPrivateData attempts to acquire a read-lock to retrieve collection config data from the ledger. This commit adds an LSCC handler to the collection config retriever so that the collection config cache is populated directly from the data provided by the handler which eliminates the need to pull the config from the ledger.

closes #202

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>