### PR TITLE
feat: Ledger configuration model

### DIFF
--- a/pkg/config/ledgerconfig/config/keyvalue.go
+++ b/pkg/config/ledgerconfig/config/keyvalue.go
@@ -1,0 +1,132 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"fmt"
+)
+
+// Key is used to uniquely identify a specific application configuration and is used as the
+// key when persisting to a state store.
+type Key struct {
+	// MspID is the ID of the MSP that owns the data
+	MspID string
+	// PeerID is the (optional) ID of the peer with which the data is associated
+	PeerID string
+	// AppName is the name of the application that owns the data
+	AppName string
+	// AppVersion is the version of the application config
+	AppVersion string
+	// ComponentName is the (optional) name of the application component
+	ComponentName string
+	// ComponentVersion is the (optional) version of the application component config
+	ComponentVersion string
+}
+
+// String returns a readable string for the key
+func (k Key) String() string {
+	return fmt.Sprintf("(MSP:%s),(Peer:%s),(Apps:%s),(AppVersion:%s),(Comp:%s),(CompVersion:%s)", k.MspID, k.PeerID, k.AppName, k.AppVersion, k.ComponentName, k.ComponentVersion)
+}
+
+// NewPeerKey creates a config key using mspID, peerID, appName and appVersion
+func NewPeerKey(mspID, peerID, appName, appVersion string) *Key {
+	return &Key{
+		MspID:      mspID,
+		PeerID:     peerID,
+		AppName:    appName,
+		AppVersion: appVersion,
+	}
+}
+
+// NewPeerComponentKey creates a config key using mspID, peerID, appName, appVersion, componentName and componentVersion
+func NewPeerComponentKey(mspID, peerID, appName, appVersion, componentName, componentVersion string) *Key {
+	return &Key{
+		MspID:            mspID,
+		PeerID:           peerID,
+		AppName:          appName,
+		AppVersion:       appVersion,
+		ComponentName:    componentName,
+		ComponentVersion: componentVersion,
+	}
+}
+
+// NewAppKey creates a config key using mspID, appName and appVersion
+func NewAppKey(mspID, appName, appVersion string) *Key {
+	return &Key{
+		MspID:      mspID,
+		AppName:    appName,
+		AppVersion: appVersion,
+	}
+}
+
+// NewComponentKey creates a config key using mspID, appName, appVersion, componentName and componentVersion
+func NewComponentKey(mspID, appName, appVersion, componentName, componentVersion string) *Key {
+	return &Key{
+		MspID:            mspID,
+		AppName:          appName,
+		AppVersion:       appVersion,
+		ComponentName:    componentName,
+		ComponentVersion: componentVersion,
+	}
+}
+
+// Format specifies the format of the configuration
+type Format string
+
+const (
+	// FormatYAML indicates that the configuration is in YAML format
+	FormatYAML Format = "YAML"
+
+	// FormatJSON indicates that the configuration is in JSON format
+	FormatJSON Format = "JSON"
+
+	// FormatOther indicates that the configuration is in an application-specific format
+	FormatOther Format = "OTHER"
+)
+
+// Value contains the configuration data and is persisted as a JSON document in the store.
+type Value struct {
+	// TxID is the ID of the transaction in which the config was stored/updated
+	TxID string
+	// Format describes the format (type) of the config data
+	Format Format
+	// Config contains the actual configuration
+	Config string
+}
+
+// NewValue returns a new config Value
+func NewValue(txID string, config string, format Format) *Value {
+	return &Value{
+		TxID:   txID,
+		Config: config,
+		Format: format,
+	}
+}
+
+// String returns a readable string for the value
+func (v *Value) String() string {
+	return fmt.Sprintf("(TxID:%s),(Config:%s),(Format:%s)", v.TxID, v.Config, v.Format)
+}
+
+// KeyValue contains the key and the value for the key
+type KeyValue struct {
+	*Key
+	*Value
+}
+
+// NewKeyValue returns a new KeyValue
+func NewKeyValue(key *Key, value *Value) *KeyValue {
+	return &KeyValue{
+		Key:   key,
+		Value: value,
+	}
+}
+
+// String returns a readable string for the key-value
+func (kv *KeyValue) String() string {
+	return fmt.Sprintf("[%s]=[%s]", kv.Key, kv.Value)
+}

