### PR TITLE
fix: Change off-ledger query results to type *queryresult.KV

### DIFF
--- a/pkg/collections/client/client_test.go
+++ b/pkg/collections/client/client_test.go
@@ -1,6 +1,5 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
-
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -12,9 +11,9 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric/core/ledger"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/queryresult"
 	pb "github.com/hyperledger/fabric/protos/peer"
 	"github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/pkg/errors"
@@ -204,28 +203,20 @@ func TestClient_Query(t *testing.T) {
 
 	query1 := "query1"
 
-	vk1 := &statedb.VersionedKV{
-		CompositeKey: statedb.CompositeKey{
-			Namespace: ns1 + "~" + coll1,
-			Key:       key1,
-		},
-		VersionedValue: statedb.VersionedValue{
-			Value: []byte("v1_1"),
-		},
+	vk1 := &queryresult.KV{
+		Namespace: ns1 + "~" + coll1,
+		Key:       key1,
+		Value:     []byte("v1_1"),
 	}
-	vk2 := &statedb.VersionedKV{
-		CompositeKey: statedb.CompositeKey{
-			Namespace: ns1 + "~" + coll1,
-			Key:       key2,
-		},
-		VersionedValue: statedb.VersionedValue{
-			Value: []byte("v1_2"),
-		},
+	vk2 := &queryresult.KV{
+		Namespace: ns1 + "~" + coll1,
+		Key:       key2,
+		Value:     []byte("v1_2"),
 	}
 
 	mockLedger := &mocks.Ledger{
 		QueryExecutor: mocks.NewQueryExecutor().
-			WithPrivateQueryResults(ns1, coll1, query1, []*statedb.VersionedKV{vk1, vk2}),
+			WithPrivateQueryResults(ns1, coll1, query1, []*queryresult.KV{vk1, vk2}),
 	}
 
 	gossip := &mockGossipAdapter{}

--- a/pkg/collections/offledger/dcas/client/dcasclient.go
+++ b/pkg/collections/offledger/dcas/client/dcasclient.go
@@ -1,6 +1,5 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
-
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -9,7 +8,7 @@ package dcasclient
 import (
 	"github.com/btcsuite/btcutil/base58"
 	commonledger "github.com/hyperledger/fabric/common/ledger"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/protos/ledger/queryresult"
 	olclient "github.com/trustbloc/fabric-peer-ext/pkg/collections/client"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas"
 )
@@ -107,7 +106,7 @@ func (it *decodingResultsIterator) Next() (commonledger.QueryResult, error) {
 		return nil, nil
 	}
 
-	kv := qr.(*statedb.VersionedKV)
+	kv := qr.(*queryresult.KV)
 	dkv := *kv
 	dkv.Key = string(base58.Decode(kv.Key))
 	return &dkv, nil

--- a/pkg/collections/offledger/dcas/client/dcasclient_test.go
+++ b/pkg/collections/offledger/dcas/client/dcasclient_test.go
@@ -1,6 +1,5 @@
 /*
 Copyright SecureKey Technologies Inc. All Rights Reserved.
-
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -12,10 +11,10 @@ import (
 
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/hyperledger/fabric/core/ledger"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	gmocks "github.com/hyperledger/fabric/extensions/gossip/mocks"
 	cb "github.com/hyperledger/fabric/protos/common"
+	"github.com/hyperledger/fabric/protos/ledger/queryresult"
 	"github.com/hyperledger/fabric/protos/transientstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -144,28 +143,20 @@ func TestClient_Query(t *testing.T) {
 
 	query1 := "query1"
 
-	vk1 := &statedb.VersionedKV{
-		CompositeKey: statedb.CompositeKey{
-			Namespace: ns1 + "~" + coll1,
-			Key:       base58.Encode([]byte(key1)),
-		},
-		VersionedValue: statedb.VersionedValue{
-			Value: value1,
-		},
+	vk1 := &queryresult.KV{
+		Namespace: ns1 + "~" + coll1,
+		Key:       base58.Encode([]byte(key1)),
+		Value:     value1,
 	}
-	vk2 := &statedb.VersionedKV{
-		CompositeKey: statedb.CompositeKey{
-			Namespace: ns1 + "~" + coll1,
-			Key:       base58.Encode([]byte(key2)),
-		},
-		VersionedValue: statedb.VersionedValue{
-			Value: value2,
-		},
+	vk2 := &queryresult.KV{
+		Namespace: ns1 + "~" + coll1,
+		Key:       base58.Encode([]byte(key2)),
+		Value:     value2,
 	}
 
 	mockLedger := &mocks.Ledger{
 		QueryExecutor: mocks.NewQueryExecutor().
-			WithPrivateQueryResults(ns1, coll1, query1, []*statedb.VersionedKV{vk1, vk2}),
+			WithPrivateQueryResults(ns1, coll1, query1, []*queryresult.KV{vk1, vk2}),
 	}
 
 	gossip := &mockGossipAdapter{}
@@ -191,14 +182,14 @@ func TestClient_Query(t *testing.T) {
 
 		next, err := it.Next()
 		require.NoError(t, err)
-		kv, ok := next.(*statedb.VersionedKV)
+		kv, ok := next.(*queryresult.KV)
 		require.True(t, ok)
 		require.Equal(t, vk1.Namespace, kv.Namespace)
 		require.Equal(t, key1, kv.Key)
 
 		next, err = it.Next()
 		require.NoError(t, err)
-		kv, ok = next.(*statedb.VersionedKV)
+		kv, ok = next.(*queryresult.KV)
 		require.True(t, ok)
 		require.Equal(t, vk2.Namespace, kv.Namespace)
 		require.Equal(t, key2, kv.Key)

--- a/pkg/mocks/mockqueryexecutor.go
+++ b/pkg/mocks/mockqueryexecutor.go
@@ -13,12 +13,13 @@ import (
 	commonledger "github.com/hyperledger/fabric/common/ledger"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/protos/ledger/queryresult"
 )
 
 // QueryExecutor is a mock query executor
 type QueryExecutor struct {
 	state        map[string]map[string][]byte
-	queryResults map[string][]*statedb.VersionedKV
+	queryResults map[string][]*queryresult.KV
 	error        error
 	queryError   error
 	itProvider   func() *ResultsIterator
@@ -29,7 +30,7 @@ type QueryExecutor struct {
 func NewQueryExecutor() *QueryExecutor {
 	return &QueryExecutor{
 		state:        make(map[string]map[string][]byte),
-		queryResults: make(map[string][]*statedb.VersionedKV),
+		queryResults: make(map[string][]*queryresult.KV),
 		itProvider:   NewResultsIterator,
 		kvItProvider: NewKVIterator,
 	}
@@ -77,13 +78,13 @@ func (m *QueryExecutor) WithDeletedPrivateState(ns, collection, key string) *Que
 }
 
 // WithQueryResults sets the query results for a given query on a namespace
-func (m *QueryExecutor) WithQueryResults(ns, query string, results []*statedb.VersionedKV) *QueryExecutor {
+func (m *QueryExecutor) WithQueryResults(ns, query string, results []*queryresult.KV) *QueryExecutor {
 	m.queryResults[queryResultsKey(ns, query)] = results
 	return m
 }
 
 // WithPrivateQueryResults sets the query results for a given query on a private collection
-func (m *QueryExecutor) WithPrivateQueryResults(ns, coll, query string, results []*statedb.VersionedKV) *QueryExecutor {
+func (m *QueryExecutor) WithPrivateQueryResults(ns, coll, query string, results []*queryresult.KV) *QueryExecutor {
 	m.queryResults[privateQueryResultsKey(ns, coll, query)] = results
 	return m
 }

--- a/pkg/mocks/mockresultsiterator.go
+++ b/pkg/mocks/mockresultsiterator.go
@@ -8,12 +8,12 @@ package mocks
 
 import (
 	commonledger "github.com/hyperledger/fabric/common/ledger"
-	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
+	"github.com/hyperledger/fabric/protos/ledger/queryresult"
 )
 
 // ResultsIterator is a mock key-value iterator
 type ResultsIterator struct {
-	results []*statedb.VersionedKV
+	results []*queryresult.KV
 	nextIdx int
 	err     error
 }
@@ -24,7 +24,7 @@ func NewResultsIterator() *ResultsIterator {
 }
 
 // WithResults sets the mock results
-func (m *ResultsIterator) WithResults(results []*statedb.VersionedKV) *ResultsIterator {
+func (m *ResultsIterator) WithResults(results []*queryresult.KV) *ResultsIterator {
 	m.results = results
 	return m
 }


### PR DESCRIPTION
The DCAS client incorrectly assumed that the query results are of type *statedb.VersionedKV but it is actually of type *queryresult.KV.

closes #274

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>