### PR TITLE
feat: Query executor state retriever

### DIFF
--- a/pkg/config/ledgerconfig/state/kvresultsiter.go
+++ b/pkg/config/ledgerconfig/state/kvresultsiter.go
@@ -1,0 +1,76 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	commonledger "github.com/hyperledger/fabric/common/ledger"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/protos/ledger/queryresult"
+	"github.com/pkg/errors"
+)
+
+// KVResultsIter is a key-value results iterator
+type KVResultsIter struct {
+	it      commonledger.ResultsIterator
+	next    commonledger.QueryResult
+	nextErr error
+}
+
+// NewKVResultsIter returns a new KVResultsIter
+func NewKVResultsIter(it commonledger.ResultsIterator) *KVResultsIter {
+	return &KVResultsIter{it: it}
+}
+
+// HasNext returns true if there are more items
+func (it *KVResultsIter) HasNext() bool {
+	queryResult, err := it.it.Next()
+	if err != nil {
+		// Save the error and return true. The caller will get the error when Next is called.
+		it.nextErr = err
+		return true
+	}
+	if queryResult == nil {
+		return false
+	}
+	it.next = queryResult
+	return true
+}
+
+// Next returns the next item
+func (it *KVResultsIter) Next() (*queryresult.KV, error) {
+	if it.nextErr != nil {
+		return nil, it.nextErr
+	}
+
+	queryResult := it.next
+	if queryResult == nil {
+		qr, err := it.it.Next()
+		if err != nil {
+			return nil, err
+		}
+		queryResult = qr
+	} else {
+		it.next = nil
+	}
+
+	if queryResult == nil {
+		return nil, errors.New("Next() called when there is no next")
+	}
+
+	versionedKV := queryResult.(*statedb.VersionedKV)
+	return &queryresult.KV{
+		Namespace: versionedKV.Namespace,
+		Key:       versionedKV.Key,
+		Value:     versionedKV.Value,
+	}, nil
+}
+
+// Close closes the iterator
+func (it *KVResultsIter) Close() error {
+	it.it.Close()
+	return nil
+}

