### PR TITLE
fix: Ambiguous error message 'field [Name] is required'

### DIFF
--- a/pkg/config/ledgerconfig/config/criteria.go
+++ b/pkg/config/ledgerconfig/config/criteria.go
@@ -17,15 +17,15 @@ type Criteria struct {
 	// MspID is the ID of the MSP that owns the data
 	MspID string
 	// PeerID is the ID of the peer with which the data is associated
-	PeerID string
+	PeerID string `json:",omitempty"`
 	// AppName is the name of the application that owns the data
-	AppName string
+	AppName string `json:",omitempty"`
 	// AppVersion is the version of the application config
-	AppVersion string
+	AppVersion string `json:",omitempty"`
 	// ComponentName is the name of the application component
-	ComponentName string
+	ComponentName string `json:",omitempty"`
 	// ComponentVersion is the version of the application component config
-	ComponentVersion string
+	ComponentVersion string `json:",omitempty"`
 }
 
 // String returns a readable string for the Criteria
@@ -39,10 +39,10 @@ func (c *Criteria) Validate() error {
 		return errors.New("field [MspID] is required")
 	}
 	if c.AppVersion != "" && c.AppName == "" {
-		return errors.New("field [Name] is required")
+		return errors.New("field [AppName] is required")
 	}
 	if c.ComponentName != "" && c.AppName == "" {
-		return errors.New("field [Name] is required")
+		return errors.New("field [AppName] is required")
 	}
 	if c.ComponentVersion != "" && c.ComponentName == "" {
 		return errors.New("field [ComponentName] is required")

--- a/pkg/config/ledgerconfig/config/criteria_test.go
+++ b/pkg/config/ledgerconfig/config/criteria_test.go
@@ -77,10 +77,10 @@ func TestCriteria_Validate(t *testing.T) {
 		require.EqualError(t, c.Validate(), "field [MspID] is required")
 
 		c = Criteria{MspID: msp1, AppVersion: v1}
-		require.EqualError(t, c.Validate(), "field [Name] is required")
+		require.EqualError(t, c.Validate(), "field [AppName] is required")
 
 		c = Criteria{MspID: msp1, ComponentName: comp1}
-		require.EqualError(t, c.Validate(), "field [Name] is required")
+		require.EqualError(t, c.Validate(), "field [AppName] is required")
 
 		c = Criteria{MspID: msp1, AppName: app1, ComponentVersion: v1}
 		require.EqualError(t, c.Validate(), "field [ComponentName] is required")

--- a/pkg/config/ledgerconfig/config/keyvalue.go
+++ b/pkg/config/ledgerconfig/config/keyvalue.go
@@ -18,15 +18,15 @@ type Key struct {
 	// MspID is the ID of the MSP that owns the data
 	MspID string
 	// PeerID is the (optional) ID of the peer with which the data is associated
-	PeerID string
+	PeerID string `json:",omitempty"`
 	// AppName is the name of the application that owns the data
 	AppName string
 	// AppVersion is the version of the application config
 	AppVersion string
 	// ComponentName is the (optional) name of the application component
-	ComponentName string
+	ComponentName string `json:",omitempty"`
 	// ComponentVersion is the (optional) version of the application component config
-	ComponentVersion string
+	ComponentVersion string `json:",omitempty"`
 }
 
 // String returns a readable string for the key

--- a/pkg/config/ledgerconfig/mgr/querymgr_test.go
+++ b/pkg/config/ledgerconfig/mgr/querymgr_test.go
@@ -223,14 +223,14 @@ func TestManager_Search_AppConfig(t *testing.T) {
 	t.Run("No Name with AppVersion -> error", func(t *testing.T) {
 		results, err := m.Query(&config.Criteria{MspID: msp1, AppVersion: v1})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "field [Name] is required")
+		require.Contains(t, err.Error(), "field [AppName] is required")
 		require.Empty(t, results)
 	})
 
 	t.Run("No Name with Component -> error", func(t *testing.T) {
 		results, err := m.Query(&config.Criteria{MspID: msp1, ComponentName: comp1})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "field [Name] is required")
+		require.Contains(t, err.Error(), "field [AppName] is required")
 		require.Empty(t, results)
 	})
 

--- a/pkg/config/ledgerconfig/mgr/updatemgr_test.go
+++ b/pkg/config/ledgerconfig/mgr/updatemgr_test.go
@@ -395,7 +395,7 @@ func TestUpdateManager_Delete(t *testing.T) {
 
 	t.Run("Invalid criteria -> error", func(t *testing.T) {
 		_, err := m.Query(&config.Criteria{MspID: msp1, PeerID: peer1, AppVersion: v1})
-		require.EqualError(t, err, "field [Name] is required")
+		require.EqualError(t, err, "field [AppName] is required")
 	})
 
 	t.Run("StateStoreProvider error", func(t *testing.T) {


### PR DESCRIPTION
- Changed the error message to 'field [AppName] is required'
- Also, omitted empty fields in Criteria and Key for marshalled JSON

closes #252

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>