### PR TITLE
test: Added ledger configuration service BDD test

### DIFF
--- a/test/bddtests/features/ledger_config.feature
+++ b/test/bddtests/features/ledger_config.feature
@@ -80,3 +80,45 @@ Feature: ledger-config
     Then the JSON path "#" of the response has 2 items
     And the JSON path "#.Config" of the response contains "msp2-app1-comp1-v1-config"
     And the JSON path "#.Config" of the response contains "msp2-app1-comp2-v1-config"
+
+  @ledger_config_s3
+  Scenario: Ledger config service - peer-specific config
+    # Save the config
+    Given variable "testSccGeneralConfig" is assigned the JSON value '{"MspID":"general","Apps":[{"AppName":"testscc","Version":"v1","Components":[{"Name":"comp1","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testscc\",\"SubComponent\":\"comp1\"}","Format":"JSON"},{"Name":"comp2","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testscc\",\"SubComponent\":\"comp2\"}","Format":"JSON"}]}]}'
+    Given variable "testSccOrg1Config" is assigned the JSON value '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p0-org1-testscc-v1-config","Format":"Other"}]},{"PeerID":"peer1.org1.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p1-org1-testscc-v1-config","Format":"Other"}]}]}'
+    Given variable "testSccOrg2Config" is assigned the JSON value '{"MspID":"Org2MSP","Peers":[{"PeerID":"peer0.org2.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p0-org2-testscc-v1-config","Format":"Other"}]},{"PeerID":"peer1.org2.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p1-org2-testscc-v1-config","Format":"Other"}]}]}'
+    Then client invokes chaincode "configscc" with args "save,${testSccGeneralConfig}" on peers "peer0.org1.example.com" on the "mychannel" channel
+    And client invokes chaincode "configscc" with args "save,${testSccOrg1Config}" on peers "peer0.org1.example.com" on the "mychannel" channel
+    And client invokes chaincode "configscc" with args "save,${testSccOrg2Config}" on peers "peer0.org2.example.com" on the "mychannel" channel
+    # Wait for the transactions to commit and for config update events to fire.
+    And we wait 3 seconds
+
+    # Get general (global) data which is not specific to an org (tests retrieval of config data using the config service)
+    Given variable "testSccGeneralComp1Criteria" is assigned the JSON value '{"MspID":"general","AppName":"testscc","AppVersion":"v1","ComponentName":"comp1","ComponentVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSccGeneralComp1Criteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
+    Then the JSON path "Org" of the response equals "general"
+    Then the JSON path "Application" of the response equals "testscc"
+    Then the JSON path "SubComponent" of the response equals "comp1"
+    Given variable "testSccGeneralComp2Criteria" is assigned the JSON value '{"MspID":"general","AppName":"testscc","AppVersion":"v1","ComponentName":"comp2","ComponentVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSccGeneralComp2Criteria}" on a single peer in the "peerorg2" org on the "mychannel" channel
+    Then the JSON path "Org" of the response equals "general"
+    Then the JSON path "Application" of the response equals "testscc"
+    Then the JSON path "SubComponent" of the response equals "comp2"
+
+    # Get peer-specific data (tests config update events)
+    Given variable "testSccOrg1Peer0Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer0.org1.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSccOrg1Peer0Criteria}" on peers "peer0.org1.example.com" on the "mychannel" channel
+    Then response from "configscc" to client equal value "p0-org1-testscc-v1-config"
+    Given variable "testSccOrg1Peer1Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer1.org1.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSccOrg1Peer1Criteria}" on peers "peer1.org1.example.com" on the "mychannel" channel
+    Then response from "configscc" to client equal value "p1-org1-testscc-v1-config"
+    Given variable "testSccOrg2Peer0Criteria" is assigned the JSON value '{"MspID":"Org2MSP","PeerID":"peer0.org2.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSccOrg2Peer0Criteria}" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "configscc" to client equal value "p0-org2-testscc-v1-config"
+    Given variable "testSccOrg2Peer1Criteria" is assigned the JSON value '{"MspID":"Org2MSP","PeerID":"peer1.org2.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSccOrg2Peer1Criteria}" on peers "peer1.org2.example.com" on the "mychannel" channel
+    Then response from "configscc" to client equal value "p1-org2-testscc-v1-config"
+    # The following peer-specific data should not be found on foreign peer
+    Given variable "testSccOrg1Peer0Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer0.org1.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSccOrg1Peer0Criteria}" on peers "peer1.org1.example.com" on the "mychannel" channel
+    Then response from "configscc" to client equal value ""

