### PR TITLE
fix: Dissemination of multiple transient data keys

### DIFF
--- a/pkg/collections/transientdata/dissemination/disseminationplan.go
+++ b/pkg/collections/transientdata/dissemination/disseminationplan.go
@@ -15,11 +15,13 @@ import (
 	gdiscovery "github.com/hyperledger/fabric/gossip/discovery"
 	"github.com/hyperledger/fabric/gossip/gossip"
 	"github.com/hyperledger/fabric/gossip/protoext"
+	"github.com/hyperledger/fabric/gossip/util"
+	cb "github.com/hyperledger/fabric/protos/common"
+	protosgossip "github.com/hyperledger/fabric/protos/gossip"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
 	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
 )
 
 type gossipAdapter interface {
@@ -44,49 +46,164 @@ func ComputeDisseminationPlan(
 		return nil, true, errors.WithMessage(err, "error unmarshalling KV read/write set for transient data")
 	}
 
-	var endorsers discovery.PeerGroup
+	keysByEndorser, err := getKeysByEndorser(ns, rwSet.CollectionName, kvRwSet, disseminator)
+	if err != nil {
+		return nil, true, err
+	}
+
+	pvtPayload := pvtDataMsg.Content.(*protosgossip.GossipMessage_PrivateData).PrivateData.Payload
+
+	// Construct one dissemination plan per endorser, which will include all keys that the endorser should store
+	var plans []*dissemination.Plan
+	for e, keys := range keysByEndorser {
+		endpoint := e
+		logger.Debugf("Keys for endorser [%s] in collection [%s:%s]: %s", endpoint, ns, rwSet.CollectionName, keys)
+
+		rwSetForKeys, err := newRWSetForKeys(ns, rwSet, keys)
+		if err != nil {
+			return nil, true, err
+		}
+
+		plan, err := computeDisseminationPlanForEndorser(channelID, e, ns, rwSetForKeys, pvtPayload, keys)
+		if err != nil {
+			return nil, true, err
+		}
+
+		logger.Debugf("Adding dissemination plan for endorser [%s] and keys [%s:%s]-%s", endpoint, ns, rwSet.CollectionName, keys)
+		plans = append(plans, plan)
+	}
+
+	logger.Debugf("Returning [%d] dissemination plan(s) for collection [%s:%s] in Tx [%s]", len(plans), ns, rwSet.CollectionName, pvtPayload.TxId)
+	return plans, true, nil
+}
+
+func getKeysByEndorser(ns, coll string, kvRwSet *kvrwset.KVRWSet, disseminator *Disseminator) (map[string][]string, error) {
+	keysByEndorser := make(map[string][]string)
 	for _, kvWrite := range kvRwSet.Writes {
 		if kvWrite.IsDelete {
 			continue
 		}
 		endorsersForKey, err := disseminator.ResolveEndorsers(kvWrite.Key)
 		if err != nil {
-			return nil, true, errors.WithMessage(err, "error resolving endorsers for transient data")
+			return nil, errors.WithMessage(err, "error resolving endorsers for transient data")
 		}
 
-		logger.Debugf("Endorsers for key [%s:%s:%s]: %s", ns, rwSet.CollectionName, kvWrite.Key, endorsersForKey)
+		logger.Debugf("Endorsers for key [%s:%s:%s]: %s", ns, coll, kvWrite.Key, endorsersForKey)
 
 		for _, endorser := range endorsersForKey {
 			if endorser.Local {
-				logger.Debugf("Not adding local endorser for key [%s:%s:%s]", ns, rwSet.CollectionName, kvWrite.Key)
+				logger.Debugf("Not adding local endorser for key [%s:%s:%s]", ns, coll, kvWrite.Key)
 				continue
 			}
-			endorsers = discovery.Merge(endorsers, endorser)
+			keysByEndorser[endorser.Endpoint] = append(keysByEndorser[endorser.Endpoint], kvWrite.Key)
 		}
 	}
+	return keysByEndorser, nil
+}
 
