### PR TITLE
fix: Off-ledger collection data should not be pushed to all committers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,10 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 
 replace github.com/trustbloc/fabric-peer-ext => ./
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6 h1:sb48sPKroe21xiA5ngniLGX6Qe4+F5nBtAvSAbKCjEM=
-github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3 h1:akLCiFI1UmEmPTjDOQ2C3JGDXM2B96FSivUfwYfw/JA=
+github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/collections/policy/validator_test.go
+++ b/mod/peer/collections/policy/validator_test.go
@@ -57,14 +57,6 @@ func TestValidateOffLedgerCollectionConfig(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Off-Ledger req == 0 -> error", func(t *testing.T) {
-		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
-		err := v.Validate(createOffLedgerCollectionConfig(coll1, policyEnvelope, 0, 2, "1m"))
-		require.Error(t, err)
-		expectedErr := "required peer count must be greater than 0"
-		assert.Truef(t, strings.Contains(err.Error(), expectedErr), "Expected error to contain '%s' but got '%s'", expectedErr, err)
-	})
-
 	t.Run("transient collection req > max -> error", func(t *testing.T) {
 		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
 		err := v.Validate(createTransientCollectionConfig(coll1, policyEnvelope, 3, 2, "1m"))
@@ -109,14 +101,6 @@ func TestValidateDCASCollectionConfig(t *testing.T) {
 		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
 		err := v.Validate(createDCASCollectionConfig(coll1, policyEnvelope, 1, 2, "1m"))
 		assert.NoError(t, err)
-	})
-
-	t.Run("DCAS req == 0 -> error", func(t *testing.T) {
-		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
-		err := v.Validate(createDCASCollectionConfig(coll1, policyEnvelope, 0, 2, "1m"))
-		require.Error(t, err)
-		expectedErr := "required peer count must be greater than 0"
-		assert.Truef(t, strings.Contains(err.Error(), expectedErr), "Expected error to contain '%s' but got '%s'", expectedErr, err)
 	})
 
 	t.Run("transient collection req > max -> error", func(t *testing.T) {

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -198,8 +198,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6 h1:sb48sPKroe21xiA5ngniLGX6Qe4+F5nBtAvSAbKCjEM=
-github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3 h1:akLCiFI1UmEmPTjDOQ2C3JGDXM2B96FSivUfwYfw/JA=
+github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/pkg/collections/offledger/dissemination/disseminator_test.go
+++ b/pkg/collections/offledger/dissemination/disseminator_test.go
@@ -87,6 +87,7 @@ func TestDisseminator_ResolvePeersForDissemination(t *testing.T) {
 		d := New(channelID, ns1, coll1,
 			&mocks.MockAccessPolicy{
 				ReqPeerCount: 1,
+				MaxPeerCount: 4,
 				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
 			}, gossip)
 
@@ -134,6 +135,31 @@ func TestDisseminator_ResolvePeersForDissemination(t *testing.T) {
 		require.Equal(t, 9, len(peers))
 		assert.NotContains(t, peers.String(), "org4")
 	})
+
+	t.Run("MaxPeerCount is 0 and not committer", func(t *testing.T) {
+		restore := roles.GetRoles()
+		defer func() {
+			rolesValue := make(map[roles.Role]struct{})
+			for _, role := range restore {
+				rolesValue[role] = struct{}{}
+			}
+			roles.SetRoles(rolesValue)
+		}()
+
+		rolesValue := make(map[roles.Role]struct{})
+		rolesValue[roles.EndorserRole] = struct{}{}
+		roles.SetRoles(rolesValue)
+
+		d := New(channelID, ns1, coll1,
+			&mocks.MockAccessPolicy{
+				ReqPeerCount: 0,
+				MaxPeerCount: 0,
+				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
+			}, gossip)
+
+		peers := d.resolvePeersForDissemination()
+		require.Equal(t, 1, len(peers))
+	})
 }
 
 func TestDisseminator_ResolvePeersForRetrieval(t *testing.T) {
@@ -156,6 +182,7 @@ func TestDisseminator_ResolvePeersForRetrieval(t *testing.T) {
 		d := New(channelID, ns1, coll1,
 			&mocks.MockAccessPolicy{
 				ReqPeerCount: 1,
+				MaxPeerCount: 2,
 				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
 			}, gossip)
 
@@ -174,6 +201,7 @@ func TestDisseminator_ResolvePeersForRetrieval(t *testing.T) {
 		d := New(channelID, ns1, coll1,
 			&mocks.MockAccessPolicy{
 				ReqPeerCount: 1,
+				MaxPeerCount: 7,
 				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID},
 			}, gossip)
 
@@ -218,6 +246,7 @@ func TestComputeDisseminationPlan(t *testing.T) {
 
 	colAP := &mocks.MockAccessPolicy{
 		ReqPeerCount: 1,
+		MaxPeerCount: 2,
 		Orgs:         []string{org2MSPID, org3MSPID},
 	}
 

--- a/pkg/collections/offledger/policy/validator.go
+++ b/pkg/collections/offledger/policy/validator.go
@@ -19,10 +19,6 @@ func ValidateConfig(config *common.StaticCollectionConfig) error {
 		return errors.Errorf("unsupported off-ledger collection type: %s", config.Type)
 	}
 
-	if config.RequiredPeerCount <= 0 {
-		return errors.Errorf("collection-name: %s -- required peer count must be greater than 0", config.Name)
-	}
-
 	if config.RequiredPeerCount > config.MaximumPeerCount {
 		return errors.Errorf("collection-name: %s -- maximum peer count (%d) must be greater than or equal to required peer count (%d)", config.Name, config.MaximumPeerCount, config.RequiredPeerCount)
 	}

--- a/pkg/collections/offledger/policy/validator_test.go
+++ b/pkg/collections/offledger/policy/validator_test.go
@@ -39,14 +39,6 @@ func TestValidateConfig(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("Off-Ledger req == 0 -> error", func(t *testing.T) {
-		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
-		err := ValidateConfig(createOffLedgerCollectionConfig(common.CollectionType_COL_OFFLEDGER, coll1, policyEnvelope, 0, 2, "1m"))
-		require.Error(t, err)
-		expectedErr := "required peer count must be greater than 0"
-		assert.Truef(t, strings.Contains(err.Error(), expectedErr), "Expected error to contain '%s' but got '%s'", expectedErr, err)
-	})
-
 	t.Run("transient collection req > max -> error", func(t *testing.T) {
 		policyEnvelope := cauthdsl.Envelope(cauthdsl.Or(cauthdsl.SignedBy(0), cauthdsl.SignedBy(1)), signers)
 		err := ValidateConfig(createOffLedgerCollectionConfig(common.CollectionType_COL_OFFLEDGER, coll1, policyEnvelope, 3, 2, "1m"))

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -11,8 +11,8 @@ git clone https://github.com/trustbloc/fabric-mod.git $GOPATH/src/github.com/hyp
 cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
-# fabric-mod (Aug 21, 2019)
-git checkout 5941d21b98c62599452169cb5af5de7a969c7bc5
+# fabric-mod (Oct 17, 2019)
+git checkout dbb9e53d90a3161c5ad853b0ba7346e62714a84c
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/trustbloc/fabric-peer-ext v0.0.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3
 
 replace github.com/hyperledger/fabric/extensions => ../../../../../../mod/peer
 

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.sum
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.sum
@@ -207,8 +207,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6 h1:sb48sPKroe21xiA5ngniLGX6Qe4+F5nBtAvSAbKCjEM=
-github.com/trustbloc/fabric-mod v0.0.0-20190821180934-5941d21b98c6/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3 h1:akLCiFI1UmEmPTjDOQ2C3JGDXM2B96FSivUfwYfw/JA=
+github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=


### PR DESCRIPTION
This patch ensures that off-ledger (and DCAS) data are not automatically pushed (disseminated) to all committers but are pushed to the number of committers specified by MaximumPeerCount in the collection policy. If MaximumPeerCount is greater than the number of committers then additional endorsers are selected.

Also, RequiredPeerCount/MaximumPeerCount are not required to be greater than 0. In some situations you may just want to store the data to the local peer. Although, if MaximumPeerCount is set to 0 but the local peer is not a committer then a random committer is chosen to which to disseminate.

close #266

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>