--- a/test/bddtests/fixtures/config/fabric/core.yaml
+++ b/test/bddtests/fixtures/config/fabric/core.yaml
@@ -557,6 +557,7 @@ chaincode:
         vscc: enable
         qscc: enable
         configscc: enable
+        testscc: enable
 
     # System chaincode plugins:
     # System chaincodes can be loaded as shared objects compiled as Go plugins.

--- a/test/bddtests/fixtures/fabric/peer/cmd/main.go
+++ b/test/bddtests/fixtures/fabric/peer/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/trustbloc/fabric-peer-ext/cmd/chaincode/configscc"
 	extscc "github.com/trustbloc/fabric-peer-ext/pkg/chaincode/scc"
+	"github.com/trustbloc/fabric-peer-ext/test/scc/testscc"
 )
 
 var logger = flogging.MustGetLogger("peer-ext-test")
@@ -41,6 +42,9 @@ func setup() {
 func registerSystemChaincodes() {
 	logger.Infof("Registering configscc...")
 	extscc.Register(configscc.New)
+
+	logger.Infof("Registering testscc...")
+	extscc.Register(testscc.New)
 }
 
 func startPeer() error {

--- a/test/scc/testscc/testscc.go
+++ b/test/scc/testscc/testscc.go
@@ -1,0 +1,195 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testscc
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/chaincode/shim"
+	"github.com/hyperledger/fabric/core/scc"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/spf13/viper"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+	configsvc "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/service"
+)
+
+var logger = flogging.MustGetLogger("testscc")
+
+const (
+	sccName        = "testscc"
+	sccPath        = "github.com/trustbloc/fabric-peer-ext/cmd/chaincodes/testscc"
+	peerConfigName = "core"
+	envPrefix      = "core"
+	peerConfigPath = "/etc/hyperledger/fabric"
+	generalMSPID   = "general"
+)
+
+type function func(shim.ChaincodeStubInterface, [][]byte) pb.Response
+
+type testSCC struct {
+	functionRegistry map[string]function
+	localMSPID       string
+	localPeerID      string
+	mutex            sync.RWMutex
+	configSvc        *configsvc.ConfigService
+	config           map[config.Key]*config.Value
+}
+
+// New returns a new configuration system chaincode
+func New() scc.SelfDescribingSysCC {
+	peerConfig, err := newPeerViper()
+	if err != nil {
+		panic("Error reading peer config: " + err.Error())
+	}
+
+	cc := &testSCC{
+		config:      make(map[config.Key]*config.Value),
+		localMSPID:  peerConfig.GetString("peer.localMspId"),
+		localPeerID: peerConfig.GetString("peer.id"),
+	}
+	cc.initFunctionRegistry()
+	return cc
+}
+
+func (scc *testSCC) Name() string              { return sccName }
+func (scc *testSCC) Path() string              { return sccPath }
+func (scc *testSCC) InitArgs() [][]byte        { return nil }
+func (scc *testSCC) Chaincode() shim.Chaincode { return scc }
+func (scc *testSCC) InvokableExternal() bool   { return true }
+func (scc *testSCC) InvokableCC2CC() bool      { return true }
+func (scc *testSCC) Enabled() bool             { return true }
+
+// Init initializes the config SCC
+func (scc *testSCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
+	if stub.GetChannelID() != "" {
+		scc.configSvc = configsvc.GetSvcMgr().ForChannel(stub.GetChannelID())
+
+		logger.Infof("Registering for config update events for local MSP [%s] and local peer [%s] and app [%s]", scc.localMSPID, scc.localPeerID, sccName)
+
+		scc.configSvc.AddUpdateHandler(func(kv *config.KeyValue) {
+			if kv.MspID == scc.localMSPID && kv.PeerID == scc.localPeerID {
+				scc.updateConfig(kv.Key, kv.Value)
+			}
+		})
+	}
+	return shim.Success(nil)
+}
+
+// Invoke invokes the config SCC
+func (scc *testSCC) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
+	args := stub.GetArgs()
+	if len(args) == 0 {
+		return shim.Error(fmt.Sprintf("Function not provided. Expecting one of [%s]", scc.functionSet()))
+	}
+
+	functionName := string(args[0])
+	f, ok := scc.functionRegistry[functionName]
+	if !ok {
+		return shim.Error(fmt.Sprintf("Invalid function: [%s]. Expecting one of [%s]", functionName, scc.functionSet()))
+	}
+
+	functionArgs := args[1:]
+
+	logger.Debugf("Invoking f [%s] with args: %s", functionName, functionArgs)
+	return f(stub, functionArgs)
+}
+
+// getConfig returns the config for the given key from the local cache if it's targeted for the local peer.
+// If a request is made for data owned by another MSP and/or peer then an empty value is returned.
+// If a request is made for the "general" MSP then the config is retrieved from the config service.
+func (scc *testSCC) getConfig(stub shim.ChaincodeStubInterface, args [][]byte) pb.Response {
+	if len(args) < 1 {
+		return shim.Error("expecting config key")
+	}
+
+	key := &config.Key{}
+	err := json.Unmarshal(args[0], key)
+	if err != nil {
+		return shim.Error(fmt.Sprintf("invalid key [%s]: %s", args[0], err))
+	}
+
+	if key.MspID == generalMSPID {
+		logger.Infof("Retrieving value for key [%s] from the config service...", key)
+		value, err := scc.configSvc.Get(key)
+		if err != nil {
+			if err == configsvc.ErrConfigNotFound {
+				logger.Infof("... value for key [%s] not found in the config service", key)
+				return shim.Success(nil)
+			}
+			return shim.Error(fmt.Sprintf("error getting value for key [%s]: %s", key, err))
+		}
+		logger.Infof("... got value for key [%s] from the config service: %s", key, value)
+		return shim.Success([]byte(value.Config))
+	}
+
+	if key.MspID != scc.localMSPID && key.PeerID != scc.localPeerID {
+		return shim.Error(fmt.Sprintf("this peer [%s] does not have access to config for key [%s]", scc.localPeerID, key))
+	}
+
+	logger.Infof("Retrieving value for key [%s] from the local cache...", key)
+	value := scc.getComponentConfig(key)
+	if value != nil {
+		logger.Infof("... got value for key [%s] from the local cache: %s", key, value)
+		return shim.Success([]byte(value.Config))
+	}
+	logger.Infof("... value for key [%s] not found in the local cache", key)
+	return shim.Success(nil)
+}
+
+func (scc *testSCC) updateConfig(key *config.Key, value *config.Value) {
+	scc.mutex.Lock()
+	defer scc.mutex.Unlock()
+
+	if value == nil {
+		delete(scc.config, *key)
+		logger.Infof("Key [%s] was deleted from local cache", key)
+	} else {
+		scc.config[*key] = value
+		logger.Infof("Value for key [%s] in local cache was updated to: %s", key, value)
+	}
+}
+
+func (scc *testSCC) getComponentConfig(key *config.Key) *config.Value {
+	scc.mutex.RLock()
+	defer scc.mutex.RUnlock()
+	return scc.config[*key]
+}
+
+func (scc *testSCC) initFunctionRegistry() {
+	scc.functionRegistry = make(map[string]function)
+	scc.functionRegistry["getconfig"] = scc.getConfig
+}
+
+// functionSet returns a string enumerating all available functions
+func (scc *testSCC) functionSet() string {
+	var functionNames string
+	for name := range scc.functionRegistry {
+		if functionNames != "" {
+			functionNames += ", "
+		}
+		functionNames += name
+	}
+	return functionNames
+}
+
+func newPeerViper() (*viper.Viper, error) {
+	peerViper := viper.New()
+	peerViper.AddConfigPath(peerConfigPath)
+	peerViper.SetConfigName(peerConfigName)
+	peerViper.SetEnvPrefix(envPrefix)
+	peerViper.AutomaticEnv()
+	peerViper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+
+	if err := peerViper.ReadInConfig(); err != nil {
+		return nil, err
+	}
+	return peerViper, nil
+}


### PR DESCRIPTION
Added a BDD test for the local configuration service which includes retrieval by key and notifications of configuration updates/deletes.
A test system chaincode was created for this test and added to the test peer image.

closes #246

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>