### PR TITLE
feat: Configuration service

### DIFF
--- a/pkg/config/ledgerconfig/config/criteria.go
+++ b/pkg/config/ledgerconfig/config/criteria.go
@@ -71,6 +71,18 @@ func (c *Criteria) AsKey() (*Key, error) {
 	}, nil
 }
 
+// CriteriaFromKey constructs Criteria from the given key
+func CriteriaFromKey(key *Key) *Criteria {
+	return &Criteria{
+		MspID:            key.MspID,
+		AppName:          key.AppName,
+		PeerID:           key.PeerID,
+		AppVersion:       key.AppVersion,
+		ComponentName:    key.ComponentName,
+		ComponentVersion: key.ComponentVersion,
+	}
+}
+
 func (c *Criteria) isAppKey() bool {
 	return c.AppName != "" && c.AppVersion != "" && c.ComponentName == "" && c.ComponentVersion == ""
 }

--- a/pkg/config/ledgerconfig/config/criteria_test.go
+++ b/pkg/config/ledgerconfig/config/criteria_test.go
@@ -91,3 +91,36 @@ func TestCriteria_String(t *testing.T) {
 	c := Criteria{MspID: msp1, PeerID: peer1, AppName: app1, AppVersion: v1, ComponentName: comp1, ComponentVersion: v1}
 	require.Equal(t, "(MSP:org1MSP),(Peer:peer1),(App:app1),(AppVersion:v1),(Comp:comp1),(CompVersion:v1)", c.String())
 }
+
+func TestCriteria_AsKey(t *testing.T) {
+	t.Run("Incomplete criteria for key -> error", func(t *testing.T) {
+		c := &Criteria{}
+		k, err := c.AsKey()
+		require.EqualError(t, err, "criteria is not unique")
+		require.Nil(t, k)
+	})
+	t.Run("Complete criteria for key -> success", func(t *testing.T) {
+		c := &Criteria{MspID: msp1, PeerID: peer1, AppName: app1, AppVersion: v1, ComponentName: comp1, ComponentVersion: v1}
+		k, err := c.AsKey()
+		require.NoError(t, err)
+		require.NotNil(t, k)
+		require.Equal(t, c.MspID, k.MspID)
+		require.Equal(t, c.AppName, k.AppName)
+		require.Equal(t, c.AppVersion, k.AppVersion)
+		require.Equal(t, c.PeerID, k.PeerID)
+		require.Equal(t, c.ComponentName, k.ComponentName)
+		require.Equal(t, c.ComponentVersion, k.ComponentVersion)
+	})
+}
+
+func TestCriteriaFromKey(t *testing.T) {
+	k := NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v1)
+	c := CriteriaFromKey(k)
+	require.NotNil(t, c)
+	require.Equal(t, k.MspID, c.MspID)
+	require.Equal(t, k.AppName, c.AppName)
+	require.Equal(t, k.AppVersion, c.AppVersion)
+	require.Equal(t, k.PeerID, c.PeerID)
+	require.Equal(t, k.ComponentName, c.ComponentName)
+	require.Equal(t, k.ComponentVersion, c.ComponentVersion)
+}

--- a/pkg/config/ledgerconfig/config/keyvalue_test.go
+++ b/pkg/config/ledgerconfig/config/keyvalue_test.go
@@ -83,3 +83,26 @@ func TestValue_String(t *testing.T) {
 	kv := NewKeyValue(NewAppKey(msp1, app1, v1), NewValue(tx1, "some config", FormatOther))
 	require.Equal(t, "[(MSP:org1MSP),(Peer:),(Apps:app1),(AppVersion:v1),(Comp:),(CompVersion:)]=[(TxID:tx1),(Config:some config),(Format:OTHER)]", kv.String())
 }
+
+func TestKey_Validate(t *testing.T) {
+	key := &Key{}
+	require.EqualError(t, key.Validate(), "field [MspID] is required")
+
+	key = &Key{MspID: msp1, PeerID: peer1}
+	require.EqualError(t, key.Validate(), "field [Name] is required for PeerID [peer1]")
+
+	key = &Key{MspID: msp1, AppName: app1}
+	require.EqualError(t, key.Validate(), "field [AppVersion] is required")
+
+	key = &Key{MspID: msp1, AppVersion: v1}
+	require.EqualError(t, key.Validate(), "one of the fields [PeerID] or [Name] is required")
+
+	key = &Key{MspID: msp1, AppName: app1, AppVersion: v1, ComponentName: comp1}
+	require.EqualError(t, key.Validate(), "field [ComponentVersion] is required")
+
+	key = &Key{MspID: msp1, AppName: app1, AppVersion: v1, ComponentVersion: v1}
+	require.EqualError(t, key.Validate(), "field [ComponentName] is required")
+
+	key = NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v1)
+	require.NoError(t, key.Validate())
+}

