### PR TITLE
fix: Panic in off-ledger client when channel not joined

### DIFF
--- a/pkg/collections/client/client.go
+++ b/pkg/collections/client/client.go
@@ -73,8 +73,12 @@ type Client struct {
 }
 
 // New returns a new client
-func New(channelID string) *Client {
+func New(channelID string) (*Client, error) {
 	ledger := getLedger(channelID)
+	if ledger == nil {
+		return nil, errors.Errorf("ledger not found for channel [%s]", channelID)
+	}
+
 	blockPublisher := getBlockPublisher(channelID)
 
 	return &Client{
@@ -82,7 +86,7 @@ func New(channelID string) *Client {
 		ledger:          ledger,
 		gossip:          getGossipAdapter(),
 		configRetriever: getCollConfigRetriever(channelID, ledger, blockPublisher),
-	}
+	}, nil
 }
 
 // Put puts the value for the given key

--- a/pkg/collections/client/client_test.go
+++ b/pkg/collections/client/client_test.go
@@ -62,7 +62,8 @@ func TestClient_Put(t *testing.T) {
 	}
 	newCreator = func() ([]byte, error) { return []byte("creator"), creatorError }
 
-	c := New(channelID)
+	c, err := New(channelID)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	value1 := []byte("value1")
@@ -139,6 +140,13 @@ func TestClient_Put(t *testing.T) {
 		err := c.Delete(ns1, coll1, key1, key2)
 		require.NoError(t, err)
 	})
+
+	t.Run("No ledger", func(t *testing.T) {
+		getLedger = func(channelID string) PeerLedger { return nil }
+		c, err := New(channelID)
+		require.Error(t, err)
+		require.Nil(t, c)
+	})
 }
 
 func TestClient_Get(t *testing.T) {
@@ -164,7 +172,8 @@ func TestClient_Get(t *testing.T) {
 	}
 	newCreator = func() ([]byte, error) { return []byte("creator"), creatorError }
 
-	c := New(channelID)
+	c, err := New(channelID)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	t.Run("Get - success", func(t *testing.T) {
@@ -241,7 +250,8 @@ func TestClient_Query(t *testing.T) {
 	}
 	newCreator = func() ([]byte, error) { return []byte("creator"), creatorError }
 
-	c := New(channelID)
+	c, err := New(channelID)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	t.Run("Query - success", func(t *testing.T) {

--- a/pkg/collections/offledger/dcas/client/dcasclient.go
+++ b/pkg/collections/offledger/dcas/client/dcasclient.go
@@ -20,10 +20,14 @@ type DCASClient struct {
 }
 
 // New returns a new DCAS olclient
-func New(channelID string) *DCASClient {
-	return &DCASClient{
-		Client: olclient.New(channelID),
+func New(channelID string) (*DCASClient, error) {
+	olClient, err := olclient.New(channelID)
+	if err != nil {
+		return nil, err
 	}
+	return &DCASClient{
+		Client: olClient,
+	}, nil
 }
 
 // Put puts the DCAS value and returns the key for the value

--- a/pkg/collections/offledger/dcas/client/dcasclient_test.go
+++ b/pkg/collections/offledger/dcas/client/dcasclient_test.go
@@ -53,7 +53,8 @@ func TestDCASClient_Put(t *testing.T) {
 	})
 	olclient.SetCreatorProvider(func() ([]byte, error) { return []byte("creator"), creatorError })
 
-	c := New(channelID)
+	c, err := New(channelID)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	value1 := []byte("value1")
@@ -91,6 +92,13 @@ func TestDCASClient_Put(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, c.Delete(ns1, coll1, casKey))
 	})
+
+	t.Run("No ledger", func(t *testing.T) {
+		olclient.SetLedgerProvider(func(channelID string) olclient.PeerLedger { return nil })
+		c, err := New(channelID)
+		require.Error(t, err)
+		require.Nil(t, c)
+	})
 }
 
 func TestDCASClient_Get(t *testing.T) {
@@ -118,7 +126,8 @@ func TestDCASClient_Get(t *testing.T) {
 	})
 	olclient.SetCreatorProvider(func() ([]byte, error) { return []byte("creator"), creatorError })
 
-	c := New(channelID)
+	c, err := New(channelID)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	t.Run("Get - success", func(t *testing.T) {
@@ -181,7 +190,8 @@ func TestClient_Query(t *testing.T) {
 	})
 	olclient.SetCreatorProvider(func() ([]byte, error) { return []byte("creator"), creatorError })
 
-	c := New(channelID)
+	c, err := New(channelID)
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	t.Run("Query - success", func(t *testing.T) {

--- a/test/bddtests/bddtests_test.go
+++ b/test/bddtests/bddtests_test.go
@@ -25,12 +25,12 @@ var composition *bddtests.Composition
 
 func TestMain(m *testing.M) {
 	projectPath, err := filepath.Abs("../..")
- 	if err != nil {
- 		panic(err.Error())
- 	}
- 	if err := os.Setenv("PROJECT_PATH", projectPath); err != nil {
- 		panic(err.Error())
- 	}
+	if err != nil {
+		panic(err.Error())
+	}
+	if err := os.Setenv("PROJECT_PATH", projectPath); err != nil {
+		panic(err.Error())
+	}
 
 	// default is to run all tests with tag @all
 	tags := "all"
@@ -58,7 +58,9 @@ func TestMain(m *testing.M) {
 				composition = newComposition
 
 				fmt.Println("docker-compose up ... waiting for peer to start ...")
-				testSleep := 30
+				// TODO: Setting this to 60s for now (since Azure is timing out) but this should be addressed
+				// 	by changing the join peer retry options in fabric-peer-test-common.
+				testSleep := 60
 				if os.Getenv("TEST_SLEEP") != "" {
 					testSleep, _ = strconv.Atoi(os.Getenv("TEST_SLEEP"))
 				}


### PR DESCRIPTION
Return an error from New if the ledger is nil for the given channel.

closes #272

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>