-	logger.Debugf("Endorsers for collection [%s:%s]: %s", ns, rwSet.CollectionName, endorsers)
+func computeDisseminationPlanForEndorser(channelID, endpoint, ns string, rwSet *rwset.CollectionPvtReadWriteSet, pvtPayload *protosgossip.PrivatePayload, keys []string) (*dissemination.Plan, error) {
+	msgForKey, err := createPrivateDataMessage(
+		channelID, pvtPayload.TxId, ns, rwSet,
+		pvtPayload.CollectionConfigs, pvtPayload.PrivateSimHeight)
+	if err != nil {
+		return nil, err
+	}
 
 	routingFilter := func(member gdiscovery.NetworkMember) bool {
-		if endorsers.ContainsPeer(member.Endpoint) {
-			logger.Debugf("Peer [%s] is an endorser for [%s:%s]", member.Endpoint, ns, rwSet.CollectionName)
+		if endpoint == member.Endpoint {
+			logger.Debugf("Peer [%s] is an endorser for key(s) [%s:%s]-%s", member.Endpoint, ns, rwSet.CollectionName, keys)
 			return true
 		}
-
-		logger.Debugf("Peer [%s] is NOT an endorser for [%s:%s]", member.Endpoint, ns, rwSet.CollectionName)
+		logger.Debugf("Peer [%s] is NOT an endorser for key(s) [%s:%s]-%s", member.Endpoint, ns, rwSet.CollectionName, keys)
 		return false
 	}
 
+	// Since we are pushing data to each endorser individually, MaxPeers and MinAck are both set to 1
 	sc := gossip.SendCriteria{
 		Timeout:    viper.GetDuration("peer.gossip.pvtData.pushAckTimeout"),
 		Channel:    common.ChainID(channelID),
-		MaxPeers:   colAP.MaximumPeerCount(),
-		MinAck:     colAP.RequiredPeerCount(),
+		MaxPeers:   1,
+		MinAck:     1,
 		IsEligible: routingFilter,
 	}
+	return &dissemination.Plan{Criteria: sc, Msg: msgForKey}, nil
+}
 
-	return []*dissemination.Plan{{
-		Criteria: sc,
-		Msg:      pvtDataMsg,
-	}}, true, nil
+func newRWSetForKeys(ns string, rwSet *rwset.CollectionPvtReadWriteSet, keys []string) (*rwset.CollectionPvtReadWriteSet, error) {
+	logger.Debugf("Creating a new collection Pvt rw-set for keys %s in collection [%s:%s]", keys, ns, rwSet.CollectionName)
+
+	kvRWSet, err := unmarshalKVRWSet(rwSet.Rwset)
+	if err != nil {
+		return nil, err
+	}
+
+	var kvWrites []*kvrwset.KVWrite
+	for _, kvWrite := range kvRWSet.Writes {
+		if containsKey(keys, kvWrite.Key) {
+			logger.Debugf("Adding KV-write for key [%s:%s:%s]", ns, rwSet.CollectionName, kvWrite.Key)
+			kvWrites = append(kvWrites, kvWrite)
+		}
+	}
+
+	rwSetBytes, err := marshalKVRWSet(&kvrwset.KVRWSet{Writes: kvWrites})
+	if err != nil {
+		return nil, err
+	}
+
+	return &rwset.CollectionPvtReadWriteSet{
+		CollectionName: rwSet.CollectionName,
+		Rwset:          rwSetBytes,
+	}, nil
+}
+
+func containsKey(keys []string, key string) bool {
+	for _, k := range keys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// unmarshalKVRWSet unmarshals the given KV rw-set bytes. This variable may be overridden by unit tests.
+var unmarshalKVRWSet = func(bytes []byte) (*kvrwset.KVRWSet, error) {
+	kvRwSet := &kvrwset.KVRWSet{}
+	err := protobuf.Unmarshal(bytes, kvRwSet)
+	if err != nil {
+		return nil, err
+	}
+	return kvRwSet, nil
+}
+
+// marshalKVRWSet marshals the given KV rw-set bytes. This variable may be overridden by unit tests.
+var marshalKVRWSet = func(rwSet *kvrwset.KVRWSet) ([]byte, error) {
+	return protobuf.Marshal(rwSet)
+}
+
+func createPrivateDataMessage(
+	channelID, txID, namespace string,
+	collRWSet *rwset.CollectionPvtReadWriteSet,
+	ccp *cb.CollectionConfigPackage, blkHt uint64) (*protoext.SignedGossipMessage, error) {
+	msg := &protosgossip.GossipMessage{
+		Channel: []byte(channelID),
+		Nonce:   util.RandomUInt64(),
+		Tag:     protosgossip.GossipMessage_CHAN_ONLY,
+		Content: &protosgossip.GossipMessage_PrivateData{
+			PrivateData: &protosgossip.PrivateDataMessage{
+				Payload: &protosgossip.PrivatePayload{
+					Namespace:         namespace,
+					CollectionName:    collRWSet.CollectionName,
+					TxId:              txID,
+					PrivateRwset:      collRWSet.Rwset,
+					PrivateSimHeight:  blkHt,
+					CollectionConfigs: ccp,
+				},
+			},
+		},
+	}
+	pvtDataMsg, err := protoext.NoopSign(msg)
+	if err != nil {
+		return nil, err
+	}
+	return pvtDataMsg, nil
 }

--- a/pkg/collections/transientdata/dissemination/disseminator.go
+++ b/pkg/collections/transientdata/dissemination/disseminator.go
@@ -46,11 +46,11 @@ func (d *Disseminator) ResolveEndorsers(key string) (discovery.PeerGroup, error)
 
 	orgs := d.chooseOrgs(h)
 
-	logger.Debugf("[%s] Chosen orgs: %s", d.ChannelID(), orgs)
+	logger.Debugf("[%s] Chosen orgs for key [%s] using hash32 [%d]: %s", d.ChannelID(), key, h, orgs)
 
 	endorsers := d.chooseEndorsers(h, orgs)
 
-	logger.Debugf("[%s] Chosen endorsers from orgs %s: %s", d.ChannelID(), orgs, endorsers)
+	logger.Debugf("[%s] Chosen endorsers for key [%s] using hash32 [%d] from orgs %s: %s", d.ChannelID(), key, h, orgs, endorsers)
 	return endorsers, nil
 }
 
@@ -71,12 +71,12 @@ func (d *Disseminator) chooseEndorsers(h uint32, orgs []string) discovery.PeerGr
 				continue
 			}
 