--- a/pkg/config/ledgerconfig/service/service.go
+++ b/pkg/config/ledgerconfig/service/service.go
@@ -1,0 +1,67 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mgr"
+	state "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+)
+
+var logger = flogging.MustGetLogger("ledgerconfig")
+
+const (
+	// ConfigNS is the namespace (chaincode name) under which configuration data is stored.
+	ConfigNS = "configscc"
+)
+
+// ErrConfigNotFound indicates that the config for the given key was not found
+var ErrConfigNotFound = errors.New("config not found")
+
+type configMgr interface {
+	Query(criteria *config.Criteria) ([]*config.KeyValue, error)
+}
+
+// ConfigService manages configuration data for a given channel
+type ConfigService struct {
+	channelID string
+	configMgr configMgr
+}
+
+// New returns a new config service
+func New(channelID string, retrieverProvider state.RetrieverProvider) *ConfigService {
+	return &ConfigService{
+		channelID: channelID,
+		configMgr: mgr.NewQueryManager(ConfigNS, retrieverProvider),
+	}
+}
+
+// Get returns the config bytes for the given criteria.
+// If the key is not found then ErrConfigNotFound error is returned
+func (s *ConfigService) Get(key *config.Key) (*config.Value, error) {
+	err := key.Validate()
+	if err != nil {
+		return nil, err
+	}
+	results, err := s.configMgr.Query(config.CriteriaFromKey(key))
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("Received results %s", results)
+
+	if len(results) > 1 {
+		return nil, errors.Errorf("received more than one result for key [%s]", key)
+	}
+	if len(results) == 0 {
+		return nil, ErrConfigNotFound
+	}
+
+	return results[0].Value, nil
+}

--- a/pkg/config/ledgerconfig/service/service_test.go
+++ b/pkg/config/ledgerconfig/service/service_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mgr"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mocks"
+)
+
+const (
+	channelID = "testchannel"
+	msp1      = "org1MSP"
+	peer1     = "peer1.example.com"
+
+	app1 = "app1"
+	app2 = "app2"
+
+	comp1 = "comp1"
+	v1    = "1"
+)
+
+func TestConfigService_Get(t *testing.T) {
+	key2 := &config.Key{MspID: msp1, AppName: app1, AppVersion: v1}
+	cfg := config.NewValue("tx1", "some config", config.FormatOther)
+	bytes, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	r := mocks.NewStateRetriever()
+	r.WithState(ConfigNS, mgr.MarshalKey(key2), bytes)
+	p := mocks.NewStateRetrieverProvider().WithStateRetriever(r)
+
+	svc := New(channelID, p)
+	require.NotNil(t, svc)
+
+	t.Run("Invalid key", func(t *testing.T) {
+		value, err := svc.Get(&config.Key{})
+		require.Error(t, err)
+		require.Nil(t, value)
+
+		value, err = svc.Get(&config.Key{MspID: msp1, PeerID: peer1})
+		require.Error(t, err)
+		require.Nil(t, value)
+
+		value, err = svc.Get(&config.Key{MspID: msp1, AppName: app1})
+		require.Error(t, err)
+		require.Nil(t, value)
+
+		_, err = svc.Get(&config.Key{MspID: msp1, AppVersion: v1})
+		require.Error(t, err)
+
+		_, err = svc.Get(&config.Key{MspID: msp1, AppName: app1, AppVersion: v1, ComponentName: comp1})
+		require.Error(t, err)
+
+		_, err = svc.Get(&config.Key{MspID: msp1, AppName: app1, AppVersion: v1, ComponentVersion: v1})
+		require.Error(t, err)
+	})
+
+	t.Run("Retriever error", func(t *testing.T) {
+		errExpected := errors.New("retriever error")
+		r.WithError(errExpected)
+		defer func() { r.WithError(nil) }()
+
+		value, err := svc.Get(key2)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.Nil(t, value)
+	})
+
+	t.Run("One result", func(t *testing.T) {
+		value, err := svc.Get(key2)
+		require.NoError(t, err)
+		require.Equal(t, cfg, value)
+	})
+
+	t.Run("No results", func(t *testing.T) {
+		value, err := svc.Get(&config.Key{MspID: msp1, AppName: app2, AppVersion: v1})
+		require.EqualError(t, err, ErrConfigNotFound.Error())
+		require.Empty(t, value)
+	})
+}
+
+func TestCache(t *testing.T) {
+	rp := mocks.NewStateRetrieverProvider()
+
+	svc := GetSvcMgr().ForChannel(channelID)
+	require.Nil(t, svc)
+
+	err := GetSvcMgr().Init(channelID, rp)
+	require.NoError(t, err)
+
+	svc = GetSvcMgr().ForChannel(channelID)
+	require.NotNil(t, svc)
+
+	require.EqualError(t, GetSvcMgr().Init(channelID, rp), "Config service already exists for channel [testchannel]")
+}

--- a/pkg/config/ledgerconfig/service/servicemgr.go
+++ b/pkg/config/ledgerconfig/service/servicemgr.go
@@ -1,0 +1,54 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package service
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	state "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+)
+
+// Manager manages a set of configuration services - one per channel
+type Manager struct {
+	serviceByChannel map[string]*ConfigService
+	mutex            sync.RWMutex
+}
+
+var svcMgr = newSvcMgr()
+
+// GetSvcMgr returns the config service manager
+func GetSvcMgr() *Manager {
+	return svcMgr
+}
+
+func newSvcMgr() *Manager {
+	return &Manager{
+		serviceByChannel: make(map[string]*ConfigService),
+	}
+}
+
+// Init initializes the ConfigService for the given channel
+func (c *Manager) Init(channelID string, provider state.RetrieverProvider) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if _, ok := c.serviceByChannel[channelID]; ok {
+		return errors.Errorf("Config service already exists for channel [%s]", channelID)
+	}
+
+	c.serviceByChannel[channelID] = New(channelID, provider)
+	return nil
+}
+
+// ForChannel returns a config service for the given channel.
+func (c *Manager) ForChannel(channelID string) *ConfigService {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	return c.serviceByChannel[channelID]
+}


### PR DESCRIPTION
Implement a configuration service that allows a peer's local resources (such as system chaincode) to read configuration data from the ledger.

closes #237

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>