### PR TITLE
feat: Implement BlockVisitor

### DIFF
--- a/mod/peer/gossip/api/gossipapi.go
+++ b/mod/peer/gossip/api/gossipapi.go
@@ -32,8 +32,8 @@ type ChaincodeUpgradeHandler func(txMetadata TxMetadata, chaincodeName string) e
 // LSCCWriteHandler handles chaincode instantiation/upgrade events
 type LSCCWriteHandler func(txMetadata TxMetadata, chaincodeName string, ccData *ccprovider.ChaincodeData, ccp *cb.CollectionConfigPackage) error
 
-// BlockPublisher allows clients to add handlers for various block events
-type BlockPublisher interface {
+// BlockHandler allows clients to add handlers for various block events
+type BlockHandler interface {
 	// AddCCUpgradeHandler adds a handler for chaincode upgrades
 	AddCCUpgradeHandler(handler ChaincodeUpgradeHandler)
 	// AddConfigUpdateHandler adds a handler for config updates
@@ -46,10 +46,22 @@ type BlockPublisher interface {
 	AddLSCCWriteHandler(handler LSCCWriteHandler)
 	// AddCCEventHandler adds a handler for chaincode events
 	AddCCEventHandler(handler ChaincodeEventHandler)
-	// Publish traverses the block and invokes all applicable handlers
-	Publish(block *cb.Block)
 	//LedgerHeight returns current in memory ledger height
 	LedgerHeight() uint64
+}
+
+// BlockVisitor allows clients to add handlers for various block events
+type BlockVisitor interface {
+	BlockHandler
+	// Visit traverses the block and invokes all applicable handlers
+	Visit(block *cb.Block) error
+}
+
+// BlockPublisher allows clients to add handlers for various block events
+type BlockPublisher interface {
+	BlockHandler
+	// Publish traverses the block and invokes all applicable handlers
+	Publish(block *cb.Block)
 }
 
 // TxMetadata contain txn metadata

--- a/pkg/common/blockvisitor/blockvisitor.go
+++ b/pkg/common/blockvisitor/blockvisitor.go
@@ -1,0 +1,520 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockvisitor
+
+import (
+	"strings"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/core/common/ccprovider"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
+	ledgerutil "github.com/hyperledger/fabric/core/ledger/util"
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+)
+
+const (
+	// LsccID is the ID of the Lifecycle system chaincode
+	LsccID = "lscc"
+	// CollectionSeparator is used as a separator between the namespace (chaincode ID) and collection name
+	CollectionSeparator = "~"
+)
+
+var logger = flogging.MustGetLogger("ext_blockvisitor")
+
+// Write contains all information related to a KV write on the block
+type Write struct {
+	BlockNum  uint64
+	TxID      string
+	TxNum     uint64
+	Namespace string
+	Write     *kvrwset.KVWrite
+}
+
+// Read contains all information related to a KV read on the block
+type Read struct {
+	BlockNum  uint64
+	TxID      string
+	TxNum     uint64
+	Namespace string
+	Read      *kvrwset.KVRead
+}
+
+// LSCCWrite contains all information related to an LSCC write on the block
+type LSCCWrite struct {
+	BlockNum uint64
+	TxID     string
+	TxNum    uint64
+	CCID     string
+	CCData   *ccprovider.ChaincodeData
+	CCP      *cb.CollectionConfigPackage
+}
+
+// CCEvent contains all information related to a chaincode Event on the block
+type CCEvent struct {
+	BlockNum uint64
+	TxID     string
+	TxNum    uint64
+	Event    *pb.ChaincodeEvent
+}
+
+// ConfigUpdate contains all information related to a config-update on the block
+type ConfigUpdate struct {
+	BlockNum     uint64
+	ConfigUpdate *cb.ConfigUpdate
+}
+
+// CCEventHandler publishes chaincode events
+type CCEventHandler func(ccEvent *CCEvent) error
+
+// ReadHandler publishes KV read events
+type ReadHandler func(read *Read) error
+
+// WriteHandler publishes KV write events
+type WriteHandler func(write *Write) error
+
+// LSCCWriteHandler publishes LSCC write events
+type LSCCWriteHandler func(lsccWrite *LSCCWrite) error
+
+// ConfigUpdateHandler publishes config updates
+type ConfigUpdateHandler func(update *ConfigUpdate) error
+
+// Handlers contains the full set of handlers
+type Handlers struct {
+	HandleCCEvent      CCEventHandler
+	HandleRead         ReadHandler
+	HandleWrite        WriteHandler
+	HandleLSCCWrite    LSCCWriteHandler
+	HandleConfigUpdate ConfigUpdateHandler
+}
+
+// Options contains all block Visitor options
+type Options struct {
+	*Handlers
+	StopOnError bool
+}
+
+// Opt is a block visitor option
+type Opt func(options *Options)
+
+// WithNoStopOnError indicates that processing should proceed even
+// though an error occurs in one of the handlers.
+func WithNoStopOnError() Opt {
+	return func(options *Options) {
+		options.StopOnError = false
+	}
+}
+
+// WithCCEventHandler sets the chaincode event handler
+func WithCCEventHandler(handler CCEventHandler) Opt {
+	return func(options *Options) {
+		options.HandleCCEvent = handler
+	}
+}
+
+// WithReadHandler sets the read handler
+func WithReadHandler(handler ReadHandler) Opt {
+	return func(options *Options) {
+		options.HandleRead = handler
+	}
+}
+
+// WithWriteHandler sets the write handler
+func WithWriteHandler(handler WriteHandler) Opt {
+	return func(options *Options) {
+		options.HandleWrite = handler
+	}
+}
+
+// WithLSCCWriteHandler sets the LSCC write handler
+func WithLSCCWriteHandler(handler LSCCWriteHandler) Opt {
+	return func(options *Options) {
+		options.HandleLSCCWrite = handler
+	}
+}
+
+// WithConfigUpdateHandler sets the config-update handler
+func WithConfigUpdateHandler(handler ConfigUpdateHandler) Opt {
+	return func(options *Options) {
+		options.HandleConfigUpdate = handler
+	}
+}
+
+// Visitor traverses a block and publishes KV Read, KV Write, LSCC write, and chaincode events to registered handlers
+type Visitor struct {
+	*Options
+	channelID          string
+	lastCommittedBlock uint64
+}
+
+// New returns a new block Visitor for the given channel
+func New(channelID string, opts ...Opt) *Visitor {
+	visitor := &Visitor{
+		channelID: channelID,
+		Options: &Options{
+			Handlers:    noopHandlers(),
+			StopOnError: true,
+		},
+	}
+
+	for _, opt := range opts {
+		opt(visitor.Options)
+	}
+
+	return visitor
+}
+
+// ChannelID returns the channel ID for the vistor
+func (p *Visitor) ChannelID() string {
+	return p.channelID
+}
+
+// Visit traverses the given block and invokes the applicable handlers
+func (p *Visitor) Visit(block *cb.Block) error {
+	defer atomic.StoreUint64(&p.lastCommittedBlock, block.Header.Number)
+	return newBlockEvent(p.channelID, block, p.Options).visit()
+}
+
+// LedgerHeight returns ledger height based on last block published
+func (p *Visitor) LedgerHeight() uint64 {
+	return atomic.LoadUint64(&p.lastCommittedBlock) + 1
+}
+
+type blockEvent struct {
+	*Options
+	channelID string
+	block     *cb.Block
+}
+
+func newBlockEvent(channelID string, block *cb.Block, options *Options) *blockEvent {
+	return &blockEvent{
+		Options:   options,
+		channelID: channelID,
+		block:     block,
+	}
+}
+
+func (p *blockEvent) visit() error {
+	logger.Debugf("[%s] Publishing block #%d", p.channelID, p.block.Header.Number)
+	for txNum := range p.block.Data.Data {
+		envelope, err := extractEnvelope(p.block, txNum)
+		if err != nil {
+			if p.StopOnError {
+				return errors.Wrapf(err, "error extracting envelope at index %d in block %d", txNum, p.block.Header.Number)
+			}
+			logger.Warningf("[%s] Error extracting envelope at index %d in block %d: %s", p.channelID, txNum, p.block.Header.Number, err)
+			continue
+		}
+		if err = p.visitEnvelope(uint64(txNum), envelope); err != nil {
+			if p.StopOnError {
+				return errors.Wrapf(err, "error visiting envelope at index %d in block %d", txNum, p.block.Header.Number)
+			}
+			logger.Warningf("[%s] Error visiting envelope at index %d in block %d: %s", p.channelID, txNum, p.block.Header.Number, err)
+		}
+	}
+	return nil
+}
+
+func (p *blockEvent) visitEnvelope(txNum uint64, envelope *cb.Envelope) error {
+	payload, err := extractPayload(envelope)
+	if err != nil {
+		return err
+	}
+
+	chdr, err := unmarshalChannelHeader(payload.Header.ChannelHeader)
+	if err != nil {
+		return err
+	}
+
+	if cb.HeaderType(chdr.Type) == cb.HeaderType_ENDORSER_TRANSACTION {
+		txFilter := ledgerutil.TxValidationFlags(p.block.Metadata.Metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER])
+		code := txFilter.Flag(int(txNum))
+		if code != pb.TxValidationCode_VALID {
+			logger.Debugf("[%s] Transaction at index %d in block %d is not valid. Status code: %s", p.channelID, txNum, p.block.Header.Number, code)
+			return nil
+		}
+		tx, err := getTransaction(payload.Data)
+		if err != nil {
+			return err
+		}
+		return newTxEvent(p.channelID, p.block.Header.Number, txNum, chdr.TxId, tx, p.Options).visit()
+	}
+
+	if cb.HeaderType(chdr.Type) == cb.HeaderType_CONFIG_UPDATE {
+		envelope := &cb.ConfigUpdateEnvelope{}
+		if err := unmarshal(payload.Data, envelope); err != nil {
+			return err
+		}
+		return newConfigUpdateEvent(p.channelID, p.block.Header.Number, envelope, p.Handlers).visit()
+	}
+
+	return nil
+}
+
+type txEvent struct {
+	*Options
+	channelID string
+	blockNum  uint64
+	txNum     uint64
+	txID      string
+	tx        *pb.Transaction
+}
+
+func newTxEvent(channelID string, blockNum uint64, txNum uint64, txID string, tx *pb.Transaction, options *Options) *txEvent {
+	return &txEvent{
+		Options:   options,
+		channelID: channelID,
+		blockNum:  blockNum,
+		txNum:     txNum,
+		txID:      txID,
+		tx:        tx,
+	}
+}
+
+func (p *txEvent) visit() error {
+	logger.Debugf("[%s] Publishing Tx %s in block #%d", p.channelID, p.txID, p.blockNum)
+	for i, action := range p.tx.Actions {
+		err := p.visitTXAction(action)
+		if err != nil {
+			if p.StopOnError {
+				return errors.Wrapf(err, "error checking TxAction at index %d", i)
+			}
+			logger.Warningf("[%s] Error checking TxAction at index %d: %s", p.channelID, i, err)
+		}
+	}
+	return nil
+}
+
+func (p *txEvent) visitTXAction(action *pb.TransactionAction) error {
+	chaPayload, err := getChaincodeActionPayload(action.Payload)
+	if err != nil {
+		return err
+	}
+	return p.visitChaincodeActionPayload(chaPayload)
+}
+
+func (p *txEvent) visitChaincodeActionPayload(chaPayload *pb.ChaincodeActionPayload) error {
+	cpp := &pb.ChaincodeProposalPayload{}
+	err := unmarshal(chaPayload.ChaincodeProposalPayload, cpp)
+	if err != nil {
+		return err
+	}
+
+	return p.visitAction(chaPayload.Action)
+}
+
+func (p *txEvent) visitAction(action *pb.ChaincodeEndorsedAction) error {
+	prp := &pb.ProposalResponsePayload{}
+	err := unmarshal(action.ProposalResponsePayload, prp)
+	if err != nil {
+		return err
+	}
+	return p.visitProposalResponsePayload(prp)
+}
+
+func (p *txEvent) visitProposalResponsePayload(prp *pb.ProposalResponsePayload) error {
+	chaincodeAction := &pb.ChaincodeAction{}
+	err := unmarshal(prp.Extension, chaincodeAction)
+	if err != nil {
+		return err
+	}
+	return p.visitChaincodeAction(chaincodeAction)
+}
+
+func (p *txEvent) visitChaincodeAction(chaincodeAction *pb.ChaincodeAction) error {
+	if len(chaincodeAction.Results) > 0 {
+		txRWSet := &rwsetutil.TxRwSet{}
+		if err := txRWSet.FromProtoBytes(chaincodeAction.Results); err != nil {
+			return err
+		}
+		if err := p.visitTxReadWriteSet(txRWSet); err != nil {
+			return err
+		}
+	}
+
+	if len(chaincodeAction.Events) > 0 {
+		evt := &pb.ChaincodeEvent{}
+		if err := unmarshal(chaincodeAction.Events, evt); err != nil {
+			logger.Warningf("[%s] Invalid chaincode Event for chaincode [%s]", p.channelID, chaincodeAction.ChaincodeId)
+			return errors.WithMessagef(err, "invalid chaincode Event for chaincode [%s]", chaincodeAction.ChaincodeId)
+		}
+		err := p.HandleCCEvent(&CCEvent{
+			BlockNum: p.blockNum,
+			TxID:     p.txID,
+			Event:    evt,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *txEvent) visitTxReadWriteSet(txRWSet *rwsetutil.TxRwSet) error {
+	for _, nsRWSet := range txRWSet.NsRwSets {
+		if err := p.visitNsReadWriteSet(nsRWSet); err != nil {
+			if p.StopOnError {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (p *txEvent) visitNsReadWriteSet(nsRWSet *rwsetutil.NsRwSet) error {
+	for _, r := range nsRWSet.KvRwSet.Reads {
+		if err := p.HandleRead(&Read{
+			BlockNum:  p.blockNum,
+			TxID:      p.txID,
+			Namespace: nsRWSet.NameSpace,
+			Read:      r,
+		}); err != nil {
+			if p.StopOnError {
+				return err
+			}
+		}
+	}
+	if nsRWSet.NameSpace == LsccID {
+		return p.publishLSCCWrite(nsRWSet.KvRwSet.Writes)
+	}
+	return p.publishWrites(nsRWSet.NameSpace, nsRWSet.KvRwSet.Writes)
+}
+
+// publishLSCCWrite publishes an LSCC Write Event which is a result of a chaincode instantiate/upgrade.
+// The Event consists of two writes: CC data and collection configs.
+func (p *txEvent) publishLSCCWrite(writes []*kvrwset.KVWrite) error {
+	ccID, ccData, ccp, err := getCCInfo(writes)
+	if err != nil {
+		if p.StopOnError {
+			return err
+		}
+		logger.Warningf("[%s] Error getting chaincode info: %s", p.channelID, err)
+		return nil
+	}
+
+	return p.HandleLSCCWrite(&LSCCWrite{
+		BlockNum: p.blockNum,
+		TxID:     p.txID,
+		CCID:     ccID,
+		CCData:   ccData,
+		CCP:      ccp,
+	})
+}
+
+func (p *txEvent) publishWrites(ns string, writes []*kvrwset.KVWrite) error {
+	for _, w := range writes {
+		if err := p.HandleWrite(&Write{
+			BlockNum:  p.blockNum,
+			TxID:      p.txID,
+			Namespace: ns,
+			Write:     w,
+		}); err != nil {
+			if p.StopOnError {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type configUpdateEvent struct {
+	*Handlers
+	channelID string
+	blockNum  uint64
+	envelope  *cb.ConfigUpdateEnvelope
+}
+
+func newConfigUpdateEvent(channelID string, blockNum uint64, envelope *cb.ConfigUpdateEnvelope, handlers *Handlers) *configUpdateEvent {
+	return &configUpdateEvent{
+		Handlers:  handlers,
+		channelID: channelID,
+		blockNum:  blockNum,
+		envelope:  envelope,
+	}
+}
+
+func (p *configUpdateEvent) visit() error {
+	cu := &cb.ConfigUpdate{}
+	if err := unmarshal(p.envelope.ConfigUpdate, cu); err != nil {
+		logger.Warningf("[%s] Error unmarshalling config update: %s", p.channelID, err)
+		return err
+	}
+
+	logger.Debugf("[%s] Publishing Config Update [%s] in block #%d", p.channelID, cu, p.blockNum)
+
+	return p.HandleConfigUpdate(&ConfigUpdate{
+		BlockNum:     p.blockNum,
+		ConfigUpdate: cu,
+	})
+}
+
+func getCCInfo(writes []*kvrwset.KVWrite) (string, *ccprovider.ChaincodeData, *cb.CollectionConfigPackage, error) {
+	var ccID string
+	var ccp *cb.CollectionConfigPackage
+	var ccData *ccprovider.ChaincodeData
+
+	for _, kvWrite := range writes {
+		if isCollectionConfigKey(kvWrite.Key) {
+			ccp = &cb.CollectionConfigPackage{}
+			if err := unmarshal(kvWrite.Value, ccp); err != nil {
+				return "", nil, nil, errors.WithMessagef(err, "error unmarshaling collection configuration")
+			}
+		} else {
+			ccID = kvWrite.Key
+			ccData = &ccprovider.ChaincodeData{}
+			if err := unmarshal(kvWrite.Value, ccData); err != nil {
+				return "", nil, nil, errors.WithMessagef(err, "error unmarshaling chaincode data")
+			}
+		}
+	}
+
+	return ccID, ccData, ccp, nil
+}
+
+func noopHandlers() *Handlers {
+	return &Handlers{
+		HandleCCEvent:      func(*CCEvent) error { return nil },
+		HandleRead:         func(*Read) error { return nil },
+		HandleWrite:        func(*Write) error { return nil },
+		HandleLSCCWrite:    func(*LSCCWrite) error { return nil },
+		HandleConfigUpdate: func(*ConfigUpdate) error { return nil },
+	}
+}
+
+func isCollectionConfigKey(key string) bool {
+	return strings.Contains(key, CollectionSeparator)
+}
+
+var unmarshal = func(buf []byte, pb proto.Message) error {
+	return proto.Unmarshal(buf, pb)
+}
+
+var extractEnvelope = func(block *cb.Block, index int) (*cb.Envelope, error) {
+	return protoutil.ExtractEnvelope(block, index)
+}
+
+var extractPayload = func(envelope *cb.Envelope) (*cb.Payload, error) {
+	return protoutil.ExtractPayload(envelope)
+}
+
+var unmarshalChannelHeader = func(bytes []byte) (*cb.ChannelHeader, error) {
+	return protoutil.UnmarshalChannelHeader(bytes)
+}
+
+var getTransaction = func(txBytes []byte) (*pb.Transaction, error) {
+	return protoutil.GetTransaction(txBytes)
+}
+
+var getChaincodeActionPayload = func(capBytes []byte) (*pb.ChaincodeActionPayload, error) {
+	return protoutil.GetChaincodeActionPayload(capBytes)
+}

--- a/pkg/common/blockvisitor/blockvisitor_test.go
+++ b/pkg/common/blockvisitor/blockvisitor_test.go
@@ -1,0 +1,458 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockvisitor
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/core/common/ccprovider"
+	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/rwset/kvrwset"
+	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	channelID = "testchannel"
+
+	txID1 = "tx1"
+	txID2 = "tx2"
+	txID3 = "tx3"
+
+	ccID1 = "cc1"
+	ccID2 = "cc2"
+
+	coll1 = "collection1"
+	coll2 = "collection2"
+
+	key1 = "key1"
+	key2 = "key2"
+	key3 = "key3"
+
+	ccEvent1 = "ccevent1"
+)
+
+func TestVisitor_HandleEndorsementEvents(t *testing.T) {
+	numReads := 0
+	numWrites := 0
+	numLSCCWrites := 0
+	numCCEvents := 0
+
+	p := New(channelID,
+		WithCCEventHandler(func(ccEvent *CCEvent) error {
+			numCCEvents++
+			return nil
+		}),
+		WithReadHandler(func(read *Read) error {
+			numReads++
+			return nil
+		}),
+		WithWriteHandler(func(write *Write) error {
+			numWrites++
+			return nil
+		}),
+		WithLSCCWriteHandler(func(lsccWrite *LSCCWrite) error {
+			numLSCCWrites++
+			return nil
+		}),
+	)
+	require.NotNil(t, p)
+	require.Equal(t, channelID, p.ChannelID())
+
+	block := mockBlockWithTransactions(t)
+	t.Run("No handlers", func(t *testing.T) {
+		p := New(channelID)
+		require.NoError(t, p.Visit(block))
+		require.NotNil(t, p)
+	})
+
+	t.Run("With handlers", func(t *testing.T) {
+		require.NoError(t, p.Visit(block))
+		assert.Equal(t, 2, numReads)
+		assert.Equal(t, 5, numWrites)
+		assert.Equal(t, 2, numCCEvents)
+		assert.Equal(t, 2, numLSCCWrites)
+		assert.EqualValues(t, 1101, p.LedgerHeight())
+	})
+}
+
+func TestVisitor_PublishConfigUpdateEvents(t *testing.T) {
+	b := mocks.NewBlockBuilder(channelID, 1100)
+	b.ConfigUpdate()
+
+	t.Run("No handlers", func(t *testing.T) {
+		p := New(channelID)
+		require.NoError(t, p.Visit(b.Build()))
+	})
+
+	t.Run("With handlers", func(t *testing.T) {
+		numConfigUpdates := 0
+
+		p := New(channelID,
+			WithConfigUpdateHandler(func(update *ConfigUpdate) error {
+				numConfigUpdates++
+				return nil
+			}),
+		)
+		require.NotNil(t, p)
+
+		require.NoError(t, p.Visit(b.Build()))
+		assert.Equal(t, 1, numConfigUpdates)
+		assert.EqualValues(t, 1101, p.LedgerHeight())
+	})
+}
+
+func TestVisitor_LSCCWriteEvent(t *testing.T) {
+	numLSCCWrites := 0
+
+	var info ccInfo
+
+	p := New(channelID,
+		WithLSCCWriteHandler(func(lsccWrite *LSCCWrite) error {
+			numLSCCWrites++
+			info.set(lsccWrite.CCID, lsccWrite.CCData, lsccWrite.CCP)
+			return nil
+		}),
+	)
+	require.NotNil(t, p)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+
+	ccData := &ccprovider.ChaincodeData{
+		Name: ccID1,
+	}
+	ccDataBytes, err := proto.Marshal(ccData)
+	require.NoError(t, err)
+
+	ccp := &cb.CollectionConfigPackage{
+		Config: []*cb.CollectionConfig{
+			{
+				Payload: &cb.CollectionConfig_StaticCollectionConfig{
+					StaticCollectionConfig: &cb.StaticCollectionConfig{
+						Name: coll1,
+						Type: cb.CollectionType_COL_TRANSIENT,
+					},
+				},
+			},
+			{
+				Payload: &cb.CollectionConfig_StaticCollectionConfig{
+					StaticCollectionConfig: &cb.StaticCollectionConfig{
+						Name: coll2,
+						Type: cb.CollectionType_COL_OFFLEDGER,
+					},
+				},
+			},
+		},
+	}
+	ccpBytes, err := proto.Marshal(ccp)
+	require.NoError(t, err)
+
+	b.Transaction(txID1, pb.TxValidationCode_VALID).
+		ChaincodeAction(LsccID).
+		Write(ccID1, ccDataBytes).
+		Write(ccID1+CollectionSeparator+"collection", ccpBytes)
+
+	require.NoError(t, p.Visit(b.Build()))
+	require.Equal(t, ccID1, info.getCCName())
+	require.NotNil(t, info.getCCData())
+	require.Equal(t, ccData.Name, info.getCCData().Name)
+	require.NotNil(t, info.getCCP())
+	require.Equal(t, 2, len(info.getCCP().Config))
+
+	config1 := info.getCCP().Config[0].GetStaticCollectionConfig()
+	require.NotNil(t, config1)
+	require.Equal(t, coll1, config1.Name)
+	require.Equal(t, cb.CollectionType_COL_TRANSIENT, config1.Type)
+
+	config2 := info.getCCP().Config[1].GetStaticCollectionConfig()
+	require.NotNil(t, config2)
+	require.Equal(t, coll2, config2.Name)
+	require.Equal(t, cb.CollectionType_COL_OFFLEDGER, config2.Type)
+}
+
+func TestVisitor_LSCCWriteEventMarshalError(t *testing.T) {
+	numLSCCWrites := 0
+
+	var info ccInfo
+
+	p := New(channelID,
+		WithLSCCWriteHandler(func(lsccWrite *LSCCWrite) error {
+			numLSCCWrites++
+			info.set(lsccWrite.CCID, lsccWrite.CCData, lsccWrite.CCP)
+			return nil
+		}),
+	)
+	require.NotNil(t, p)
+
+	ccData := &ccprovider.ChaincodeData{
+		Name: ccID1,
+	}
+	ccDataBytes, err := proto.Marshal(ccData)
+	require.NoError(t, err)
+
+	ccp := &cb.CollectionConfigPackage{
+		Config: []*cb.CollectionConfig{
+			{
+				Payload: &cb.CollectionConfig_StaticCollectionConfig{
+					StaticCollectionConfig: &cb.StaticCollectionConfig{
+						Name: coll1,
+					},
+				},
+			},
+		},
+	}
+	ccpBytes, err := proto.Marshal(ccp)
+	require.NoError(t, err)
+
+	t.Run("CCData unmarshal error", func(t *testing.T) {
+		b := mocks.NewBlockBuilder(channelID, 1100)
+
+		b.Transaction(txID1, pb.TxValidationCode_VALID).
+			ChaincodeAction(LsccID).
+			Write(ccID1, []byte("invalid cc data")).
+			Write(ccID1+CollectionSeparator+"collection", ccpBytes)
+
+		err := p.Visit(b.Build())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error unmarshaling chaincode data")
+		require.Empty(t, info.ccName)
+		require.Nil(t, info.ccData)
+		require.Nil(t, info.ccp)
+	})
+
+	t.Run("CCP unmarshal error", func(t *testing.T) {
+		b := mocks.NewBlockBuilder(channelID, 1100)
+
+		b.Transaction(txID1, pb.TxValidationCode_VALID).
+			ChaincodeAction(LsccID).
+			Write(ccID1, ccDataBytes).
+			Write(ccID1+CollectionSeparator+"collection", []byte("invalid ccp"))
+
+		err := p.Visit(b.Build())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error unmarshaling collection configuration")
+		require.Empty(t, info.ccName)
+		require.Nil(t, info.ccData)
+		require.Nil(t, info.ccp)
+	})
+}
+
+func TestVisitor_Error(t *testing.T) {
+	p := New(channelID)
+	pNoStop := New(channelID, WithNoStopOnError())
+
+	block := mockBlockWithTransactions(t)
+
+	t.Run("Unmarshal error", func(t *testing.T) {
+		errExpected := errors.New("injected Unmarshal error")
+		restore := unmarshal
+		unmarshal = func(buf []byte, pb proto.Message) error { return errExpected }
+		defer func() { unmarshal = restore }()
+
+		err := p.Visit(block)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.NoError(t, pNoStop.Visit(block))
+	})
+
+	t.Run("ExtractEnvelope error", func(t *testing.T) {
+		errExpected := errors.New("injected ExtractEnvelope error")
+		restore := extractEnvelope
+		extractEnvelope = func(block *cb.Block, index int) (envelope *cb.Envelope, e error) { return nil, errExpected }
+		defer func() { extractEnvelope = restore }()
+
+		err := p.Visit(block)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.NoError(t, pNoStop.Visit(block))
+	})
+
+	t.Run("ExtractPayload error", func(t *testing.T) {
+		errExpected := errors.New("injected ExtractPayload error")
+		restore := extractPayload
+		extractPayload = func(envelope *cb.Envelope) (payload *cb.Payload, e error) { return nil, errExpected }
+		defer func() { extractPayload = restore }()
+
+		err := p.Visit(block)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.NoError(t, pNoStop.Visit(block))
+	})
+
+	t.Run("UnmarshalChannelHeader error", func(t *testing.T) {
+		errExpected := errors.New("injected UnmarshalChannelHeader error")
+		restore := unmarshalChannelHeader
+		unmarshalChannelHeader = func(bytes []byte) (header *cb.ChannelHeader, e error) { return nil, errExpected }
+		defer func() { unmarshalChannelHeader = restore }()
+
+		err := p.Visit(block)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.NoError(t, pNoStop.Visit(block))
+	})
+
+	t.Run("GetTransaction error", func(t *testing.T) {
+		errExpected := errors.New("injected GetTransaction error")
+		restore := getTransaction
+		getTransaction = func(txBytes []byte) (transaction *pb.Transaction, e error) { return nil, errExpected }
+		defer func() { getTransaction = restore }()
+
+		err := p.Visit(block)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.NoError(t, pNoStop.Visit(block))
+	})
+
+	t.Run("GetChaincodeActionPayload error", func(t *testing.T) {
+		errExpected := errors.New("injected GetChaincodeActionPayload error")
+		restore := getChaincodeActionPayload
+		getChaincodeActionPayload = func(capBytes []byte) (payload *pb.ChaincodeActionPayload, e error) { return nil, errExpected }
+		defer func() { getChaincodeActionPayload = restore }()
+
+		err := p.Visit(block)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), errExpected.Error())
+		require.NoError(t, pNoStop.Visit(block))
+	})
+}
+
+func TestVisitor_NoStopOnError(t *testing.T) {
+	expectedErr := fmt.Errorf("injected error")
+	numReads := 0
+	numWrites := 0
+	numLSCCWrites := 0
+	numCCEvents := 0
+
+	p := New(channelID, WithNoStopOnError(),
+		WithCCEventHandler(func(ccEvent *CCEvent) error {
+			numCCEvents++
+			return expectedErr
+		}),
+		WithReadHandler(func(read *Read) error {
+			numReads++
+			return expectedErr
+		}),
+		WithWriteHandler(func(write *Write) error {
+			numWrites++
+			return expectedErr
+		}),
+		WithLSCCWriteHandler(func(lsccWrite *LSCCWrite) error {
+			numLSCCWrites++
+			return expectedErr
+		}),
+	)
+	require.NotNil(t, p)
+
+	require.NoError(t, p.Visit(mockBlockWithTransactions(t)))
+	assert.Equal(t, 2, numReads)
+	assert.Equal(t, 5, numWrites)
+	assert.Equal(t, 2, numCCEvents)
+	assert.EqualValues(t, 1101, p.LedgerHeight())
+}
+
+type ccInfo struct {
+	mutex  sync.RWMutex
+	ccName string
+	ccData *ccprovider.ChaincodeData
+	ccp    *cb.CollectionConfigPackage
+}
+
+func (info *ccInfo) set(ccName string, ccData *ccprovider.ChaincodeData, ccp *cb.CollectionConfigPackage) {
+	info.mutex.Lock()
+	defer info.mutex.Unlock()
+
+	info.ccName = ccName
+	info.ccData = ccData
+	info.ccp = ccp
+}
+
+func (info *ccInfo) getCCName() string {
+	info.mutex.RLock()
+	defer info.mutex.RUnlock()
+	return info.ccName
+}
+
+func (info *ccInfo) getCCData() *ccprovider.ChaincodeData {
+	info.mutex.RLock()
+	defer info.mutex.RUnlock()
+	return info.ccData
+}
+
+func (info *ccInfo) getCCP() *cb.CollectionConfigPackage {
+	info.mutex.RLock()
+	defer info.mutex.RUnlock()
+	return info.ccp
+}
+
+func mockBlockWithTransactions(t *testing.T) *cb.Block {
+	var (
+		value1 = []byte("value1")
+		value2 = []byte("value2")
+		value3 = []byte("value3")
+
+		v1 = &kvrwset.Version{
+			BlockNum: 1000,
+			TxNum:    0,
+		}
+		v2 = &kvrwset.Version{
+			BlockNum: 1001,
+			TxNum:    1,
+		}
+	)
+
+	b := mocks.NewBlockBuilder(channelID, 1100)
+
+	tb1 := b.Transaction(txID1, pb.TxValidationCode_VALID)
+	tb1.ChaincodeAction(ccID1).
+		Write(key1, value1).
+		Read(key1, v1).
+		ChaincodeEvent(ccEvent1, []byte("ccpayload"))
+	tb1.ChaincodeAction(ccID2).
+		Write(key2, value2).
+		Read(key2, v2)
+
+	tb2 := b.Transaction(txID2, pb.TxValidationCode_VALID)
+	cc2_1 := tb2.ChaincodeAction(ccID1).
+		Write(key2, value2)
+	cc2_1.Collection(coll1).
+		Write(key1, value2)
+	cc2_1.Collection(coll2).
+		Delete(key1)
+
+	// This transaction should not be published
+	tb3 := b.Transaction(txID3, pb.TxValidationCode_MVCC_READ_CONFLICT)
+	tb3.ChaincodeAction(ccID1).
+		Write(key3, value3).
+		ChaincodeEvent(ccEvent1, []byte("ccpayload"))
+
+	lceBytes, err := proto.Marshal(&pb.LifecycleEvent{ChaincodeName: ccID2})
+	require.NoError(t, err)
+	require.NotNil(t, lceBytes)
+
+	ccData := &ccprovider.ChaincodeData{
+		Name: ccID1,
+	}
+	ccDataBytes, err := proto.Marshal(ccData)
+	require.NoError(t, err)
+
+	b.Transaction(txID1, pb.TxValidationCode_VALID).
+		ChaincodeAction(LsccID).
+		Write(ccID1, ccDataBytes)
+
+	tb4 := b.Transaction(txID2, pb.TxValidationCode_VALID)
+	tb4.ChaincodeAction(LsccID).
+		Write(ccID1, ccDataBytes).
+		ChaincodeEvent(ccEvent1, nil)
+
+	return b.Build()
+}


### PR DESCRIPTION
Added a BlockVisitor that is synchronous and has the capability of (1) returning errors to the caller and (2) stopping traversal as soon as an error occurs.
The existing BlockPublisher was refactored to use the BlockVisitor to traverse the block.

closes #263

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>