### PR TITLE
feat: Save ledger configuration

### DIFF
--- a/pkg/config/ledgerconfig/config/config.go
+++ b/pkg/config/ledgerconfig/config/config.go
@@ -1,0 +1,150 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Config contains zero or more application configurations and zero or more peer-specific application configurations
+type Config struct {
+	// MspID is the ID of the MSP
+	MspID string
+	// Peers contains configuration for zero or more peers
+	Peers []*Peer
+	// Apps contains configuration for zero or more application
+	Apps []*App
+}
+
+// Validate validates the config
+func (c *Config) Validate() error {
+	if c.MspID == "" {
+		return errors.New("field [MspID] is required")
+	}
+	if len(c.Peers) == 0 && len(c.Apps) == 0 {
+		return errors.Errorf("config for MSP [%s] failed to validate: either one of the fields [Peers] or [Apps] is required", c.MspID)
+	}
+	if err := c.validatePeers(); err != nil {
+		return errors.WithMessagef(err, "peer config for MSP [%s] failed to validate", c.MspID)
+	}
+	if err := c.validateApps(); err != nil {
+		return errors.WithMessagef(err, "app config for MSP [%s] failed to validate", c.MspID)
+	}
+	return nil
+}
+
+func (c *Config) validatePeers() error {
+	for _, p := range c.Peers {
+		if err := p.Validate(); err != nil {
+			return errors.WithMessagef(err, "peer [%s] failed to validate", p.PeerID)
+		}
+	}
+	return nil
+}
+
+func (c *Config) validateApps() error {
+	for _, app := range c.Apps {
+		if err := app.Validate(); err != nil {
+			return errors.WithMessagef(err, "app [%s] failed to validate", app.AppName)
+		}
+	}
+
+	return nil
+}
+
+// Peer contains a collection of application configurations for a given peer
+type Peer struct {
+	// PeerID is the unique ID of the peer
+	PeerID string
+	// Apps contains configuration for one or more application
+	Apps []*App
+}
+
+// Validate validates the peer config
+func (p *Peer) Validate() error {
+	if p.PeerID == "" {
+		return errors.New("field [PeerID] is required")
+	}
+	if len(p.Apps) == 0 {
+		return errors.New("field [Apps] is required")
+	}
+	for _, app := range p.Apps {
+		if err := app.Validate(); err != nil {
+			return errors.WithMessagef(err, "app [%s] in peer [%s] failed to validate", app.AppName, p.PeerID)
+		}
+	}
+
+	return nil
+}
+
+// App contains the configuration for an application and/or multiple sub-components.
+type App struct {
+	// Name is the name of the application
+	AppName string
+	// Version is the version of the config
+	Version string
+	// Format describes the format of the data
+	Format Format
+	// Config contains the actual configuration
+	Config string
+	// Components zero or more component configs
+	Components []*Component
+}
+
+// Validate validates the application configuration
+func (app *App) Validate() error {
+	if app.AppName == "" {
+		return errors.New("field [Name] is required")
+	}
+	if app.Config == "" && len(app.Components) == 0 {
+		return errors.New("either one of the fields [Config] or [Components] is required")
+	}
+	if len(app.Version) == 0 {
+		return errors.New("field [Version] is required")
+	}
+	if app.Config != "" {
+		if app.Format == "" {
+			return errors.New("field [Format] is required")
+		}
+	} else {
+		for _, comp := range app.Components {
+			if err := comp.Validate(); err != nil {
+				return errors.WithMessagef(err, "component [%s] in app [%s] failed to validate", comp.Name, app.AppName)
+			}
+		}
+	}
+	return nil
+}
+
+// Component contains the configuration for an application component.
+type Component struct {
+	// Name is the name of the component
+	Name string
+	// Version is the version of the config
+	Version string
+	// Format describes the format of the data
+	Format Format
+	// Config contains the actual configuration
+	Config string
+}
+
+// Validate validates the Component
+func (c *Component) Validate() error {
+	if c.Name == "" {
+		return errors.New("field [Name] is required")
+	}
+	if c.Config == "" {
+		return errors.New("field [Config] is required")
+	}
+	if c.Format == "" {
+		return errors.New("field [Format] is required")
+	}
+	if len(c.Version) == 0 {
+		return errors.New("field [Version] is required")
+	}
+	return nil
+}