--- a/pkg/config/ledgerconfig/config/keyvalue_test.go
+++ b/pkg/config/ledgerconfig/config/keyvalue_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	msp1  = "org1MSP"
+	peer1 = "peer1"
+	app1  = "app1"
+	v1    = "v1"
+	comp1 = "comp1"
+	tx1   = "tx1"
+)
+
+func TestNewAppKey(t *testing.T) {
+	key := NewAppKey(msp1, app1, v1)
+	require.NotNil(t, key)
+	require.Equal(t, msp1, key.MspID)
+	require.Equal(t, app1, key.AppName)
+	require.Equal(t, v1, key.AppVersion)
+	require.Empty(t, key.PeerID)
+	require.Empty(t, key.ComponentName)
+	require.Empty(t, key.ComponentVersion)
+}
+
+func TestNewComponentKey(t *testing.T) {
+	key := NewComponentKey(msp1, app1, v1, comp1, v1)
+	require.NotNil(t, key)
+	require.Equal(t, msp1, key.MspID)
+	require.Equal(t, app1, key.AppName)
+	require.Equal(t, v1, key.AppVersion)
+	require.Equal(t, comp1, key.ComponentName)
+	require.Equal(t, v1, key.ComponentVersion)
+	require.Empty(t, key.PeerID)
+}
+
+func TestNewPeerKey(t *testing.T) {
+	key := NewPeerKey(msp1, peer1, app1, v1)
+	require.NotNil(t, key)
+	require.Equal(t, msp1, key.MspID)
+	require.Equal(t, peer1, key.PeerID)
+	require.Equal(t, app1, key.AppName)
+	require.Equal(t, v1, key.AppVersion)
+	require.Empty(t, key.ComponentName)
+	require.Empty(t, key.ComponentVersion)
+}
+
+func TestNewPeerComponentKey(t *testing.T) {
+	key := NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v1)
+	require.NotNil(t, key)
+	require.Equal(t, msp1, key.MspID)
+	require.Equal(t, peer1, key.PeerID)
+	require.Equal(t, app1, key.AppName)
+	require.Equal(t, v1, key.AppVersion)
+	require.Equal(t, comp1, key.ComponentName)
+	require.Equal(t, v1, key.ComponentVersion)
+}
+
+func TestNewKeyValue(t *testing.T) {
+	key := NewAppKey(msp1, app1, v1)
+	value := NewValue(tx1, "some config", FormatOther)
+	kv := NewKeyValue(key, value)
+	require.NotNil(t, kv)
+	require.Equal(t, key, kv.Key)
+	require.Equal(t, value, kv.Value)
+}
+
+func TestKey_String(t *testing.T) {
+	key := NewAppKey(msp1, app1, v1)
+	require.Equal(t, "(MSP:org1MSP),(Peer:),(Apps:app1),(AppVersion:v1),(Comp:),(CompVersion:)", key.String())
+}
+
+func TestValue_String(t *testing.T) {
+	kv := NewKeyValue(NewAppKey(msp1, app1, v1), NewValue(tx1, "some config", FormatOther))
+	require.Equal(t, "[(MSP:org1MSP),(Peer:),(Apps:app1),(AppVersion:v1),(Comp:),(CompVersion:)]=[(TxID:tx1),(Config:some config),(Format:OTHER)]", kv.String())
+}


### PR DESCRIPTION
Defined a key-value model that can store configuration data for an application in an MSP which is specific to a peer or applicable to all peers. The application data is uniquely identified by [MSP, peer-id, app-name, app-version]. Application sub-components may also be defined and are also uniquely identified by [MSP, peer-id, app-name, app-version, component-name, component-version].

closes #206

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>