### PR TITLE
fix: No match for query if criteria is 'unique'

### DIFF
--- a/pkg/config/ledgerconfig/mgr/querymgr.go
+++ b/pkg/config/ledgerconfig/mgr/querymgr.go
@@ -42,21 +42,15 @@ func (m *QueryManager) Query(criteria *config.Criteria) ([]*config.KeyValue, err
 	key, err := criteria.AsKey()
 	if err == nil {
 		// Retrieve the individual config item by key
-		logger.Debugf("Retrieving config by key [%s]", key)
-		retriever, err := m.retrieverProvider.GetStateRetriever()
+		results, err := m.queryByKey(key)
 		if err != nil {
 			return nil, err
 		}
-		defer retriever.Done()
-
-		value, err := m.getConfig(retriever, key)
-		if err != nil {
-			return nil, err
+		// If the result of the query returned a value then we're done,
+		// otherwise fall through and perform an index-based query
+		if len(results) > 0 {
+			return results, nil
 		}
-		if value == nil {
-			return nil, nil
-		}
-		return []*config.KeyValue{{Key: key, Value: value}}, nil
 	}
 
 	// Query for keys and and out undesired records
@@ -98,6 +92,25 @@ func (m *QueryManager) query(criteria *config.Criteria) ([]*config.KeyValue, err
 		configs = append(configs, &config.KeyValue{Key: k, Value: v})
 	}
 	return ConfigResults(configs).Filter(criteria), nil
+}
+
+func (m *QueryManager) queryByKey(key *config.Key) ([]*config.KeyValue, error) {
+	logger.Debugf("Retrieving config by key [%s]", key)
+	retriever, err := m.retrieverProvider.GetStateRetriever()
+	if err != nil {
+		return nil, err
+	}
+	defer retriever.Done()
+
+	value, err := m.getConfig(retriever, key)
+	if err != nil {
+		return nil, err
+	}
+	var results []*config.KeyValue
+	if value != nil {
+		results = append(results, &config.KeyValue{Key: key, Value: value})
+	}
+	return results, nil
 }
 
 func (m *QueryManager) getConfig(retriever state.StateRetriever, key *config.Key) (*config.Value, error) {

--- a/pkg/config/ledgerconfig/mgr/querymgr_test.go
+++ b/pkg/config/ledgerconfig/mgr/querymgr_test.go
@@ -331,7 +331,11 @@ func TestManager_Search_PeerConfig(t *testing.T) {
 	})
 
 	t.Run("Peer-app-component-version -> success", func(t *testing.T) {
-		results, err := m.Query(&config.Criteria{MspID: msp1, PeerID: peer1, AppName: app5, AppVersion: v1, ComponentName: comp1})
+		results, err := m.Query(&config.Criteria{MspID: msp1, PeerID: peer1, AppName: app5, AppVersion: v1})
+		require.NoError(t, err)
+		require.Equal(t, 3, len(results))
+
+		results, err = m.Query(&config.Criteria{MspID: msp1, PeerID: peer1, AppName: app5, AppVersion: v1, ComponentName: comp1})
 		require.NoError(t, err)
 		require.Equal(t, 2, len(results))
 


### PR DESCRIPTION
When a search is performed using criteria that is deemed to be 'complete' then the retrieval is performed by key as opposed to by indexed query.
In the case where applications have components, and an AppName and AppVersion were provided, then only a key-based retrieval was performed. This resulted in the key not being found.
This patch modifies the behavior by also performing an index-based query if the key retrieval resulted in nil.

closes #251

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>