--- a/pkg/config/ledgerconfig/config/config_test.go
+++ b/pkg/config/ledgerconfig/config/config_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	configData = "x = y"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("Apps", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Apps: []*App{
+				{AppName: app1, Version: v1, Format: FormatOther, Config: configData},
+			},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("Apps components", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Apps: []*App{
+				{
+					AppName: app1, Version: v1,
+					Components: []*Component{
+						{Name: comp1, Version: v1, Format: FormatOther, Config: configData},
+					},
+				},
+			},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("Peer apps", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{AppName: app1, Version: v1, Format: FormatOther, Config: configData},
+					},
+				},
+			},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("Peer app components", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{
+							AppName: app1, Version: v1,
+							Components: []*Component{
+								{Name: comp1, Version: v1, Format: FormatOther, Config: configData},
+							},
+						},
+					},
+				},
+			},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("No MSP ID", func(t *testing.T) {
+		cfg := &Config{}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [MspID] is required")
+	})
+
+	t.Run("No peers nor apps", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "either one of the fields [Peers] or [Apps] is required")
+	})
+
+	t.Run("No app name", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Apps: []*App{
+				{Version: v1, Config: configData},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Name] is required")
+	})
+
+	t.Run("No peer ID", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					Apps: []*App{
+						{AppName: app1, Version: v1, Config: configData},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [PeerID] is required")
+	})
+
+	t.Run("No peer app", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{PeerID: peer1},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Apps] is required")
+	})
+
+	t.Run("No peer app name", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{Version: v1, Config: configData},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Name] is required")
+	})
+
+	t.Run("No peer app version", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{AppName: app1, Config: configData},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Version] is required")
+	})
+
+	t.Run("No peer app config", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{AppName: app1, Version: v1},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "either one of the fields [Config] or [Components] is required")
+	})
+
+	t.Run("No peer app config format", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{AppName: app1, Version: v1, Config: configData},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Format] is required")
+	})
+
+	t.Run("No peer app component name", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{
+							AppName: app1, Version: v1,
+							Components: []*Component{
+								{Version: v1, Config: configData},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Name] is required")
+	})
+
+	t.Run("No peer app component version", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{
+							AppName: app1, Version: v1,
+							Components: []*Component{
+								{Name: comp1, Format: FormatOther, Config: configData},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Version] is required")
+	})
+
+	t.Run("No peer app component config", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{
+							AppName: app1, Version: v1,
+							Components: []*Component{
+								{Name: comp1, Version: v1},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Config] is required")
+	})
+
+	t.Run("No peer app component config format", func(t *testing.T) {
+		cfg := &Config{
+			MspID: msp1,
+			Peers: []*Peer{
+				{
+					PeerID: peer1,
+					Apps: []*App{
+						{
+							AppName: app1, Version: v1,
+							Components: []*Component{
+								{Name: comp1, Version: v1, Config: configData},
+							},
+						},
+					},
+				},
+			},
+		}
+		err := cfg.Validate()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Format] is required")
+	})
+}

