### PR TITLE
test: Add test for collection type modification in upgrade

### DIFF
--- a/test/bddtests/features/off_ledger.feature
+++ b/test/bddtests/features/off_ledger.feature
@@ -56,7 +56,7 @@ Feature: off-ledger
     Then response from "ol_examplecc" to client equal value "value4"
 
     # Test expiry
-    Given we wait 10 seconds
+    Given we wait 15 seconds
 
     # Should have expired
     When client queries chaincode "ol_examplecc" with args "getprivate,collection1,key1" on the "mychannel" channel

--- a/test/bddtests/features/step_definitions/common_steps.js
+++ b/test/bddtests/features/step_definitions/common_steps.js
@@ -49,4 +49,7 @@ defineSupportCode(function ({And, But, Given, Then, When}) {
     Given(/^"([^"]*)" chaincode "([^"]*)" is upgraded with version "([^"]*)" from path "([^"]*)" on the "([^"]*)" channel with args "([^"]*)" with endorsement policy "([^"]*)" with collection policy "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, callback) {
         callback.pending();
     });
+    Given(/^"([^"]*)" chaincode "([^"]*)" is upgraded with version "([^"]*)" from path "([^"]*)" on the "([^"]*)" channel with args "([^"]*)" with endorsement policy "([^"]*)" with collection policy "([^"]*)" then the error response should contain "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, callback) {
+        callback.pending();
+    });
 });

--- a/test/bddtests/features/transient_data.feature
+++ b/test/bddtests/features/transient_data.feature
@@ -111,10 +111,14 @@ Feature:
     And we wait 5 seconds
     When client invokes chaincode "tdata_examplecc" with args "putprivatemultiple,collection1,key1,value1,collection3,keyC," on the "mychannel" channel
 
-    # Test Chaincode Upgrade and Cache Expiration
-    #   When the chaincode is upgraded with a new policy, all caches should be refreshed
-    #   Change the policy of collection1 so that it expires in 1m instead of 3s and
-    #   change the policy of collection2 so that it expires in 3s instead of 10m
+    # Test Chaincode Upgrade:
+    #   - Ensure collection Type cannot be changed during chaincode upgrade
+    Given transient collection config "coll3_upgrade" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=1m
+    And "test" chaincode "tdata_examplecc" version "v999" is installed from path "github.com/trustbloc/e2e_cc" to all peers
+    And "test" chaincode "tdata_examplecc" is upgraded with version "v999" from path "github.com/trustbloc/e2e_cc" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "tdata_coll1,tdata_coll2,coll3_upgrade" then the error response should contain "ENDORSEMENT_POLICY_FAILURE. Description: instantiateOrUpgradeCC failed"
+    #   - When the chaincode is upgraded with a new policy, all caches should be refreshed.
+    #     Change the policy of collection1 so that it expires in 1m instead of 3s and
+    #     change the policy of collection2 so that it expires in 3s instead of 10m
     Given transient collection config "tdata_coll1_upgrade" is defined for collection "collection1" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=1m
     And transient collection config "tdata_coll2_upgrade" is defined for collection "collection2" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=3s
     And collection config "coll3" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and blocksToLive=1000

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -13,5 +13,5 @@ require (
 	github.com/hyperledger/fabric-sdk-go/third_party/github.com/hyperledger/fabric v0.0.0-20190429134815-48bb0d199e2c
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/viper v1.0.2
-	github.com/trustbloc/fabric-peer-test-common v0.0.0-20190702155929-65e50b1c2186
+	github.com/trustbloc/fabric-peer-test-common v0.0.0-20190815213819-ecf8b72b9163
 )

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -127,6 +127,8 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/trustbloc/fabric-peer-test-common v0.0.0-20190702155929-65e50b1c2186 h1:P+Us2NxV0wupfq/8/R8ybJYnYiqXKiJswdoFX/RG/Jg=
 github.com/trustbloc/fabric-peer-test-common v0.0.0-20190702155929-65e50b1c2186/go.mod h1:WkMYVPBLYZVYmkoke8/KmwBnGxeQQTeZafbV3FVexew=
+github.com/trustbloc/fabric-peer-test-common v0.0.0-20190815213819-ecf8b72b9163 h1:+QW8/0L97V1iRKuJHjSmEU422738RxfhRcELmDkw1Jg=
+github.com/trustbloc/fabric-peer-test-common v0.0.0-20190815213819-ecf8b72b9163/go.mod h1:WkMYVPBLYZVYmkoke8/KmwBnGxeQQTeZafbV3FVexew=
 github.com/trustbloc/fabric-sdk-go-ext/fabric v0.0.0-20190528182243-b95c24511993 h1:iQH8rOUokmkMRuaXS9SwzGvJeuZ3rb1V9o6yXHjCdL4=
 github.com/trustbloc/fabric-sdk-go-ext/fabric v0.0.0-20190528182243-b95c24511993/go.mod h1:24RzLAEPTcvxFatT0GLRXZTPkvkYyiBlp8yNxEwg2ig=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=


### PR DESCRIPTION
Added a BDD test to ensure a collection's type cannot be changed during a chaincode upgrade.

closes #216

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>