### PR TITLE
feat: Ledger configuration search criteria

### DIFF
--- a/pkg/config/ledgerconfig/config/criteria.go
+++ b/pkg/config/ledgerconfig/config/criteria.go
@@ -1,0 +1,88 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// Criteria is used for configuration searches
+type Criteria struct {
+	// MspID is the ID of the MSP that owns the data
+	MspID string
+	// PeerID is the ID of the peer with which the data is associated
+	PeerID string
+	// AppName is the name of the application that owns the data
+	AppName string
+	// AppVersion is the version of the application config
+	AppVersion string
+	// ComponentName is the name of the application component
+	ComponentName string
+	// ComponentVersion is the version of the application component config
+	ComponentVersion string
+}
+
+// String returns a readable string for the Criteria
+func (c *Criteria) String() string {
+	return fmt.Sprintf("(MSP:%s),(Peer:%s),(App:%s),(AppVersion:%s),(Comp:%s),(CompVersion:%s)", c.MspID, c.PeerID, c.AppName, c.AppVersion, c.ComponentName, c.ComponentVersion)
+}
+
+// Validate ensures that the criteria is valid
+func (c *Criteria) Validate() error {
+	if c.MspID == "" {
+		return errors.New("field [MspID] is required")
+	}
+	if c.AppVersion != "" && c.AppName == "" {
+		return errors.New("field [Name] is required")
+	}
+	if c.ComponentName != "" && c.AppName == "" {
+		return errors.New("field [Name] is required")
+	}
+	if c.ComponentVersion != "" && c.ComponentName == "" {
+		return errors.New("field [ComponentName] is required")
+	}
+	return nil
+}
+
+// IsUnique validates that the criteria has all of the necessary parts to uniquely identify the config
+func (c *Criteria) IsUnique() bool {
+	return c.MspID != "" && (c.isPeerAppKey() || c.isPeerAppComponentKey() || c.isAppKey() || c.isAppComponentKey())
+}
+
+// AsKey transforms the Criteria into a Key. If the Criteria is not unique then
+// an error is returned (since a key must uniquely identify a config item).
+func (c *Criteria) AsKey() (*Key, error) {
+	if !c.IsUnique() {
+		return nil, errors.New("criteria is not unique")
+	}
+	return &Key{
+		MspID:            c.MspID,
+		AppName:          c.AppName,
+		PeerID:           c.PeerID,
+		AppVersion:       c.AppVersion,
+		ComponentName:    c.ComponentName,
+		ComponentVersion: c.ComponentVersion,
+	}, nil
+}
+
+func (c *Criteria) isAppKey() bool {
+	return c.AppName != "" && c.AppVersion != "" && c.ComponentName == "" && c.ComponentVersion == ""
+}
+
+func (c *Criteria) isAppComponentKey() bool {
+	return c.AppName != "" && c.AppVersion != "" && c.ComponentName != "" && c.ComponentVersion != ""
+}
+
+func (c *Criteria) isPeerAppKey() bool {
+	return c.PeerID != "" && c.AppName != "" && c.AppVersion != "" && c.ComponentName == "" && c.ComponentVersion == ""
+}
+
+func (c *Criteria) isPeerAppComponentKey() bool {
+	return c.PeerID != "" && c.AppName != "" && c.AppVersion != "" && c.ComponentName != "" && c.ComponentVersion != ""
+}