--- a/pkg/config/ledgerconfig/state/qestateretriever.go
+++ b/pkg/config/ledgerconfig/state/qestateretriever.go
@@ -1,0 +1,71 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/compositekey"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+)
+
+var logger = flogging.MustGetLogger("ledgerconfig")
+
+// QERetrieverProvider is a RetrieverProvider using a QueryExecutor
+type QERetrieverProvider struct {
+	channelID  string
+	qeProvider qeProvider
+}
+
+type qeProvider interface {
+	GetQueryExecutorForLedger(cid string) (ledger.QueryExecutor, error)
+}
+
+// NewQERetrieverProvider returns a new state qeRetriever provider
+func NewQERetrieverProvider(channelID string, qeProvider qeProvider) *QERetrieverProvider {
+	return &QERetrieverProvider{
+		channelID:  channelID,
+		qeProvider: qeProvider,
+	}
+}
+
+// GetStateRetriever returns the state qeRetriever
+func (p *QERetrieverProvider) GetStateRetriever() (api.StateRetriever, error) {
+	qe, err := p.qeProvider.GetQueryExecutorForLedger(p.channelID)
+	if err != nil {
+		return nil, err
+	}
+	return &qeRetriever{
+		qe: qe,
+	}, nil
+}
+
+// qeRetriever implements the StateRetriever interface
+type qeRetriever struct {
+	qe ledger.QueryExecutor
+}
+
+// GetState returns the value for the given key
+func (s *qeRetriever) GetState(namespace, key string) ([]byte, error) {
+	return s.qe.GetState(namespace, key)
+}
+
+// GetStateByPartialCompositeKey returns an iterator for the given index and attributes
+func (s *qeRetriever) GetStateByPartialCompositeKey(namespace, objectType string, attributes []string) (api.ResultsIterator, error) {
+	startKey, endKey := compositekey.CreateRangeKeysForPartialCompositeKey(objectType, attributes)
+	logger.Debugf("Namespace [%s], StartKey [%s], EndKey [%s]", namespace, startKey, endKey)
+	it, err := s.qe.GetStateRangeScanIterator(namespace, startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
+	return NewKVResultsIter(it), nil
+}
+
+// Done releases resources occupied by the StateRetriever
+func (s *qeRetriever) Done() {
+	s.qe.Done()
+}

--- a/pkg/config/ledgerconfig/state/qestateretriever_test.go
+++ b/pkg/config/ledgerconfig/state/qestateretriever_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/compositekey"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	channelID = "testchannel"
+
+	index   = "index1"
+	prefix1 = "prefix1"
+	prefix2 = "prefix2"
+)
+
+func TestQERetriever_GetState(t *testing.T) {
+	v1 := []byte("v1")
+
+	t.Run("Success", func(t *testing.T) {
+		rp := NewQERetrieverProvider(channelID,
+			mocks.NewQueryExecutorProvider().
+				WithMockQueryExecutor(mocks.NewQueryExecutor().WithState(ns1, key1, v1)),
+		)
+
+		r, err := rp.GetStateRetriever()
+		require.NoError(t, err)
+		require.NotNil(t, r)
+
+		v, err := r.GetState(ns1, key1)
+		require.NoError(t, err)
+		require.Equal(t, v1, v)
+
+		require.NotPanics(t, func() { r.Done() })
+	})
+	t.Run("QueryExecutorProvider error", func(t *testing.T) {
+		errExpected := errors.New("query executor error")
+		rp := NewQERetrieverProvider(channelID,
+			mocks.NewQueryExecutorProvider().WithError(errExpected),
+		)
+
+		r, err := rp.GetStateRetriever()
+		require.EqualError(t, err, errExpected.Error())
+		require.Nil(t, r)
+	})
+	t.Run("Iterator error", func(t *testing.T) {
+		errExpected := errors.New("iterator error")
+		rp := NewQERetrieverProvider(channelID,
+			mocks.NewQueryExecutorProvider().
+				WithMockQueryExecutor(mocks.NewQueryExecutor().WithQueryError(errExpected)),
+		)
+
+		r, err := rp.GetStateRetriever()
+		require.NoError(t, err)
+		require.NotNil(t, r)
+
+		it, err := r.GetStateByPartialCompositeKey(ns1, key1, nil)
+		require.EqualError(t, err, errExpected.Error())
+		require.Nil(t, it)
+	})
+}
+
+func TestQERetriever_GetStateByPartialCompositeKey(t *testing.T) {
+	qe := mocks.NewQueryExecutor()
+	rp := NewQERetrieverProvider(
+		channelID, mocks.NewQueryExecutorProvider().WithMockQueryExecutor(qe),
+	)
+
+	ck1 := compositekey.Create(index, []string{prefix1, key1})
+	qe.WithState(ns1, ck1, []byte("{}"))
+
+	ck2 := compositekey.Create(index, []string{prefix1, key2})
+	qe.WithState(ns1, ck2, []byte("{}"))
+
+	ck3 := compositekey.Create(index, []string{prefix2, key3})
+	qe.WithState(ns1, ck3, []byte("{}"))
+
+	r, err := rp.GetStateRetriever()
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	defer r.Done()
+
+	it, err := r.GetStateByPartialCompositeKey(ns1, index, []string{prefix1})
+	require.NoError(t, err)
+	require.NotNil(t, it)
+
+	require.True(t, it.HasNext())
+	kv, err := it.Next()
+	require.NoError(t, err)
+	require.NotNil(t, kv)
+
+	indexName, keys := compositekey.Split(kv.Key)
+	require.Equal(t, index, indexName)
+	require.Equal(t, 2, len(keys))
+	require.Equal(t, key1, keys[1])
+
+	require.True(t, it.HasNext())
+	kv, err = it.Next()
+	require.NoError(t, err)
+	require.NotNil(t, kv)
+
+	indexName, keys = compositekey.Split(kv.Key)
+	require.Equal(t, index, indexName)
+	require.Equal(t, 2, len(keys))
+	require.Equal(t, key2, keys[1])
+
+	require.False(t, it.HasNext())
+
+	kv, err = it.Next()
+	require.EqualError(t, err, "Next() called when there is no next")
+	require.Nil(t, kv)
+	require.NoError(t, it.Close())
+
+	it, err = r.GetStateByPartialCompositeKey(ns1, index, []string{prefix2})
+	require.NoError(t, err)
+	require.NotNil(t, it)
+
+	require.True(t, it.HasNext())
+	kv, err = it.Next()
+	require.NoError(t, err)
+	require.NotNil(t, kv)
+
+	indexName, keys = compositekey.Split(kv.Key)
+	require.Equal(t, index, indexName)
+	require.Equal(t, 2, len(keys))
+	require.Equal(t, key3, keys[1])
+
+	require.False(t, it.HasNext())
+	require.NoError(t, it.Close())
+}
+
+func TestQERetriever_GetStateByPartialCompositeKey_Error(t *testing.T) {
+	errExpected := errors.New("iterator error")
+	rp := NewQERetrieverProvider(
+		channelID, mocks.NewQueryExecutorProvider().WithMockQueryExecutor(
+			mocks.NewQueryExecutor().WithKVIteratorProvider(
+				func(kvs []*statedb.VersionedKV) *mocks.KVIterator {
+					return mocks.NewKVIterator(kvs).WithError(errExpected)
+				},
+			),
+		),
+	)
+
+	r, err := rp.GetStateRetriever()
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	defer r.Done()
+
+	it, err := r.GetStateByPartialCompositeKey(ns1, index, []string{prefix1})
+	require.NoError(t, err)
+	require.NotNil(t, it)
+
+	require.True(t, it.HasNext())
+	kv, err := it.Next()
+	require.EqualError(t, err, errExpected.Error())
+	require.Nil(t, kv)
+}

--- a/pkg/mocks/mockqueryexecutor.go
+++ b/pkg/mocks/mockqueryexecutor.go
@@ -237,7 +237,8 @@ func privateQueryResultsKey(namespace, coll, query string) string {
 
 // QueryExecutorProvider is a mock query executor provider
 type QueryExecutorProvider struct {
-	qe *QueryExecutor
+	qe  *QueryExecutor
+	err error
 }
 
 // NewQueryExecutorProvider returns a mock query executor provider
@@ -253,8 +254,17 @@ func (m *QueryExecutorProvider) WithMockQueryExecutor(qe *QueryExecutor) *QueryE
 	return m
 }
 
+// WithError injects an error into the mock provider
+func (m *QueryExecutorProvider) WithError(err error) *QueryExecutorProvider {
+	m.err = err
+	return m
+}
+
 // GetQueryExecutorForLedger returns the query executor for the given channel ID
 func (m *QueryExecutorProvider) GetQueryExecutorForLedger(channelID string) (ledger.QueryExecutor, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	return m.qe, nil
 }
 


### PR DESCRIPTION
Implemented a ledger configuration state retriever based on the ledger's QueryExecutor.

closes #235

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>