### PR TITLE
fix: Don't store transient data on endorser if not assigned

### DIFF
--- a/pkg/collections/transientdata/storeprovider/store/cache/cache.go
+++ b/pkg/collections/transientdata/storeprovider/store/cache/cache.go
@@ -16,7 +16,7 @@ import (
 	"github.com/trustbloc/fabric-peer-ext/pkg/config"
 )
 
-var logger = flogging.MustGetLogger("memtransientdatastore")
+var logger = flogging.MustGetLogger("transientdata")
 
 // Cache is an in-memory key-value cache
 type Cache struct {
@@ -120,7 +120,7 @@ func (c *Cache) storeToDB(key, value interface{}) {
 		if !isExpired {
 			dbstoreErr := c.dbstore.AddKey(k, v)
 			if dbstoreErr != nil {
-				logger.Error(dbstoreErr.Error())
+				logger.Errorf("Key [%s] could not be offloaded to DB: %s", key, dbstoreErr.Error())
 			} else {
 				logger.Debugf("Key [%s] offloaded to DB", key)
 			}

--- a/pkg/collections/transientdata/storeprovider/store/dbstore/dbstore_test.go
+++ b/pkg/collections/transientdata/storeprovider/store/dbstore/dbstore_test.go
@@ -6,10 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 package dbstore
 
 import (
+	"errors"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/hyperledger/fabric/common/ledger/util/leveldbhelper"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/storeprovider/store/api"
@@ -94,6 +96,67 @@ func TestAddRetrieveKeysFromDB(t *testing.T) {
 
 }
 
+func TestDBStore_Error(t *testing.T) {
+	t.Run("Encode value error", func(t *testing.T) {
+		restore := encodeCacheVal
+		defer func() { encodeCacheVal = restore }()
+
+		errExpected := errors.New("encode value error")
+		encodeCacheVal = func(v *api.Value) (bytes []byte, e error) {
+			return nil, errExpected
+		}
+
+		p := NewDBProvider()
+		db, err := p.OpenDBStore("testchannel")
+		require.NoError(t, err)
+		defer p.Close()
+
+		err = db.AddKey(k1, v1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("Decode value error", func(t *testing.T) {
+		restore := decodeCacheVal
+		defer func() { decodeCacheVal = restore }()
+
+		errExpected := errors.New("decode value error")
+		decodeCacheVal = func(b []byte) (value *api.Value, e error) {
+			return nil, errExpected
+		}
+
+		p := NewDBProvider()
+		db, err := p.OpenDBStore("testchannel")
+		require.NoError(t, err)
+		defer p.Close()
+
+		err = db.AddKey(k1, v1)
+		require.NoError(t, err)
+
+		v, err := db.GetKey(k1)
+		require.Error(t, err)
+		require.Nil(t, v)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+
+	t.Run("Add error", func(t *testing.T) {
+		errExpected := errors.New("db error")
+
+		h := newMockLevelDBHandle().WithError(errExpected)
+		db := newDBStore(h, "testdb")
+		defer db.Close()
+
+		err := db.AddKey(k1, v1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+
+		v, err := db.GetKey(k1)
+		require.Error(t, err)
+		require.Nil(t, v)
+		require.Contains(t, err.Error(), errExpected.Error())
+	})
+}
+
 func TestMain(m *testing.M) {
 	removeDBPath(nil)
 	viper.Set("peer.fileSystemPath", "/tmp/fabric/ledgertests/transientdatadb")
@@ -110,4 +173,49 @@ func removePath(t testing.TB, path string) {
 	if err := os.RemoveAll(path); err != nil {
 		t.Fatalf("Err: %s", err)
 	}
+}
+
+type mockLevelDBHandle struct {
+	err error
+}
+
+func newMockLevelDBHandle() *mockLevelDBHandle {
+	return &mockLevelDBHandle{}
+}
+
+func (m *mockLevelDBHandle) WithError(err error) *mockLevelDBHandle {
+	m.err = err
+	return m
+}
+
+func (m *mockLevelDBHandle) Get(key []byte) ([]byte, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	panic("not implemented")
+}
+
+func (m *mockLevelDBHandle) Put(key []byte, value []byte, sync bool) error {
+	if m.err != nil {
+		return m.err
+	}
+	panic("not implemented")
+}
+
+func (m *mockLevelDBHandle) Delete(key []byte, sync bool) error {
+	if m.err != nil {
+		return m.err
+	}
+	panic("not implemented")
+}
+
+func (m *mockLevelDBHandle) WriteBatch(batch *leveldbhelper.UpdateBatch, sync bool) error {
+	if m.err != nil {
+		return m.err
+	}
+	panic("not implemented")
+}
+
+func (m *mockLevelDBHandle) GetIterator(startKey []byte, endKey []byte) *leveldbhelper.Iterator {
+	panic("not implemented")
 }

--- a/pkg/collections/transientdata/storeprovider/tdstore_test.go
+++ b/pkg/collections/transientdata/storeprovider/tdstore_test.go
@@ -7,14 +7,19 @@ SPDX-License-Identifier: Apache-2.0
 package storeprovider
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/hyperledger/fabric/core/common/privdata"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	gcommon "github.com/hyperledger/fabric/gossip/common"
+	"github.com/hyperledger/fabric/protos/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/storeprovider/store/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
@@ -24,6 +29,7 @@ const (
 	txID1 = "txid1"
 	txID2 = "txid2"
 	txID3 = "txid3"
+	txID4 = "txid4"
 
 	ns1 = "ns1"
 
@@ -34,7 +40,24 @@ const (
 
 	key1 = "key1"
 	key2 = "key2"
-	key3 = "key3"
+	key4 = "key4"
+	key6 = "key6"
+
+	collPolicy = "OR('Org1MSP.member','Org2MSP.member')"
+)
+
+var (
+	org1MSPID      = "Org1MSP"
+	p1Org1Endpoint = "p1.org1.com"
+	p1Org1PKIID    = gcommon.PKIidType("pkiid_P1O1")
+	p2Org1Endpoint = "p2.org1.com"
+	p2Org1PKIID    = gcommon.PKIidType("pkiid_P2O1")
+
+	org2MSPID      = "Org2MSP"
+	p1Org2Endpoint = "p1.org2.com"
+	p1Org2PKIID    = gcommon.PKIidType("pkiid_P1O2")
+	p2Org2Endpoint = "p2.org2.com"
+	p2Org2PKIID    = gcommon.PKIidType("pkiid_P2O2")
 )
 
 func TestStore(t *testing.T) {
@@ -56,9 +79,11 @@ func TestStore(t *testing.T) {
 func TestStorePutAndGet(t *testing.T) {
 	value1_1 := []byte("value1_1")
 	value1_2 := []byte("value1_2")
+	value1_4 := []byte("value1_4")
 
 	value2_1 := []byte("value2_1")
 	value3_1 := []byte("value3_1")
+	value4_1 := []byte("value4_1")
 
 	s := newStore(channelID, 1, newMockDB())
 	require.NotNil(t, s)
@@ -68,18 +93,41 @@ func TestStorePutAndGet(t *testing.T) {
 	ns1Builder := b.Namespace(ns1)
 	coll1Builder := ns1Builder.Collection(coll1)
 	coll1Builder.
-		TransientConfig("OR('Org1MSP.member')", 1, 2, "1m").
+		TransientConfig(collPolicy, 1, 2, "1m").
 		Write(key1, value1_1).
-		Write(key2, value1_2)
+		Write(key2, value1_2).
+		Write(key4, value1_4)
 	coll2Builder := ns1Builder.Collection(coll2)
 	coll2Builder.
-		TransientConfig("OR('Org1MSP.member')", 1, 2, "1m").
+		TransientConfig(collPolicy, 1, 2, "1m").
 		Write(key1, value2_1).
+		Write(key4, value4_1).
 		Delete(key2)
 	coll3Builder := ns1Builder.Collection(coll3)
 	coll3Builder.
 		StaticConfig("OR('Org1MSP.member')", 1, 2, 100).
 		Write(key1, value3_1)
+
+	p1Org1 := mocks.NewMember(p1Org1Endpoint, p1Org1PKIID)
+	p2Org1 := mocks.NewMember(p2Org1Endpoint, p2Org1PKIID)
+	p1Org2 := mocks.NewMember(p1Org2Endpoint, p1Org2PKIID)
+	p2Org2 := mocks.NewMember(p2Org2Endpoint, p2Org2PKIID)
+
+	gossip := mocks.NewMockGossipAdapter().
+		Self(org1MSPID, p1Org1).
+		Member(org1MSPID, p2Org1).
+		Member(org2MSPID, p1Org2).
+		Member(org2MSPID, p2Org2)
+
+	gossipProvider = func() gossipAdapter {
+		return gossip
+	}
+
+	// Expected endorsers:
+	// - coll1-key1: p2.org2.com, p2.org1.com
+	// - coll1-key2: p1.org1.com, p1.org2.com
+	// - coll2-key1: p2.org2.com, p2.org1.com
+	// - coll2-key2: p1.org1.com, p1.org2.com
 
 	err := s.Persist(txID1, b.Build())
 	assert.NoError(t, err)
@@ -91,15 +139,20 @@ func TestStorePutAndGet(t *testing.T) {
 	})
 
 	t.Run("GetTransientData in same transaction -> nil", func(t *testing.T) {
-		value, err := s.GetTransientData(storeapi.NewKey(txID1, ns1, coll1, key1))
-		assert.NoError(t, err)
-		assert.Nil(t, value)
+		value, err := s.GetTransientData(storeapi.NewKey(txID1, ns1, coll1, key2))
+		require.NoError(t, err)
+		require.Nil(t, value)
+
+		value, err = s.GetTransientData(storeapi.NewKey(txID2, ns1, coll1, key2))
+		require.NoError(t, err)
+		require.NotNil(t, value)
+		require.Equal(t, value1_2, value.Value)
 	})
 
 	t.Run("GetTransientData in new transaction -> valid", func(t *testing.T) {
 		value, err := s.GetTransientData(storeapi.NewKey(txID2, ns1, coll1, key1))
 		assert.NoError(t, err)
-		assert.Equal(t, value1_1, value.Value)
+		assert.Nil(t, value) // key1 should not be persisted locally since p1.org1.com is not part of the peer group for key1
 
 		value, err = s.GetTransientData(storeapi.NewKey(txID2, ns1, coll1, key2))
 		assert.NoError(t, err)
@@ -107,10 +160,15 @@ func TestStorePutAndGet(t *testing.T) {
 	})
 
 	t.Run("GetTransientData collection2 -> valid", func(t *testing.T) {
-		// Collection2
-		value, err := s.GetTransientData(storeapi.NewKey(txID2, ns1, coll2, key1))
+		// coll2-key1
+		value, err := s.GetTransientData(storeapi.NewKey(txID2, ns1, coll2, key1)) // key1 should not be persisted locally since p1.org1.com is not part of the peer group for key1
 		assert.NoError(t, err)
-		assert.Equal(t, value2_1, value.Value)
+		assert.Nil(t, value)
+
+		// coll2-key4
+		value, err = s.GetTransientData(storeapi.NewKey(txID2, ns1, coll2, key4))
+		assert.NoError(t, err)
+		assert.Equal(t, value4_1, value.Value)
 	})
 
 	t.Run("GetTransientData on non-transient collection -> nil", func(t *testing.T) {
@@ -120,25 +178,38 @@ func TestStorePutAndGet(t *testing.T) {
 	})
 
 	t.Run("GetTransientDataMultipleKeys -> valid", func(t *testing.T) {
-		values, err := s.GetTransientDataMultipleKeys(storeapi.NewMultiKey(txID2, ns1, coll1, key1, key2))
+		values, err := s.GetTransientDataMultipleKeys(storeapi.NewMultiKey(txID2, ns1, coll1, key1, key2, key4))
 		assert.NoError(t, err)
-		require.Equal(t, 2, len(values))
-		assert.Equal(t, value1_1, values[0].Value)
+		require.Equal(t, 3, len(values))
+		assert.Nil(t, values[0]) // key1 should not be persisted locally since p1.org1.com is not part of the peer group for key1
 		assert.Equal(t, value1_2, values[1].Value)
+		assert.Equal(t, value1_4, values[2].Value)
 	})
 
 	t.Run("Disallow update transient data", func(t *testing.T) {
 		b := mocks.NewPvtReadWriteSetBuilder()
-		ns1Builder := b.Namespace(ns1)
-		coll1Builder := ns1Builder.Collection(coll1)
-		coll1Builder.
-			TransientConfig("OR('Org1MSP.member')", 1, 2, "1m").
-			Write(key1, value2_1)
+		nsBuilder1 := b.Namespace(ns1)
+		collBuilder1 := nsBuilder1.Collection(coll2)
+		collBuilder1.
+			TransientConfig(collPolicy, 1, 2, "1m").
+			Write(key6, value1_1)
+		err = s.Persist(txID1, b.Build())
+		require.NoError(t, err)
 
-		err = s.Persist(txID2, b.Build())
+		value, err := s.GetTransientData(storeapi.NewKey(txID2, ns1, coll2, key6))
+		require.NoError(t, err)
+		require.Equal(t, value1_1, value.Value)
+
+		b2 := mocks.NewPvtReadWriteSetBuilder()
+		nsBuilder2 := b2.Namespace(ns1)
+		collBuilder2 := nsBuilder2.Collection(coll2)
+		collBuilder2.
+			TransientConfig(collPolicy, 1, 2, "1m").
+			Write(key6, value2_1)
+		err = s.Persist(txID3, b2.Build())
 		assert.NoError(t, err)
 
-		value, err := s.GetTransientData(storeapi.NewKey(txID3, ns1, coll1, key1))
+		value, err = s.GetTransientData(storeapi.NewKey(txID4, ns1, coll2, key6))
 		assert.NoError(t, err)
 		assert.Equalf(t, value1_1, value.Value, "expecting transient data to not have been updated")
 	})
@@ -148,38 +219,77 @@ func TestStorePutAndGet(t *testing.T) {
 		ns1Builder := b.Namespace(ns1)
 		coll1Builder := ns1Builder.Collection(coll1)
 		coll1Builder.
-			TransientConfig("OR('Org1MSP.member')", 1, 2, "10ms").
-			Write(key3, value1_1)
+			TransientConfig(collPolicy, 1, 2, "10ms").
+			Write(key6, value1_1)
 
 		err = s.Persist(txID2, b.Build())
 		assert.NoError(t, err)
 
-		value, err := s.GetTransientData(storeapi.NewKey(txID3, ns1, coll1, key3))
+		value, err := s.GetTransientData(storeapi.NewKey(txID3, ns1, coll1, key6))
 		assert.NoError(t, err)
 		assert.Equal(t, value1_1, value.Value)
 
 		time.Sleep(15 * time.Millisecond)
 
-		value, err = s.GetTransientData(storeapi.NewKey(txID3, ns1, coll1, key3))
+		value, err = s.GetTransientData(storeapi.NewKey(txID3, ns1, coll1, key6))
 		assert.NoError(t, err)
 		assert.Nilf(t, value, "expecting key to have expired")
 	})
 }
 
-func TestStoreInvalidRWSet(t *testing.T) {
+func TestStoreInvalidData(t *testing.T) {
 	s := newStore(channelID, 100, newMockDB())
 	require.NotNil(t, s)
 	defer s.Close()
 
-	b := mocks.NewPvtReadWriteSetBuilder()
-	b.Namespace(ns1).
-		Collection(coll1).
-		TransientConfig("OR('Org1MSP.member')", 1, 2, "1m").
-		Write(key1, []byte("value")).
-		WithMarshalError()
+	t.Run("Invalid RW set", func(t *testing.T) {
+		b := mocks.NewPvtReadWriteSetBuilder()
+		b.Namespace(ns1).
+			Collection(coll1).
+			TransientConfig(collPolicy, 1, 2, "1m").
+			Write(key1, []byte("value")).
+			WithMarshalError()
 
-	err := s.Persist(txID1, b.Build())
-	assert.Errorf(t, err, "expecting marshal error")
+		err := s.Persist(txID1, b.Build())
+		require.Errorf(t, err, "expecting marshal error")
+	})
+
+	t.Run("Invalid time-to-live", func(t *testing.T) {
+		b := mocks.NewPvtReadWriteSetBuilder()
+		b.Namespace(ns1).
+			Collection(coll1).
+			TransientConfig(collPolicy, 1, 2, "1xxx").
+			Write(key1, []byte("value"))
+
+		err := s.Persist(txID1, b.Build())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error parsing time-to-live for collection")
+	})
+
+	t.Run("Invalid policy", func(t *testing.T) {
+		p, err := s.loadPolicy(ns1, &common.StaticCollectionConfig{})
+		require.Error(t, err)
+		require.Nil(t, p)
+		require.Contains(t, err.Error(), "error setting up collection policy")
+	})
+
+	t.Run("Resolver error", func(t *testing.T) {
+		restore := getResolver
+		errExpected := errors.New("resolver error")
+		getResolver = func(channelID, ns, coll string, policy privdata.CollectionAccessPolicy, gossip gossipAdapter) endorserResolver {
+			return newMockResolver().WithError(errExpected)
+		}
+		defer func() { getResolver = restore }()
+
+		b := mocks.NewPvtReadWriteSetBuilder()
+		b.Namespace(ns1).
+			Collection(coll1).
+			TransientConfig(collPolicy, 1, 2, "1m").
+			Write(key1, []byte("value"))
+
+		err := s.Persist(txID1, b.Build())
+		require.EqualError(t, err, errExpected.Error())
+	})
 }
 
 type mockDB struct {
@@ -206,4 +316,24 @@ func (db *mockDB) DeleteExpiredKeys() error {
 func (db *mockDB) GetKey(key api.Key) (*api.Value, error) {
 	fmt.Printf("DB Store - Getting key [%s]\n", key)
 	return db.data[key], db.err
+}
+
+type mockResolver struct {
+	err error
+}
+
+func newMockResolver() *mockResolver {
+	return &mockResolver{}
+}
+
+func (m *mockResolver) WithError(err error) *mockResolver {
+	m.err = err
+	return m
+}
+
+func (m *mockResolver) ResolveEndorsers(key string) (discovery.PeerGroup, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	panic("not implemented")
 }


### PR DESCRIPTION
This patch adds a check during persistence of transient data to make sure that the key is assigned to the peer. If not then it is not stored locally (but still disseminated to other peers).

Also, changed the name of the loggers for all sub-packages of transientdata to be consistent in order to help in debugging.

closes #211

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>