--- a/pkg/config/ledgerconfig/config/criteria_test.go
+++ b/pkg/config/ledgerconfig/config/criteria_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCriteria_IsUnique(t *testing.T) {
+	t.Run("Unique", func(t *testing.T) {
+		c := Criteria{MspID: msp1, AppName: app1, AppVersion: v1}
+		require.True(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1, AppName: app1, AppVersion: v1, ComponentName: comp1, ComponentVersion: v1}
+		require.True(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1, PeerID: peer1, AppName: app1, AppVersion: v1}
+		require.True(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1, PeerID: peer1, AppName: app1, AppVersion: v1, ComponentName: comp1, ComponentVersion: v1}
+		require.True(t, c.IsUnique())
+	})
+
+	t.Run("Not unique", func(t *testing.T) {
+		c := Criteria{}
+		require.False(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1}
+		require.False(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1, AppName: app1}
+		require.False(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1, AppName: app1, AppVersion: v1, ComponentName: comp1}
+		require.False(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1, PeerID: peer1}
+		require.False(t, c.IsUnique())
+
+		c = Criteria{MspID: msp1, PeerID: peer1, AppName: app1, AppVersion: v1, ComponentName: comp1}
+		require.False(t, c.IsUnique())
+	})
+}
+
+func TestCriteria_Validate(t *testing.T) {
+	t.Run("Test valid", func(t *testing.T) {
+		c := Criteria{MspID: msp1, PeerID: peer1}
+		require.NoError(t, c.Validate())
+
+		c = Criteria{MspID: msp1, AppName: app1}
+		require.NoError(t, c.Validate())
+
+		c = Criteria{MspID: msp1, AppName: app1, AppVersion: v1}
+		require.NoError(t, c.Validate())
+
+		c = Criteria{MspID: msp1, PeerID: peer1, AppName: app1}
+		require.NoError(t, c.Validate())
+
+		c = Criteria{MspID: msp1, PeerID: peer1, AppName: app1, AppVersion: v1}
+		require.NoError(t, c.Validate())
+
+		c = Criteria{MspID: msp1, AppName: app1, ComponentName: comp1}
+		require.NoError(t, c.Validate())
+
+		c = Criteria{MspID: msp1, AppName: app1, ComponentName: comp1, ComponentVersion: v1}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("Test invalid", func(t *testing.T) {
+		c := Criteria{}
+		require.EqualError(t, c.Validate(), "field [MspID] is required")
+
+		c = Criteria{MspID: msp1, AppVersion: v1}
+		require.EqualError(t, c.Validate(), "field [Name] is required")
+
+		c = Criteria{MspID: msp1, ComponentName: comp1}
+		require.EqualError(t, c.Validate(), "field [Name] is required")
+
+		c = Criteria{MspID: msp1, AppName: app1, ComponentVersion: v1}
+		require.EqualError(t, c.Validate(), "field [ComponentName] is required")
+	})
+}
+
+func TestCriteria_String(t *testing.T) {
+	c := Criteria{MspID: msp1, PeerID: peer1, AppName: app1, AppVersion: v1, ComponentName: comp1, ComponentVersion: v1}
+	require.Equal(t, "(MSP:org1MSP),(Peer:peer1),(App:app1),(AppVersion:v1),(Comp:comp1),(CompVersion:v1)", c.String())
+}

--- a/pkg/config/ledgerconfig/mgr/configresults.go
+++ b/pkg/config/ledgerconfig/mgr/configresults.go
@@ -1,0 +1,93 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mgr
+
+import (
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+)
+
+// ConfigResults holds the results of a configuration query
+type ConfigResults []*config.KeyValue
+
+// Filter filters the results based on the given criteria
+func (r ConfigResults) Filter(criteria *config.Criteria) ConfigResults {
+	if criteria.PeerID == "" && criteria.AppName == "" {
+		// No filter
+		return r
+	}
+	if criteria.PeerID != "" {
+		return r.filterByPeer(criteria)
+	}
+	return r.filterByApp(criteria)
+}
+
+func (r ConfigResults) filterByPeer(criteria *config.Criteria) ConfigResults {
+	return r.and(criteria,
+		mustHavePeerID,
+		mayHaveAppName,
+		mayHaveAppVersion,
+		mayHaveComponentName,
+		mayHaveComponentVersion,
+	)
+}
+
+func (r ConfigResults) filterByApp(criteria *config.Criteria) ConfigResults {
+	return r.and(criteria,
+		mustHaveAppName,
+		mayHaveAppVersion,
+		mayHaveComponentName,
+		mayHaveComponentVersion,
+	)
+}
+
+type predicate func(v *config.KeyValue, criteria *config.Criteria) bool
+
+type predicates []predicate
+
+func (ps predicates) apply(kv *config.KeyValue, criteria *config.Criteria) bool {
+	for _, p := range ps {
+		if !p(kv, criteria) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r ConfigResults) and(criteria *config.Criteria, p ...predicate) ConfigResults {
+	var results ConfigResults
+	for _, v := range r {
+		if predicates(p).apply(v, criteria) {
+			logger.Debugf("... adding [%s]", v.Key)
+			results = append(results, v)
+		}
+	}
+	return results
+}
+
+func mustHaveAppName(kv *config.KeyValue, criteria *config.Criteria) bool {
+	return kv.AppName == criteria.AppName
+}
+
+func mustHavePeerID(kv *config.KeyValue, criteria *config.Criteria) bool {
+	return kv.PeerID == criteria.PeerID
+}
+
+func mayHaveAppName(kv *config.KeyValue, criteria *config.Criteria) bool {
+	return criteria.AppName == "" || kv.AppName == criteria.AppName
+}
+
+func mayHaveAppVersion(kv *config.KeyValue, criteria *config.Criteria) bool {
+	return criteria.AppVersion == "" || kv.AppVersion == criteria.AppVersion
+}
+
+func mayHaveComponentName(kv *config.KeyValue, criteria *config.Criteria) bool {
+	return criteria.ComponentName == "" || kv.ComponentName == criteria.ComponentName
+}
+
+func mayHaveComponentVersion(kv *config.KeyValue, criteria *config.Criteria) bool {
+	return criteria.ComponentVersion == "" || kv.ComponentVersion == criteria.ComponentVersion
+}

--- a/pkg/config/ledgerconfig/mgr/configresults_test.go
+++ b/pkg/config/ledgerconfig/mgr/configresults_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+)
+
+const (
+	app4 = "app4"
+	app5 = "app5"
+	app6 = "app6"
+)
+
+func TestConfigResults_Filter(t *testing.T) {
+	v := config.NewValue(txID1, "some config", config.FormatOther)
+
+	keyPeer0App1V1 := config.NewPeerKey(msp1, peer1, app1, v1)
+	keyPeer0App1V2 := config.NewPeerKey(msp1, peer1, app1, v2)
+	keyPeer0App2V1 := config.NewPeerKey(msp1, peer1, app2, v1)
+	keyPeer0App2V2 := config.NewPeerKey(msp1, peer1, app2, v2)
+	keyPeer1App1V1 := config.NewPeerKey(msp1, peer2, app1, v1)
+	keyPeer1App1V2 := config.NewPeerKey(msp1, peer2, app1, v2)
+	keyPeer1App2V1 := config.NewPeerKey(msp1, peer2, app2, v1)
+	keyPeer1App2V2 := config.NewPeerKey(msp1, peer2, app2, v2)
+
+	keyApp3V1 := config.NewAppKey(msp1, app3, v1)
+	keyApp3V2 := config.NewAppKey(msp1, app3, v2)
+	keyApp4V1 := config.NewAppKey(msp1, app4, v1)
+	keyApp4V2 := config.NewAppKey(msp1, app4, v2)
+
+	keyApp5V1Comp1V1 := config.NewComponentKey(msp1, app5, v1, comp1, v1)
+	keyApp5V1Comp1V2 := config.NewComponentKey(msp1, app5, v1, comp1, v2)
+	keyApp5V1Comp2V1 := config.NewComponentKey(msp1, app5, v1, comp2, v1)
+	keyApp5V1Comp2V2 := config.NewComponentKey(msp1, app5, v1, comp2, v2)
+	keyApp6V1Comp1V1 := config.NewComponentKey(msp1, app6, v1, comp1, v1)
+	keyApp6V1Comp1V2 := config.NewComponentKey(msp1, app6, v1, comp1, v2)
+	keyApp6V1Comp2V1 := config.NewComponentKey(msp1, app6, v1, comp2, v1)
+	keyApp6V1Comp2V2 := config.NewComponentKey(msp1, app6, v1, comp2, v2)
+
+	r1 := ConfigResults{
+		{Key: keyPeer0App1V1, Value: v},
+		{Key: keyPeer0App1V2, Value: v},
+		{Key: keyPeer0App2V1, Value: v},
+		{Key: keyPeer0App2V2, Value: v},
+		{Key: keyPeer1App1V1, Value: v},
+		{Key: keyPeer1App1V2, Value: v},
+		{Key: keyPeer1App2V1, Value: v},
+		{Key: keyPeer1App2V2, Value: v},
+
+		{Key: keyApp3V1, Value: v},
+		{Key: keyApp3V2, Value: v},
+		{Key: keyApp4V1, Value: v},
+		{Key: keyApp4V2, Value: v},
+
+		{Key: keyApp5V1Comp1V1, Value: v},
+		{Key: keyApp5V1Comp1V2, Value: v},
+		{Key: keyApp5V1Comp2V1, Value: v},
+		{Key: keyApp5V1Comp2V2, Value: v},
+		{Key: keyApp6V1Comp1V1, Value: v},
+		{Key: keyApp6V1Comp1V2, Value: v},
+		{Key: keyApp6V1Comp2V1, Value: v},
+		{Key: keyApp6V1Comp2V2, Value: v},
+	}
+
+	t.Run("No filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1})
+		require.Equal(t, r1, r)
+	})
+
+	t.Run("PeerID filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1, PeerID: peer2})
+		require.Len(t, r, 4)
+		require.Equal(t, keyPeer1App1V1, r[0].Key)
+		require.Equal(t, keyPeer1App1V2, r[1].Key)
+		require.Equal(t, keyPeer1App2V1, r[2].Key)
+		require.Equal(t, keyPeer1App2V2, r[3].Key)
+	})
+
+	t.Run("PeerID Apps filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1, PeerID: peer2, AppName: app2})
+		require.Len(t, r, 2)
+		require.Equal(t, keyPeer1App2V1, r[0].Key)
+		require.Equal(t, keyPeer1App2V2, r[1].Key)
+	})
+
+	t.Run("PeerID Apps Version filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1, PeerID: peer2, AppName: app2, AppVersion: v2})
+		require.Len(t, r, 1)
+		require.Equal(t, keyPeer1App2V2, r[0].Key)
+	})
+
+	t.Run("Apps filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1, AppName: app4})
+		require.Len(t, r, 2)
+		require.Equal(t, keyApp4V1, r[0].Key)
+		require.Equal(t, keyApp4V2, r[1].Key)
+	})
+
+	t.Run("Apps Version filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1, AppName: app4, AppVersion: v2})
+		require.Len(t, r, 1)
+		require.Equal(t, keyApp4V2, r[0].Key)
+	})
+
+	t.Run("Apps ComponentName filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1, AppName: app6, ComponentName: comp2})
+		require.Len(t, r, 2)
+		require.Equal(t, keyApp6V1Comp2V1, r[0].Key)
+		require.Equal(t, keyApp6V1Comp2V2, r[1].Key)
+	})
+
+	t.Run("Apps ComponentName filter", func(t *testing.T) {
+		r := r1.Filter(&config.Criteria{MspID: msp1, AppName: app6, ComponentName: comp2, ComponentVersion: v2})
+		require.Len(t, r, 1)
+		require.Equal(t, keyApp6V1Comp2V2, r[0].Key)
+	})
+}


### PR DESCRIPTION
Added a Criteria structure that allows a client to specifiy a partial key for looking up one or more config items. Also added a 'results filter' which filters a slice of config KeyValue according to the criteria.

closes #230

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>