-			logger.Debugf("[%s] Endorsers for [%s]: %s", d.ChannelID(), org, endorsersForOrg)
+			logger.Debugf("[%s] Endorsers for [%s] using hash32 [%d]: %s", d.ChannelID(), org, h, endorsersForOrg)
 
 			// Deterministically choose an endorser
 			endorserForOrg := endorsersForOrg[(int(h)+i)%len(endorsersForOrg)]
 			if endorsers.Contains(endorserForOrg) {
-				logger.Debugf("[%s] Will not add endorser [%s] from org [%s] since it is already added", d.ChannelID(), endorserForOrg, org)
+				logger.Debugf("[%s] Will not add endorser [%s] from org [%s] using hash32 [%d] since it is already added", d.ChannelID(), endorserForOrg, org, h)
 				continue
 			}
 

--- a/test/bddtests/features/transient_data.feature
+++ b/test/bddtests/features/transient_data.feature
@@ -39,6 +39,29 @@ Feature:
     And client queries chaincode "tdata_examplecc" with args "getprivatemultiple,collection1,keyX,collection2,keyY,collection3,keyZ" on the "mychannel" channel
     Then response from "tdata_examplecc" to client equal value "valX,valY,"
 
+    # Test for put of keys on multiple transient data collections within the same endorsement.
+    When client queries chaincode "tdata_examplecc" with args "putprivatemultiple,collection2,key_0,val_0,collection2,key_1,val_1,collection2,key_2,val_2,collection2,key_3,val_3,collection2,key_4,val_4,collection2,key_5,val_5,collection2,key_6,val_6,collection2,key_7,val_7,collection2,key_8,val_8,collection2,key_9,val_9" on the "mychannel" channel
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_0" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_0"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_1" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_1"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_2" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_2"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_3" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_3"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_4" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_4"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_5" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_5"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_6" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_6"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_7" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_7"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_8" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_8"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection2,key_9" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "val_9"
+
     # Test for the case where get transient data should not return data that was stored in the current transaction.
     # When multiple peers are involved in an endorsement then one endorser may already have propagated the private
     # data to another endorser. The first endorser will think that there is no value for a given key but the second


### PR DESCRIPTION
The dissemination logic was changed in order to ensure that each endorser is disseminated all applicable keys. Initially only one dissemination plan was created for all peers and this was causing some peers to miss data since the MaxPeerCount was reached. This patch creates multiple dissemination plans - one per peer - which includes all keys applicable to the endorser.

closes #210

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>