### PR TITLE
feat: System managed resources with dependency injection

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -35,3 +35,4 @@ jobs:
       displayName: Run BDD tests
     - publish: test/bddtests/docker-compose.log
       artifact: docker-compose.log
+      condition: always()

--- a/mod/peer/resource/resource.go
+++ b/mod/peer/resource/resource.go
@@ -1,0 +1,34 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resource
+
+import (
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/trustbloc/fabric-peer-ext/pkg/resource"
+)
+
+var logger = flogging.MustGetLogger("ext_resource")
+
+// Initialize invokes all registered resource creator functions using the given set of providers.
+func Initialize(providers ...interface{}) error {
+	logger.Info("Initializing resources")
+	return resource.Mgr.Initialize(providers...)
+}
+
+// ChannelJoined is called when the peer joins a channel. All resources that define the
+// function, ChannelJoined(string) are invoked.
+func ChannelJoined(channelID string) {
+	logger.Infof("Notifying resources that channel [%s] was joined", channelID)
+	resource.Mgr.ChannelJoined(channelID)
+}
+
+// Close is called when the peer is shut down. All resources that define the
+// function, Close() are invoked.
+func Close() {
+	logger.Infof("Notifying resources that peer is shutting down")
+	resource.Mgr.Close()
+}

--- a/mod/peer/resource/resource_test.go
+++ b/mod/peer/resource/resource_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitialize(t *testing.T) {
+	require.NoError(t, Initialize(&someProvider{}))
+}
+
+func TestChannelJoined(t *testing.T) {
+	require.NotPanics(t, func() { ChannelJoined("testchannel") })
+}
+
+func TestClose(t *testing.T) {
+	require.NotPanics(t, func() { Close() })
+}
+
+type someProvider struct {
+}

--- a/pkg/resource/resourcemgr.go
+++ b/pkg/resource/resourcemgr.go
@@ -1,0 +1,206 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resource
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/pkg/errors"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/injectinvoker"
+)
+
+var logger = flogging.MustGetLogger("ext_resource")
+
+// Mgr is the singleton resource manager
+var Mgr = NewManager()
+
+// closable is implemented by resources that should be closed at peer shutdown.
+type closable interface {
+	Close()
+}
+
+// channelNotifier is implemented by resources that wish to be informed when a peer joins a channel
+type channelNotifier interface {
+	ChannelJoined(channelID string)
+}
+
+// Manager initializes resources at peer startup and closes them at peer shutdown.
+type Manager struct {
+	mutex         sync.Mutex
+	registrations registrations
+	resources     []interface{}
+	joinedChan    chan string
+	order         int
+}
+
+// NewManager returns a new resource Manager
+func NewManager() *Manager {
+	m := &Manager{
+		joinedChan: make(chan string, 1),
+	}
+	go m.listenChannel()
+	return m
+}
+
+// Priority is the relative priority of the resource
+type Priority uint
+
+const (
+	// PriorityHighest indicates that the resource should be initialized first
+	PriorityHighest Priority = 0
+
+	// PriorityHigh indicates that the resource should be among the first to be initialized
+	PriorityHigh Priority = 10
+
+	// PriorityAboveNormal indicates that the resource should be initialized before normal resources
+	PriorityAboveNormal Priority = 25
+
+	// PriorityNormal indicates that the resource can be initialized in any order
+	PriorityNormal Priority = 50
+
+	// PriorityBelowNormal indicates that the resource should be initialized after normal resources
+	PriorityBelowNormal Priority = 75
+
+	// PriorityLow indicates that the resource should be among the last to be initialized
+	PriorityLow Priority = 90
+
+	// PriorityLowest indicates that the resource should be initialized last
+	PriorityLowest Priority = 100
+)
+
+// Register registers a resource creator function. The function is invoked on peer startup.
+// The creator function defines a set of arguments (which must all be of type interface{},
+// struct{}, or *struct{}) and returns a single pointer to a struct. Each of the args are resolved
+// against a set of registered providers. If a provider is found then it is passed in as the argument
+// value. If a provider is not found then a panic results.
+//
+// Argument, priority, specifies the order in which the resource should be initialized
+// relative to other resources.
+//
+// Example:
+//
+//	func CreateMyResource(x someProvider, y someOtherProvider) *MyStruct {
+//		return &MyResource{x: x, y: y}
+//	}
+//
+//	Register(CreateMyResource, resource.PriorityNormal)
+//
+func (b *Manager) Register(creator interface{}, priority Priority) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.order++
+	b.registrations = append(b.registrations, newRegistration(creator, priority, b.order))
+}
+
+// Initialize initializes all of the registered resources with the given set of providers.
+func (b *Manager) Initialize(providers ...interface{}) error {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	invoker := injectinvoker.New(providers...)
+	for _, creator := range b.registrations.sort().creators() {
+		r, err := create(invoker, creator)
+		if err != nil {
+			return errors.WithMessagef(err, "Error creating resource [%s]", reflect.TypeOf(creator))
+		}
+		b.resources = append(b.resources, r)
+
+		// Add the resource to the set of providers to be available
+		// for subsequent resources' dependencies
+		invoker.AddProvider(r)
+	}
+	return nil
+}
+
+// ChannelJoined notifies all applicable resources that the peer has joined a channel
+func (b *Manager) ChannelJoined(channelID string) {
+	b.joinedChan <- channelID
+}
+
+// Close closes all applicable resources (i.e. the ones that implement closable).
+func (b *Manager) Close() {
+	close(b.joinedChan)
+	for _, r := range b.resources {
+		doClose(r)
+	}
+}
+
+func (b *Manager) listenChannel() {
+	for channelID := range b.joinedChan {
+		for _, r := range b.resources {
+			notifyChannelJoined(r, channelID)
+		}
+	}
+}
+
+func create(invoker *injectinvoker.Invoker, fctn interface{}) (interface{}, error) {
+	retVals, err := invoker.Invoke(fctn)
+	if err != nil {
+		return nil, err
+	}
+
+	// The function must return exactly one value, which is the Resource
+	if len(retVals) != 1 {
+		return nil, errors.New("invalid number of return values - expecting return value [Resource]")
+	}
+
+	return retVals[0].Interface(), nil
+}
+
+func doClose(res interface{}) {
+	c, ok := res.(closable)
+	if ok {
+		logger.Debugf("Notifying resource %s that we're shutting down", reflect.TypeOf(res))
+		c.Close()
+	}
+}
+
+func notifyChannelJoined(res interface{}, channelID string) {
+	n, ok := res.(channelNotifier)
+	if ok {
+		logger.Debugf("Notifying resource %s that channel [%s] was joined", reflect.TypeOf(res), channelID)
+		n.ChannelJoined(channelID)
+	}
+}
+
+type registration struct {
+	creator  interface{}
+	priority Priority
+	order    int
+}
+
+func newRegistration(creator interface{}, priority Priority, order int) *registration {
+	return &registration{creator: creator, priority: priority, order: order}
+}
+
+type registrations []*registration
+
+// sort sorts the resources first by priority and then by the
+// order in which the resources were registered.
+func (r registrations) sort() registrations {
+	sort.Slice(r, func(i, j int) bool {
+		ri := r[i]
+		rj := r[j]
+		if ri.priority == rj.priority {
+			return ri.order < rj.order
+		}
+		return ri.priority < rj.priority
+	})
+	return r
+}
+
+func (r registrations) creators() []interface{} {
+	creators := make([]interface{}, len(r))
+	for i, entry := range r {
+		creators[i] = entry.creator
+	}
+	return creators
+}