--- a/pkg/config/ledgerconfig/mgr/keyvaluemap.go
+++ b/pkg/config/ledgerconfig/mgr/keyvaluemap.go
@@ -1,0 +1,103 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mgr
+
+import (
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+)
+
+type keyValueMap map[config.Key]*config.Value
+
+// newKeyValueMap constructs a map of Key's to Value's from the given Config
+func newKeyValueMap(cfg *config.Config, txID string) (keyValueMap, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	cbk := make(keyValueMap)
+	if err := cbk.populate(cfg, txID); err != nil {
+		return nil, err
+	}
+	return cbk, nil
+}
+
+func (c keyValueMap) populate(config *config.Config, txID string) error {
+	err := c.populatePeers(config, txID)
+	if err != nil {
+		return err
+	}
+	return c.populateApps(config, txID)
+}
+
+func (c keyValueMap) populatePeers(config *config.Config, txID string) error {
+	logger.Debugf("Adding peer config ...")
+	for _, peer := range config.Peers {
+		if err := c.populatePeerApps(config.MspID, peer, txID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c keyValueMap) populatePeerApps(mspID string, peer *config.Peer, txID string) error {
+	logger.Debugf("... adding app configs for peer [%s] ...", peer.PeerID)
+	for _, app := range peer.Apps {
+		if err := c.populatePeerApp(mspID, peer.PeerID, app, txID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c keyValueMap) populateApps(config *config.Config, txID string) error {
+	logger.Debugf("... adding app configs ...")
+	for _, app := range config.Apps {
+		if err := c.populateApp(config.MspID, app, txID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c keyValueMap) populateApp(mspID string, app *config.App, txID string) error {
+	if len(app.Components) > 0 {
+		return c.populateComponents(mspID, app, txID)
+	}
+
+	logger.Debugf("... adding config for app [%s] ...", app.AppName)
+
+	c[*config.NewAppKey(mspID, app.AppName, app.Version)] = config.NewValue(txID, app.Config, app.Format)
+	return nil
+}
+
+func (c keyValueMap) populatePeerApp(mspID, peerID string, app *config.App, txID string) error {
+	logger.Debugf("... adding config for peer [%s] and app [%s] ...", peerID, app.AppName)
+	if len(app.Components) > 0 {
+		return c.populatePeerComponents(mspID, peerID, app, txID)
+	}
+
+	logger.Debugf("... adding config for peer [%s] and app [%s] ...", peerID, app.AppName)
+	c[*config.NewPeerKey(mspID, peerID, app.AppName, app.Version)] = config.NewValue(txID, app.Config, app.Format)
+	return nil
+}
+
+func (c keyValueMap) populateComponents(mspID string, app *config.App, txID string) error {
+	logger.Debugf("... adding components for app [%s] ...", app.AppName)
+	for _, comp := range app.Components {
+		logger.Debugf("... adding component [%s:%s] for app [%s] ...", comp.Name, comp.Version, app.AppName)
+		c[*config.NewComponentKey(mspID, app.AppName, app.Version, comp.Name, comp.Version)] = config.NewValue(txID, comp.Config, comp.Format)
+	}
+	return nil
+}
+
+func (c keyValueMap) populatePeerComponents(mspID, peerID string, app *config.App, txID string) error {
+	logger.Debugf("... adding components for peer [%s] and app [%s] ...", peerID, app.AppName)
+	for _, comp := range app.Components {
+		logger.Debugf("... adding component [%s:%s] for peer [%s] and app [%s] ...", comp.Name, comp.Version, peerID, app.AppName)
+		c[*config.NewPeerComponentKey(mspID, peerID, app.AppName, app.Version, comp.Name, comp.Version)] = config.NewValue(txID, comp.Config, comp.Format)
+	}
+	return nil
+}

--- a/pkg/config/ledgerconfig/mgr/updatemgr.go
+++ b/pkg/config/ledgerconfig/mgr/updatemgr.go
@@ -1,0 +1,75 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mgr
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+	state "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+)
+
+var logger = flogging.MustGetLogger("ledgerconfig")
+
+const (
+	// keyDivider is used to separate key parts
+	keyDivider = "!"
+)
+
+// UpdateManager allows you to update ledger configuration
+type UpdateManager struct {
+	namespace     string
+	storeProvider state.StoreProvider
+}
+
+// NewUpdateManager returns a new configuration update manager
+func NewUpdateManager(namespace string, sp state.StoreProvider) *UpdateManager {
+	return &UpdateManager{
+		namespace:     namespace,
+		storeProvider: sp,
+	}
+}
+
+// Save saves the configuration to the ledger
+func (m *UpdateManager) Save(txID string, cfg *config.Config) error {
+	configMap, err := newKeyValueMap(cfg, txID)
+	if err != nil {
+		return err
+	}
+	return m.save(configMap)
+}
+
+//save saves keys/values to the repository.
+func (m *UpdateManager) save(kvMap keyValueMap) error {
+	store, err := m.storeProvider.GetStore()
+	if err != nil {
+		return err
+	}
+	defer store.Done()
+
+	for key, value := range kvMap {
+		strKey := marshalKey(key)
+		valueBytes, err := json.Marshal(value)
+		if err != nil {
+			return errors.WithMessagef(err, "error marshalling config value")
+		}
+		logger.Debugf("Saving config [%s]=%s", strKey, valueBytes)
+		err = store.PutState(m.namespace, strKey, valueBytes)
+		if err != nil {
+			return errors.WithMessagef(err, "error saving config [%s]", key)
+		}
+	}
+	return nil
+}
+
+// marshalKey marshals the key into a string that may be used as a key in the state store
+func marshalKey(k config.Key) string {
+	return strings.Join([]string{k.MspID, k.PeerID, k.AppName, k.AppVersion, k.ComponentName, k.ComponentVersion}, keyDivider)
+}

--- a/pkg/config/ledgerconfig/mgr/updatemgr_test.go
+++ b/pkg/config/ledgerconfig/mgr/updatemgr_test.go
@@ -1,0 +1,394 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mgr
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+)
+
+const (
+	configNamespace = "configcc"
+
+	msp1 = "org1MSP"
+	msp2 = "org2MSP"
+
+	peer1 = "peer1.example.com"
+	peer2 = "peer2.example.com"
+
+	app1 = "app1"
+	app2 = "app2"
+	app3 = "app3"
+
+	comp1 = "comp1"
+	comp2 = "comp2"
+	comp3 = "comp3"
+
+	v1 = "1"
+	v2 = "2"
+
+	txID1 = "tx1"
+	txID2 = "tx2"
+	txID3 = "tx3"
+
+	msp1App1V1Config = "msp1-app1-v1-config"
+	msp1App1V2Config = "msp1-app1-v2-config"
+	msp1App2V1Config = `{"msp":"msp1", key1": "value1"}`
+	msp1App2V2Config = `{"msp":"msp1", "key1_1": "value1"}`
+
+	msp2App1V1Config = "msp2-app1-v1-config"
+	msp2App1V2Config = "msp2-app1-v2-config"
+	msp2App2V1Config = `{"msp":"msp2", key1": "value1"}`
+	msp2App2V2Config = `{"msp":"msp2", "key1_1": "value1"}`
+
+	msp1App1V1ConfigUpdate = `{"msp":"msp1", "key2": "value2"}`
+
+	msp1Peer1App1V1Config = "org1-peer1-app1-v1-config"
+	msp1Peer1App1V2Config = "org1-peer1-app1-v2-config"
+	msp1Peer1App2V1Config = "org1-peer1-app2-v1-config"
+	msp1Peer1App2V2Config = "org1-peer1-app2-v2-config"
+
+	msp1Peer2App1V1Config = "org1-peer2-app1-v1-config"
+	msp1Peer2App1V2Config = "org1-peer2-app1-v2-config"
+	msp1Peer2App2V1Config = "org1-peer2-app2-v1-config"
+	msp1Peer2App2V2Config = "org1-peer2-app2-v2-config"
+	msp1Peer2App3V1Config = "org1-peer2-app3-v1-config"
+
+	msp1Peer1App1V1ConfigUpdated = "org1-peer1-app1-v1-config-updated"
+
+	peer1App1V1Comp1V1Config = "org1-peer1-app1-v1-comp1-v1-config"
+	peer1App1V1Comp1V2Config = "org1-peer1-app1-v1-comp1-v2-config"
+	peer1App1V1Comp2V1Config = "org1-peer1-app1-v1-comp2-v1-config"
+	peer1App1V1Comp2V2Config = "org1-peer1-app1-v1-comp2-v2-config"
+
+	peer2App1V1Comp1V1Config = "org1-peer2-app1-v1-comp1-v1-config"
+	peer2App1V1Comp1V2Config = "org1-peer2-app1-v1-comp1-v2-config"
+	peer2App1V1Comp2V1Config = "org1-peer2-app1-v1-comp2-v1-config"
+	peer2App1V1Comp2V2Config = "org1-peer2-app1-v1-comp2-v2-config"
+
+	peer1App1V1Comp1V1ConfigUpdate = "org1-peer1-app1-v1-comp1-v1-config-update"
+	peer2App2V1Comp1V1Config       = "org1-peer2-app2-v1-comp1-v1-config"
+
+	comp1V1Config = "comp1-v1-config"
+	comp1V2Config = "comp1-v2-config"
+	comp2V1Config = "comp2-v1-config"
+	comp3V1Config = "comp3-v1-config"
+	comp3V2Config = "comp3-v2-config"
+
+	comp1V1ConfigUpdate = "comp1-v1-config-update"
+)
+
+var (
+	msp1App1ComponentsConfig = &config.Config{
+		MspID: msp1,
+		Apps: []*config.App{
+			{
+				AppName: app1, Version: v1,
+				Components: []*config.Component{
+					{Name: comp1, Version: v1, Config: comp1V1Config, Format: config.FormatOther},
+					{Name: comp1, Version: v2, Config: comp1V2Config, Format: config.FormatOther},
+					{Name: comp2, Version: v1, Config: comp2V1Config, Format: config.FormatOther},
+				},
+			},
+		},
+	}
+	msp1App1ComponentsConfigUpdate1 = &config.Config{
+		MspID: msp1,
+		Apps: []*config.App{
+			{
+				AppName: app1, Version: v1,
+				Components: []*config.Component{
+					{Name: comp3, Version: v1, Config: comp3V1Config, Format: config.FormatOther},
+				},
+			},
+		},
+	}
+	msp1App1ComponentsConfigUpdate2 = &config.Config{
+		MspID: msp1,
+		Apps: []*config.App{
+			{
+				AppName: app1, Version: v1,
+				Components: []*config.Component{
+					{Name: comp1, Version: v1, Config: comp1V1ConfigUpdate, Format: config.FormatOther},
+					{Name: comp3, Version: v2, Config: comp3V2Config, Format: config.FormatOther},
+				},
+			},
+		},
+	}
+	msp1AppConfig = &config.Config{
+		MspID: msp1,
+		Apps: []*config.App{
+			{AppName: app1, Version: v1, Config: msp1App1V1Config, Format: config.FormatOther},
+			{AppName: app1, Version: v2, Config: msp1App1V2Config, Format: config.FormatOther},
+			{AppName: app2, Version: v1, Config: msp1App2V1Config, Format: config.FormatJSON},
+			{AppName: app2, Version: v2, Config: msp1App2V2Config, Format: config.FormatJSON},
+		},
+	}
+	msp2AppConfig = &config.Config{
+		MspID: msp2,
+		Apps: []*config.App{
+			{AppName: app1, Version: v1, Config: msp2App1V1Config, Format: config.FormatOther},
+			{AppName: app1, Version: v2, Config: msp2App1V2Config, Format: config.FormatOther},
+			{AppName: app2, Version: v1, Config: msp2App2V1Config, Format: config.FormatJSON},
+			{AppName: app2, Version: v2, Config: msp2App2V2Config, Format: config.FormatJSON},
+		},
+	}
+	msp1AppConfigUpdate = &config.Config{
+		MspID: msp1,
+		Apps: []*config.App{
+			{AppName: app1, Version: v1, Config: msp1App1V1ConfigUpdate, Format: config.FormatJSON},
+		},
+	}
+	peerConfig = &config.Config{
+		MspID: msp1,
+		Peers: []*config.Peer{
+			{
+				PeerID: peer1,
+				Apps: []*config.App{
+					{AppName: app1, Version: v1, Config: msp1Peer1App1V1Config, Format: config.FormatOther},
+					{AppName: app1, Version: v2, Config: msp1Peer1App1V2Config, Format: config.FormatOther},
+					{AppName: app2, Version: v1, Config: msp1Peer1App2V1Config, Format: config.FormatOther},
+					{AppName: app2, Version: v2, Config: msp1Peer1App2V2Config, Format: config.FormatOther},
+				},
+			},
+			{
+				PeerID: peer2,
+				Apps: []*config.App{
+					{AppName: app1, Version: v1, Config: msp1Peer2App1V1Config, Format: config.FormatOther},
+					{AppName: app1, Version: v2, Config: msp1Peer2App1V2Config, Format: config.FormatOther},
+					{AppName: app2, Version: v1, Config: msp1Peer2App2V1Config, Format: config.FormatOther},
+					{AppName: app2, Version: v2, Config: msp1Peer2App2V2Config, Format: config.FormatOther},
+				},
+			},
+		},
+	}
+	peerConfigUpdate = &config.Config{
+		MspID: msp1,
+		Peers: []*config.Peer{
+			{
+				PeerID: peer1,
+				Apps: []*config.App{
+					{AppName: app1, Version: v1, Config: msp1Peer1App1V1ConfigUpdated, Format: config.FormatOther},
+				},
+			},
+			{
+				PeerID: peer2,
+				Apps: []*config.App{
+					{AppName: app3, Version: v1, Config: msp1Peer2App3V1Config, Format: config.FormatOther},
+				},
+			},
+		},
+	}
+	peerComponentConfig = &config.Config{
+		MspID: msp1,
+		Peers: []*config.Peer{
+			{
+				PeerID: peer1,
+				Apps: []*config.App{
+					{
+						AppName: app1, Version: v1,
+						Components: []*config.Component{
+							{Name: comp1, Version: v1, Config: peer1App1V1Comp1V1Config, Format: config.FormatOther},
+							{Name: comp1, Version: v2, Config: peer1App1V1Comp1V2Config, Format: config.FormatOther},
+							{Name: comp2, Version: v1, Config: peer1App1V1Comp2V1Config, Format: config.FormatOther},
+							{Name: comp2, Version: v2, Config: peer1App1V1Comp2V2Config, Format: config.FormatOther},
+						},
+					},
+				},
+			},
+			{
+				PeerID: peer2,
+				Apps: []*config.App{
+					{
+						AppName: app1, Version: v1,
+						Components: []*config.Component{
+							{Name: comp1, Version: v1, Config: peer2App1V1Comp1V1Config, Format: config.FormatOther},
+							{Name: comp1, Version: v2, Config: peer2App1V1Comp1V2Config, Format: config.FormatOther},
+							{Name: comp2, Version: v1, Config: peer2App1V1Comp2V1Config, Format: config.FormatOther},
+							{Name: comp2, Version: v2, Config: peer2App1V1Comp2V2Config, Format: config.FormatOther},
+						},
+					},
+				},
+			},
+		},
+	}
+	peerComponentConfigUpdate = &config.Config{
+		MspID: msp1,
+		Peers: []*config.Peer{
+			{
+				PeerID: peer1,
+				Apps: []*config.App{
+					{
+						AppName: app1, Version: v1,
+						Components: []*config.Component{
+							{Name: comp1, Version: v1, Config: peer1App1V1Comp1V1ConfigUpdate, Format: config.FormatOther},
+						},
+					},
+				},
+			},
+			{
+				PeerID: peer2,
+				Apps: []*config.App{
+					{
+						AppName: app2, Version: v1,
+						Components: []*config.Component{
+							{Name: comp1, Version: v1, Config: peer2App2V1Comp1V1Config, Format: config.FormatYAML},
+						},
+					},
+				},
+			},
+		},
+	}
+	noAppName = &config.Config{
+		MspID: msp1,
+		Peers: []*config.Peer{
+			{
+				PeerID: peer1,
+				Apps: []*config.App{
+					{Version: v1, Config: "data"},
+				},
+			},
+		},
+	}
+)
+
+func TestUpdateManager_StoreError(t *testing.T) {
+	t.Run("Provider error", func(t *testing.T) {
+		expectedErr := errors.New("provider error")
+		sp := mocks.NewStoreProvider().WithError(expectedErr)
+		m := NewUpdateManager(configNamespace, sp)
+		require.EqualError(t, m.Save("tx1", msp1App1ComponentsConfig), expectedErr.Error())
+	})
+	t.Run("StateStore error", func(t *testing.T) {
+		expectedErr := errors.New("store error")
+		s := mocks.NewStateStore().WithStoreError(expectedErr)
+		sp := mocks.NewStoreProvider().WithStore(s)
+		m := NewUpdateManager(configNamespace, sp)
+		err := m.Save("tx1", msp1App1ComponentsConfig)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), expectedErr.Error())
+	})
+	t.Run("StateRetriever error", func(t *testing.T) {
+		expectedErr := errors.New("retriever error")
+		s := mocks.NewStateStore().WithRetrieverError(expectedErr)
+		sp := mocks.NewStoreProvider().WithStore(s)
+
+		m := NewUpdateManager(configNamespace, sp)
+		err := m.Save("tx1", msp1App1ComponentsConfig)
+		require.NoError(t, err)
+
+		_, err = s.GetState(configNamespace, "xxx")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), expectedErr.Error())
+	})
+}
+
+func TestUpdateManager_Save(t *testing.T) {
+	sp := mocks.NewStoreProvider()
+	r, err := sp.GetStateRetriever()
+	require.NoError(t, err)
+
+	m := NewUpdateManager(configNamespace, sp)
+
+	t.Run("Invalid config", func(t *testing.T) {
+		err := m.Save(txID1, noAppName)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "field [Name] is required")
+	})
+	t.Run("Apps", func(t *testing.T) {
+		// Save MSP1
+		require.NoError(t, m.Save(txID1, msp1AppConfig))
+		requireEqualValue(t, r, config.NewAppKey(msp1, app1, v1), config.NewValue(txID1, msp1App1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewAppKey(msp1, app1, v2), config.NewValue(txID1, msp1App1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewAppKey(msp1, app2, v1), config.NewValue(txID1, msp1App2V1Config, config.FormatJSON))
+		requireEqualValue(t, r, config.NewAppKey(msp1, app2, v2), config.NewValue(txID1, msp1App2V2Config, config.FormatJSON))
+
+		// Save MSP2
+		require.NoError(t, m.Save(txID2, msp2AppConfig))
+		requireEqualValue(t, r, config.NewAppKey(msp2, app1, v1), config.NewValue(txID2, msp2App1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewAppKey(msp2, app1, v2), config.NewValue(txID2, msp2App1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewAppKey(msp2, app2, v1), config.NewValue(txID2, msp2App2V1Config, config.FormatJSON))
+		requireEqualValue(t, r, config.NewAppKey(msp2, app2, v2), config.NewValue(txID2, msp2App2V2Config, config.FormatJSON))
+
+		// Update app1 in msp1
+		require.NoError(t, m.Save(txID3, msp1AppConfigUpdate))
+		requireEqualValue(t, r, config.NewAppKey(msp1, app1, v1), config.NewValue(txID3, msp1App1V1ConfigUpdate, config.FormatJSON))
+
+		// Ensure other data is still there
+		requireEqualValue(t, r, config.NewAppKey(msp1, app1, v2), config.NewValue(txID1, msp1App1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewAppKey(msp1, app2, v1), config.NewValue(txID1, msp1App2V1Config, config.FormatJSON))
+		requireEqualValue(t, r, config.NewAppKey(msp1, app2, v2), config.NewValue(txID1, msp1App2V2Config, config.FormatJSON))
+	})
+	t.Run("App components", func(t *testing.T) {
+		// Save MSP1 components
+		require.NoError(t, m.Save(txID1, msp1App1ComponentsConfig))
+		requireEqualValue(t, r, config.NewComponentKey(msp1, app1, v1, comp1, v1), config.NewValue(txID1, comp1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewComponentKey(msp1, app1, v1, comp1, v2), config.NewValue(txID1, comp1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewComponentKey(msp1, app1, v1, comp2, v1), config.NewValue(txID1, comp2V1Config, config.FormatOther))
+
+		// Add comp3
+		require.NoError(t, m.Save(txID2, msp1App1ComponentsConfigUpdate1))
+		requireEqualValue(t, r, config.NewComponentKey(msp1, app1, v1, comp3, v1), config.NewValue(txID2, comp3V1Config, config.FormatOther))
+
+		// Add comp3/v2 and update comp1/v1
+		require.NoError(t, m.Save(txID3, msp1App1ComponentsConfigUpdate2))
+		requireEqualValue(t, r, config.NewComponentKey(msp1, app1, v1, comp3, v2), config.NewValue(txID3, comp3V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewComponentKey(msp1, app1, v1, comp1, v1), config.NewValue(txID3, comp1V1ConfigUpdate, config.FormatOther))
+	})
+	t.Run("Peer apps", func(t *testing.T) {
+		// Save peer apps
+		require.NoError(t, m.Save(txID1, peerConfig))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer1, app1, v1), config.NewValue(txID1, msp1Peer1App1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer1, app1, v2), config.NewValue(txID1, msp1Peer1App1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer2, app1, v1), config.NewValue(txID1, msp1Peer2App1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer2, app1, v2), config.NewValue(txID1, msp1Peer2App1V2Config, config.FormatOther))
+
+		// Update peer1/app1/v1 and add peer2/app3/v1
+		require.NoError(t, m.Save(txID2, peerConfigUpdate))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer1, app1, v1), config.NewValue(txID2, msp1Peer1App1V1ConfigUpdated, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer2, app3, v1), config.NewValue(txID2, msp1Peer2App3V1Config, config.FormatOther))
+
+		// Ensure other data is still there
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer1, app1, v2), config.NewValue(txID1, msp1Peer1App1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer2, app1, v1), config.NewValue(txID1, msp1Peer2App1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerKey(msp1, peer2, app1, v2), config.NewValue(txID1, msp1Peer2App1V2Config, config.FormatOther))
+	})
+	t.Run("Peer app components", func(t *testing.T) {
+		// Save MSP1 components
+		require.NoError(t, m.Save(txID1, peerComponentConfig))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v1), config.NewValue(txID1, peer1App1V1Comp1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v2), config.NewValue(txID1, peer1App1V1Comp1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer1, app1, v1, comp2, v1), config.NewValue(txID1, peer1App1V1Comp2V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer1, app1, v1, comp2, v2), config.NewValue(txID1, peer1App1V1Comp2V2Config, config.FormatOther))
+
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer2, app1, v1, comp1, v1), config.NewValue(txID1, peer2App1V1Comp1V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer2, app1, v1, comp1, v2), config.NewValue(txID1, peer2App1V1Comp1V2Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer2, app1, v1, comp2, v1), config.NewValue(txID1, peer2App1V1Comp2V1Config, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer2, app1, v1, comp2, v2), config.NewValue(txID1, peer2App1V1Comp2V2Config, config.FormatOther))
+
+		// Update peer1/app1/v1/comp1/v1 and add peer2/app2/v1/comp1/v1
+		require.NoError(t, m.Save(txID2, peerComponentConfigUpdate))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v1), config.NewValue(txID2, peer1App1V1Comp1V1ConfigUpdate, config.FormatOther))
+		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer2, app2, v1, comp1, v1), config.NewValue(txID2, peer2App2V1Comp1V1Config, config.FormatYAML))
+	})
+}
+
+func requireEqualValue(t *testing.T, retriever api.StateRetriever, key *config.Key, expectedValue *config.Value) {
+	bytes, err := retriever.GetState(configNamespace, marshalKey(*key))
+	require.NoError(t, err)
+	require.NotEmpty(t, bytes)
+
+	value := &config.Value{}
+	require.NoError(t, json.Unmarshal(bytes, value))
+	require.Equal(t, expectedValue, value)
+}

