### PR TITLE
feat: Configuration cache

### DIFF
--- a/cmd/chaincode/configscc/configscc.go
+++ b/cmd/chaincode/configscc/configscc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric/core/chaincode/shim"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/scc"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/pkg/errors"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
@@ -41,18 +42,27 @@ type queryExecutorProvider interface {
 	GetQueryExecutorForLedger(cid string) (ledger.QueryExecutor, error)
 }
 
+type blockPublisherProvider interface {
+	ForChannel(channelID string) gossipapi.BlockPublisher
+}
+
 type configSCC struct {
 	qeProvider       queryExecutorProvider
+	pubProvider      blockPublisherProvider
 	functionRegistry map[string]function
 }
 
 // New returns a new configuration system chaincode
-func New(qeProvider queryExecutorProvider) scc.SelfDescribingSysCC {
+func New(qeProvider queryExecutorProvider, pubProvider blockPublisherProvider) scc.SelfDescribingSysCC {
 	if qeProvider == nil {
 		panic("nil query executor provider")
 	}
+	if pubProvider == nil {
+		panic("nil block publisher provider")
+	}
 	cc := &configSCC{
-		qeProvider: qeProvider,
+		qeProvider:  qeProvider,
+		pubProvider: pubProvider,
 	}
 	cc.initFunctionRegistry()
 	return cc
@@ -70,7 +80,9 @@ func (scc *configSCC) Enabled() bool             { return true }
 func (scc *configSCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
 	if stub.GetChannelID() != "" {
 		logger.Infof("Initializing configuration service for channel: [%s]", stub.GetChannelID())
-		if err := service.GetSvcMgr().Init(stub.GetChannelID(), state.NewQERetrieverProvider(stub.GetChannelID(), scc.qeProvider)); err != nil {
+		retriever := state.NewQERetrieverProvider(stub.GetChannelID(), scc.qeProvider)
+		publisher := scc.pubProvider.ForChannel(stub.GetChannelID())
+		if err := service.GetSvcMgr().Init(stub.GetChannelID(), retriever, publisher); err != nil {
 			return shim.Error(err.Error())
 		}
 	}

--- a/cmd/chaincode/configscc/configscc_test.go
+++ b/cmd/chaincode/configscc/configscc_test.go
@@ -26,12 +26,15 @@ const (
 )
 
 func TestConfigSCC_New(t *testing.T) {
-	t.Run("Unresolved dependencies", func(t *testing.T) {
-		require.Panics(t, func() { New(nil) })
+	t.Run("Unresolved dependency: QE Provider", func(t *testing.T) {
+		require.Panics(t, func() { New(nil, mocks.NewBlockPublisherProvider()) })
+	})
+	t.Run("Unresolved dependency: Block Publisher", func(t *testing.T) {
+		require.Panics(t, func() { New(mocks.NewQueryExecutorProvider(), nil) })
 	})
 	t.Run("Success", func(t *testing.T) {
 		qep := mocks.NewQueryExecutorProvider()
-		cc := New(qep)
+		cc := New(qep, mocks.NewBlockPublisherProvider())
 		require.NotNil(t, cc)
 
 		require.Equal(t, service.ConfigNS, cc.Name())
@@ -46,7 +49,7 @@ func TestConfigSCC_New(t *testing.T) {
 
 func TestConfigSCC_Init(t *testing.T) {
 	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep)
+	cc := New(qep, mocks.NewBlockPublisherProvider())
 	require.NotNil(t, cc)
 
 	t.Run("System channel", func(t *testing.T) {
@@ -83,7 +86,7 @@ func TestConfigSCC_Init(t *testing.T) {
 
 func TestConfigSCC_Invoke_Invalid(t *testing.T) {
 	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep)
+	cc := New(qep, mocks.NewBlockPublisherProvider())
 	require.NotNil(t, cc)
 
 	t.Run("No func arg", func(t *testing.T) {
@@ -105,7 +108,7 @@ func TestConfigSCC_Invoke_Invalid(t *testing.T) {
 
 func TestConfigSCC_Invoke_Save(t *testing.T) {
 	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep)
+	cc := New(qep, mocks.NewBlockPublisherProvider())
 	require.NotNil(t, cc)
 
 	t.Run("Empty config", func(t *testing.T) {
@@ -161,7 +164,7 @@ func TestConfigSCC_Invoke_Save(t *testing.T) {
 
 func TestConfigSCC_Invoke_Get(t *testing.T) {
 	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep)
+	cc := New(qep, mocks.NewBlockPublisherProvider())
 	require.NotNil(t, cc)
 
 	t.Run("No criteria", func(t *testing.T) {
@@ -257,7 +260,7 @@ func TestConfigSCC_Invoke_Get(t *testing.T) {
 
 func TestConfigSCC_Invoke_Delete(t *testing.T) {
 	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep)
+	cc := New(qep, mocks.NewBlockPublisherProvider())
 	require.NotNil(t, cc)
 
 	t.Run("No criteria", func(t *testing.T) {

--- a/pkg/config/ledgerconfig/service/service.go
+++ b/pkg/config/ledgerconfig/service/service.go
@@ -7,7 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package service
 
 import (
+	"encoding/json"
+
+	"github.com/bluele/gcache"
 	"github.com/hyperledger/fabric/common/flogging"
+	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
 	"github.com/pkg/errors"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mgr"
@@ -32,14 +37,37 @@ type configMgr interface {
 type ConfigService struct {
 	channelID string
 	configMgr configMgr
+	cache     gcache.Cache
+}
+
+type blockPublisher interface {
+	AddWriteHandler(handler gossipapi.WriteHandler)
 }
 
 // New returns a new config service
-func New(channelID string, retrieverProvider state.RetrieverProvider) *ConfigService {
-	return &ConfigService{
+func New(channelID string, retrieverProvider state.RetrieverProvider, publisher blockPublisher) *ConfigService {
+	s := &ConfigService{
 		channelID: channelID,
 		configMgr: mgr.NewQueryManager(ConfigNS, retrieverProvider),
 	}
+
+	// Set size to 0 so that all config is cached
+	s.cache = gcache.New(0).
+		LoaderFunc(func(key interface{}) (interface{}, error) {
+			return s.load(key.(config.Key))
+		}).
+		Build()
+
+	// Register for KV write events so we can invalidate our cache when config is updated/deleted
+	publisher.AddWriteHandler(func(txMetadata gossipapi.TxMetadata, ns string, kvWrite *kvrwset.KVWrite) error {
+		if ns != ConfigNS {
+			// Only interested in config chaincode
+			return nil
+		}
+		return s.handleKeyUpdate(kvWrite)
+	})
+
+	return s
 }
 
 // Get returns the config bytes for the given criteria.
@@ -49,12 +77,21 @@ func (s *ConfigService) Get(key *config.Key) (*config.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	results, err := s.configMgr.Query(config.CriteriaFromKey(key))
+	value, err := s.cache.Get(*key)
+	if err != nil {
+		return nil, err
+	}
+	return value.(*config.Value), nil
+}
+
+func (s *ConfigService) load(key config.Key) (*config.Value, error) {
+	logger.Debugf("[%s] Loading key [%s] from ledger...", s.channelID, key)
+	results, err := s.configMgr.Query(config.CriteriaFromKey(&key))
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Debugf("Received results %s", results)
+	logger.Debugf("[%s] ... received results for key [%s]: %s", s.channelID, key, results)
 
 	if len(results) > 1 {
 		return nil, errors.Errorf("received more than one result for key [%s]", key)
@@ -62,6 +99,38 @@ func (s *ConfigService) Get(key *config.Key) (*config.Value, error) {
 	if len(results) == 0 {
 		return nil, ErrConfigNotFound
 	}
-
 	return results[0].Value, nil
+}
+
+func (s *ConfigService) handleKeyUpdate(kvWrite *kvrwset.KVWrite) error {
+	logger.Debugf("[%s] Got KV write: [%s]", s.channelID, kvWrite.Key)
+	key, err := mgr.UnmarshalKey(kvWrite.Key)
+	if err != nil {
+		// Not a Key - could be an index
+		logger.Debugf("[%s] KV write [%s] is not a config key. Ignoring.", s.channelID, kvWrite.Key)
+		return nil
+	}
+
+	if kvWrite.IsDelete {
+		if s.cache.Remove(*key) {
+			logger.Debugf("[%s] Removed deleted config key [%s] from cache", s.channelID, key)
+		} else {
+			logger.Debugf("[%s] Deleted config key [%s] not found in cache", s.channelID, key)
+		}
+		return nil
+	}
+
+	value := &config.Value{}
+	if err := json.Unmarshal(kvWrite.Value, value); err != nil {
+		logger.Errorf("[%s] Error unmarshalling config value for key [%s]: %s", s.channelID, key, err)
+		return err
+	}
+
+	logger.Debugf("[%s] Adding config key [%s] to cache", s.channelID, key)
+	if err := s.cache.Set(*key, value); err != nil {
+		logger.Errorf("[%s] Error caching config value for key [%s]: %s", s.channelID, key, err)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/config/ledgerconfig/service/service_test.go
+++ b/pkg/config/ledgerconfig/service/service_test.go
@@ -10,11 +10,15 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/hyperledger/fabric/protos/peer"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mgr"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/gossip/blockpublisher"
+	mocks2 "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
 const (
@@ -24,14 +28,25 @@ const (
 
 	app1 = "app1"
 	app2 = "app2"
+	app3 = "app3"
+	app4 = "app4"
 
 	comp1 = "comp1"
 	v1    = "1"
+
+	tx1 = "tx1"
+	tx2 = "tx2"
+	tx3 = "tx3"
+
+	config1        = "config1"
+	config2        = "config2"
+	config3        = "config3"
+	config1Updated = "config1-updated"
 )
 
 func TestConfigService_Get(t *testing.T) {
 	key2 := &config.Key{MspID: msp1, AppName: app1, AppVersion: v1}
-	cfg := config.NewValue("tx1", "some config", config.FormatOther)
+	cfg := config.NewValue(tx1, config1, config.FormatOther)
 	bytes, err := json.Marshal(cfg)
 	require.NoError(t, err)
 
@@ -39,7 +54,7 @@ func TestConfigService_Get(t *testing.T) {
 	r.WithState(ConfigNS, mgr.MarshalKey(key2), bytes)
 	p := mocks.NewStateRetrieverProvider().WithStateRetriever(r)
 
-	svc := New(channelID, p)
+	svc := New(channelID, p, mocks2.NewBlockPublisher())
 	require.NotNil(t, svc)
 
 	t.Run("Invalid key", func(t *testing.T) {
@@ -89,17 +104,110 @@ func TestConfigService_Get(t *testing.T) {
 	})
 }
 
-func TestCache(t *testing.T) {
+func TestConfigService_CacheUpdate(t *testing.T) {
+	r := mocks.NewStateRetriever()
+	p := mocks.NewStateRetrieverProvider().WithStateRetriever(r)
+
+	publisher := blockpublisher.New(channelID)
+	svc := New(channelID, p, publisher)
+	require.NotNil(t, svc)
+
+	key1 := config.NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v1)
+	_, err := svc.Get(key1)
+	require.EqualError(t, err, ErrConfigNotFound.Error())
+
+	val1 := config.NewValue(tx1, config1, config.FormatOther)
+	val1Bytes, err := json.Marshal(val1)
+	require.NoError(t, err)
+
+	key2 := config.NewPeerComponentKey(msp1, peer1, app2, v1, comp1, v1)
+	_, err = svc.Get(key2)
+	require.EqualError(t, err, ErrConfigNotFound.Error())
+	val2 := config.NewValue(tx1, config2, config.FormatOther)
+	val2Bytes, err := json.Marshal(val2)
+	require.NoError(t, err)
+
+	key3 := config.NewPeerComponentKey(msp1, peer1, app3, v1, comp1, v1)
+	val3 := config.NewValue(tx1, config2, config.FormatOther)
+	val3Bytes, err := json.Marshal(val3)
+	require.NoError(t, err)
+
+	key4 := config.NewPeerComponentKey(msp1, peer1, app4, v1, comp1, v1)
+
+	// Add key1 and key2
+	b := mocks2.NewBlockBuilder(channelID, 1000)
+	txb := b.Transaction(tx1, peer.TxValidationCode_VALID)
+	txb.ChaincodeAction(ConfigNS).
+		Write(mgr.MarshalKey(key1), val1Bytes).
+		Write(mgr.MarshalKey(key2), val2Bytes).
+		// Invalid keys should be ignored
+		Write("some-other-key", []byte("some value")).
+		Write(mgr.MarshalKey(key4), []byte("invalid JSON")) // Invalid JSON should be logged and ignored
+	// Other namespaces should be ignored
+	txb.ChaincodeAction("some-other-cc").
+		Write(mgr.MarshalKey(key3), val3Bytes)
+	publisher.Publish(b.Build())
+
+	// Give the event enough time to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	value, err := svc.Get(key1)
+	require.NoError(t, err)
+	require.Equal(t, val1, value)
+
+	value, err = svc.Get(key2)
+	require.NoError(t, err)
+	require.Equal(t, val2, value)
+
+	value, err = svc.Get(key3)
+	require.Nil(t, value)
+	require.EqualError(t, err, ErrConfigNotFound.Error())
+
+	val1Updated := config.NewValue(tx1, config1Updated, config.FormatOther)
+	v1UpdatedBytes, err := json.Marshal(val1Updated)
+	require.NoError(t, err)
+
+	// Update key1, delete key2, add key3, delete key4 (which isn't in the cache)
+	b = mocks2.NewBlockBuilder(channelID, 1001)
+	b.Transaction(tx2, peer.TxValidationCode_VALID).
+		ChaincodeAction(ConfigNS).
+		Write(mgr.MarshalKey(key1), v1UpdatedBytes).
+		Delete(mgr.MarshalKey(key2)).
+		Write(mgr.MarshalKey(key3), val3Bytes).
+		Delete(mgr.MarshalKey(key4))
+	publisher.Publish(b.Build())
+
+	// Give the event enough time to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	value, err = svc.Get(key1)
+	require.NoError(t, err)
+	require.Equal(t, val1Updated, value)
+
+	value, err = svc.Get(key2)
+	require.Nil(t, value)
+	require.EqualError(t, err, ErrConfigNotFound.Error())
+
+	value, err = svc.Get(key3)
+	require.NoError(t, err)
+	require.Equal(t, val3, value)
+
+	value, err = svc.Get(key4)
+	require.Nil(t, value)
+	require.EqualError(t, err, ErrConfigNotFound.Error())
+}
+
+func TestManager(t *testing.T) {
 	rp := mocks.NewStateRetrieverProvider()
 
 	svc := GetSvcMgr().ForChannel(channelID)
 	require.Nil(t, svc)
 
-	err := GetSvcMgr().Init(channelID, rp)
+	err := GetSvcMgr().Init(channelID, rp, mocks2.NewBlockPublisher())
 	require.NoError(t, err)
 
 	svc = GetSvcMgr().ForChannel(channelID)
 	require.NotNil(t, svc)
 
-	require.EqualError(t, GetSvcMgr().Init(channelID, rp), "Config service already exists for channel [testchannel]")
+	require.EqualError(t, GetSvcMgr().Init(channelID, rp, mocks2.NewBlockPublisher()), "Config service already exists for channel [testchannel]")
 }

--- a/pkg/config/ledgerconfig/service/servicemgr.go
+++ b/pkg/config/ledgerconfig/service/servicemgr.go
@@ -33,7 +33,7 @@ func newSvcMgr() *Manager {
 }
 
 // Init initializes the ConfigService for the given channel
-func (c *Manager) Init(channelID string, provider state.RetrieverProvider) error {
+func (c *Manager) Init(channelID string, provider state.RetrieverProvider, publisher blockPublisher) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
@@ -41,7 +41,7 @@ func (c *Manager) Init(channelID string, provider state.RetrieverProvider) error
 		return errors.Errorf("Config service already exists for channel [%s]", channelID)
 	}
 
-	c.serviceByChannel[channelID] = New(channelID, provider)
+	c.serviceByChannel[channelID] = New(channelID, provider, publisher)
 	return nil
 }
 

--- a/pkg/mocks/mockblockpublisher.go
+++ b/pkg/mocks/mockblockpublisher.go
@@ -65,3 +65,20 @@ func (m *MockBlockPublisher) Publish(block *common.Block) {
 func (m *MockBlockPublisher) LedgerHeight() uint64 {
 	panic("not implemented")
 }
+
+// MockBlockPublisherProvider is a mock block publisher provider
+type MockBlockPublisherProvider struct {
+	publisher gossipapi.BlockPublisher
+}
+
+// NewBlockPublisherProvider returns a mock block publisher provider
+func NewBlockPublisherProvider() *MockBlockPublisherProvider {
+	return &MockBlockPublisherProvider{
+		publisher: NewBlockPublisher(),
+	}
+}
+
+// ForChannel returns the mock block publisher
+func (m *MockBlockPublisherProvider) ForChannel(channelID string) gossipapi.BlockPublisher {
+	return m.publisher
+}


### PR DESCRIPTION
Added a cache to the config service. The cache is populated on demand, i.e. if the config key does not exist then it is loaded using the Retriever.
The service registers with a block publisher to receive notifications of writes to the ledger. An update handler adds/updates/removes keys as it receives notifications from the block publisher.

closes #169

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>