### PR TITLE
fix: Error converting to Timestamp

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -78,8 +78,7 @@ func IsNil(p interface{}) bool {
 
 // ToTimestamp converts the Time into Timestamp
 func ToTimestamp(t time.Time) *timestamp.Timestamp {
-	now := time.Now().UTC()
-	return &(timestamp.Timestamp{Seconds: now.Unix()})
+	return &(timestamp.Timestamp{Seconds: t.Unix()})
 }
 
 // FromTimestamp converts the Timestamp into Time

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -104,7 +104,7 @@ func TestValues_Merge(t *testing.T) {
 }
 
 func TestTimestamp(t *testing.T) {
-	tim := time.Now()
+	tim := time.Now().Add(time.Second)
 	tim2 := FromTimestamp(ToTimestamp(tim))
 	assert.Equal(t, tim.Unix(), tim2.Unix())
 }


### PR DESCRIPTION
When converting from time.Time to timestamp.Timestamp, the current time was always being used.

closes #261

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>