--- a/pkg/config/ledgerconfig/mocks/mockstoreprovider.go
+++ b/pkg/config/ledgerconfig/mocks/mockstoreprovider.go
@@ -1,0 +1,99 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+// StoreProvider is a mock StoreProvider
+type StoreProvider struct {
+	store api.StateStore
+	err   error
+}
+
+// NewStoreProvider returns a mock StoreProvider
+func NewStoreProvider() *StoreProvider {
+	return &StoreProvider{
+		store: NewStateStore(),
+	}
+}
+
+// WithStore sets the StateStore
+func (m *StoreProvider) WithStore(store api.StateStore) *StoreProvider {
+	m.store = store
+	return m
+}
+
+// WithError injects the store provider with an error
+func (m *StoreProvider) WithError(err error) *StoreProvider {
+	m.err = err
+	return m
+}
+
+// GetStateRetriever returns a mock StateRetriever
+func (m *StoreProvider) GetStateRetriever() (api.StateRetriever, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.store, nil
+}
+
+// GetStore returns a mock StateStore
+func (m *StoreProvider) GetStore() (api.StateStore, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.store, nil
+}
+
+// StateStore is a mock StateStore
+type StateStore struct {
+	*StateRetriever
+	err error
+}
+
+// NewStateStore returns a mock StateStore
+func NewStateStore() *StateStore {
+	return &StateStore{
+		StateRetriever: NewStateRetriever(),
+	}
+}
+
+// WithStoreError injects the state store with an error
+func (m *StateStore) WithStoreError(err error) *StateStore {
+	m.err = err
+	return m
+}
+
+// WithRetrieverError injects the state retriever with an error
+func (m *StateStore) WithRetrieverError(err error) *StateStore {
+	m.StateRetriever.WithError(err)
+	return m
+}
+
+// PutState saves the given state
+func (m *StateStore) PutState(namespace, key string, value []byte) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.WithState(namespace, key, value)
+	return nil
+}
+
+// StateRetriever is a mock implementation of StateRetriever
+type StateRetriever struct {
+	*mocks.QueryExecutor
+}
+
+// NewStateRetriever returns a mock StateRetriever
+func NewStateRetriever() *StateRetriever {
+	return &StateRetriever{
+		QueryExecutor: mocks.NewQueryExecutor(),
+	}
+}

--- a/pkg/config/ledgerconfig/state/api/api.go
+++ b/pkg/config/ledgerconfig/state/api/api.go
@@ -1,0 +1,30 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+// StateRetriever retrieves ledger state
+type StateRetriever interface {
+	GetState(namespace, key string) ([]byte, error)
+	Done()
+}
+
+// RetrieverProvider returns a State Retriever
+type RetrieverProvider interface {
+	GetStateRetriever() (StateRetriever, error)
+}
+
+// StateStore extends the StateRetriever and adds functions to save ledger state
+type StateStore interface {
+	StateRetriever
+	PutState(namespace, key string, value []byte) error
+}
+
+// StoreProvider returns a State Store
+type StoreProvider interface {
+	RetrieverProvider
+	GetStore() (StateStore, error)
+}


### PR DESCRIPTION
Defined a hierarchical  structure that allows a client to save one or more config key-value pairs.
Also created a config UpdateManager that converts the config structure into one or more key-value pairs and stores each one into a state store.

closes #168

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>