--- a/pkg/resource/resourcemgr_test.go
+++ b/pkg/resource/resourcemgr_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resource
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/injectinvoker"
+)
+
+const (
+	ccName1  = "cc1"
+	ccPath1  = "/scc/cc1"
+	arg1     = "arg1"
+	arg2     = "arg2"
+	channel1 = "channel1"
+	channel2 = "channel2"
+)
+
+func TestManager_Initialize(t *testing.T) {
+	mgr := NewManager()
+
+	creators := &creators{}
+	mgr.Register(creators.creator4, PriorityLow)
+	mgr.Register(creators.creator3, PriorityLow)
+	mgr.Register(creators.creator2, PriorityNormal)
+	mgr.Register(creators.creator1, PriorityHighest)
+
+	err := mgr.Initialize(
+		&nameAndPathProviderImpl{
+			name: ccName1,
+			path: ccPath1,
+		},
+		&argsProviderImpl{
+			args: [][]byte{
+				[]byte(arg1),
+				[]byte(arg2),
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, mgr.resources, 4)
+
+	require.Equal(t, 1, creators.creator1InitOrder)
+	require.Equal(t, 2, creators.creator2InitOrder)
+	require.Equal(t, 3, creators.creator4InitOrder)
+	require.Equal(t, 4, creators.creator3InitOrder)
+
+	r1, ok := mgr.resources[0].(*testResource1)
+	require.True(t, ok)
+	require.NotNil(t, r1)
+	require.Equal(t, ccName1, r1.name)
+	require.Equal(t, ccPath1, r1.path)
+
+	r2, ok := mgr.resources[1].(*testResource2)
+	require.True(t, ok)
+	require.NotNil(t, r2)
+	require.Equal(t, ccName1, r2.name)
+	require.Empty(t, r2.ChannelIDs())
+
+	r4, ok := mgr.resources[2].(*testResource4)
+	require.True(t, ok)
+	require.NotNil(t, r4)
+
+	// testResource3 depends on the previous resources as providers
+	r3, ok := mgr.resources[3].(*testResource3)
+	require.True(t, ok)
+	require.NotNil(t, r3)
+	require.Equal(t, ccName1+" - "+ccPath1, r3.nameAndPath)
+
+	mgr.ChannelJoined(channel1)
+	mgr.ChannelJoined(channel2)
+
+	time.Sleep(100 * time.Millisecond)
+	require.Len(t, r2.ChannelIDs(), 2)
+
+	mgr.Close()
+	require.True(t, r2.closed)
+}
+
+func TestManager_InitializeError(t *testing.T) {
+	t.Run("Invalid number of return args -> error", func(t *testing.T) {
+		mgr := NewManager()
+		require.NotNil(t, mgr)
+		mgr.Register(NoRetArgs, PriorityNormal)
+		err := mgr.Initialize(&nameAndPathProviderImpl{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid number of return values")
+	})
+	t.Run("Dependency not found -> error", func(t *testing.T) {
+		mgr := NewManager()
+		require.NotNil(t, mgr)
+		mgr.Register(UnknownProvider, PriorityNormal)
+		err := mgr.Initialize(&nameAndPathProviderImpl{})
+		require.Error(t, err)
+		require.Equal(t, injectinvoker.ErrProviderNotFound, errors.Cause(err))
+	})
+}
+
+type nameAndPathProviderImpl struct {
+	name string
+	path string
+}
+
+func (s *nameAndPathProviderImpl) GetName() string {
+	return s.name
+}
+
+func (s *nameAndPathProviderImpl) GetPath() string {
+	return s.path
+}
+
+type argsProviderImpl struct {
+	args [][]byte
+}
+
+func (s *argsProviderImpl) GetArgs() [][]byte {
+	return s.args
+}
+
+type nameProvider interface {
+	GetName() string
+}
+
+type pathProvider interface {
+	GetPath() string
+}
+
+type argsProvider interface {
+	GetArgs() [][]byte
+}
+
+type creators struct {
+	order             int
+	creator1InitOrder int
+	creator2InitOrder int
+	creator3InitOrder int
+	creator4InitOrder int
+}
+
+func (c *creators) creator1(np nameProvider, pp pathProvider, argsp argsProvider) *testResource1 {
+	c.order++
+	c.creator1InitOrder = c.order
+	return &testResource1{
+		name:     np.GetName(),
+		path:     pp.GetPath(),
+		initArgs: argsp.GetArgs(),
+	}
+}
+
+func (c *creators) creator2(np nameProvider) *testResource2 {
+	c.order++
+	c.creator2InitOrder = c.order
+	r := &testResource2{}
+	r.name = np.GetName()
+	return r
+}
+
+type nameAddPathProvider interface {
+	GetNameAndPath() string
+}
+
+type someFunctionProvider interface {
+	SomeFunction(arg string) error
+}
+
+func (c *creators) creator3(npp nameAddPathProvider, sfp someFunctionProvider) *testResource3 {
+	c.order++
+	c.creator3InitOrder = c.order
+	err := sfp.SomeFunction("arg1")
+	if err != nil {
+		panic(err.Error())
+	}
+	return &testResource3{
+		nameAndPath: npp.GetNameAndPath(),
+	}
+}
+
+func (c *creators) creator4() *testResource4 {
+	c.order++
+	c.creator4InitOrder = c.order
+	return &testResource4{}
+}
+
+func NoRetArgs() {
+}
+
+type customProvider interface {
+	GetData(arg int) string
+}
+
+func UnknownProvider(customProvider) *testResource1 {
+	return &testResource1{}
+}
+
+type testResource1 struct {
+	name     string
+	path     string
+	initArgs [][]byte
+}
+
+func (s *testResource1) Name() string {
+	return s.name
+}
+
+func (s *testResource1) Path() string {
+	return s.path
+}
+
+func (s *testResource1) InitArgs() [][]byte {
+	return s.initArgs
+}
+
+func (s *testResource1) GetNameAndPath() string {
+	return s.name + " - " + s.path
+}
+
+type testResource2 struct {
+	testResource1
+	closed     bool
+	channelIDs []string
+	mutex      sync.RWMutex
+}
+
+func (s *testResource2) Close() {
+	s.closed = true
+}
+
+func (s *testResource2) ChannelJoined(channelID string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.channelIDs = append(s.channelIDs, channelID)
+}
+
+func (s *testResource2) SomeFunction(arg string) error {
+	return nil
+}
+
+func (s *testResource2) ChannelIDs() []string {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.channelIDs
+}
+
+type testResource3 struct {
+	nameAndPath string
+}
+
+type testResource4 struct {
+}


### PR DESCRIPTION
Added a mechanism to provide dependencies to resources on peer startup and when joining a channel. The peer manages the lifecycle of the resource as follows:

- New(dependencies...) - Create a new instance of the resource where the peer provides all of the declared dependencies
- ChannelJoined(channelID) - Called when a peer joins a channel
- Close - Called when the peer is shut down

closes #259

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>