### PR TITLE
feat: Added CollRWSetFilter and Dispatcher provider resources

### DIFF
--- a/mod/peer/endorser/endorser.go
+++ b/mod/peer/endorser/endorser.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package endorser
 
 import (
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
 	"github.com/hyperledger/fabric/extensions/endorser/api"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/support"
 	extendorser "github.com/trustbloc/fabric-peer-ext/pkg/endorser"
 )
 
@@ -20,5 +22,21 @@ type CollRWSetFilter interface {
 
 // NewCollRWSetFilter returns a new collection RW set filter
 func NewCollRWSetFilter(api.QueryExecutorProviderFactory, api.BlockPublisherProvider) CollRWSetFilter {
-	return extendorser.NewCollRWSetFilter()
+	f := extendorser.NewCollRWSetFilter()
+
+	// For now, explicitly call Initialize. After the CollRWSetFilter is registered as a resource,
+	// this code should be removed since Initialize will be called by the resource manager.
+	f.Initialize(&ccProvider{})
+
+	return f
+}
+
+// The code below is temporarily added to facilitate the migration to dependency injected resources.
+// This code should be removed once all resources have been converted to use dependency injection.
+
+type ccProvider struct {
+}
+
+func (p *ccProvider) ForChannel(channelID string) supportapi.CollectionConfigRetriever {
+	return support.CollectionConfigRetrieverForChannel(channelID)
 }

--- a/mod/peer/endorser/endorser_test.go
+++ b/mod/peer/endorser/endorser_test.go
@@ -9,10 +9,7 @@ package endorser
 import (
 	"testing"
 
-	"github.com/hyperledger/fabric/extensions/endorser/api"
-	xgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	"github.com/hyperledger/fabric/protos/ledger/rwset"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,25 +18,16 @@ const (
 )
 
 func TestFilterPubSimulationResults(t *testing.T) {
-	f := NewCollRWSetFilter(&mockQueryExecutorProviderFactory{}, &mockBlockPublisherProvider{})
+	f := NewCollRWSetFilter(nil, nil)
 	require.NotNil(t, f)
 
 	pubSimulationResults := &rwset.TxReadWriteSet{}
 	p, err := f.Filter(channelID, pubSimulationResults)
-	assert.NoError(t, err)
-	assert.Equal(t, pubSimulationResults, p)
+	require.NoError(t, err)
+	require.Equal(t, pubSimulationResults, p)
 }
 
-type mockQueryExecutorProviderFactory struct {
-}
-
-func (m *mockQueryExecutorProviderFactory) GetQueryExecutorProvider(channelID string) api.QueryExecutorProvider {
-	return nil
-}
-
-type mockBlockPublisherProvider struct {
-}
-
-func (m *mockBlockPublisherProvider) ForChannel(channelID string) xgossipapi.BlockPublisher {
-	return nil
+func TestCcProvider_ForChannel(t *testing.T) {
+	p := &ccProvider{}
+	require.Nil(t, p.ForChannel("channel1"))
 }

--- a/mod/peer/gossip/dispatcher/dispatcher.go
+++ b/mod/peer/gossip/dispatcher/dispatcher.go
@@ -9,10 +9,12 @@ package dispatcher
 import (
 	"github.com/hyperledger/fabric/core/ledger"
 	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	supportapi "github.com/hyperledger/fabric/extensions/collections/api/support"
 	gossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 	gossip "github.com/hyperledger/fabric/gossip/api"
 	"github.com/hyperledger/fabric/gossip/common"
 	"github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/support"
 	extdispatcher "github.com/trustbloc/fabric-peer-ext/pkg/gossip/dispatcher"
 )
 
@@ -33,5 +35,22 @@ func New(
 	gossipAdapter gossipAdapter,
 	ledger ledger.PeerLedger,
 	blockPublisher blockPublisher) *extdispatcher.Dispatcher {
-	return extdispatcher.New(channelID, dataStore, gossipAdapter)
+
+	p := extdispatcher.NewProvider()
+
+	// For now, explicitly call Initialize. After the dispatcher provider is registered as a resource,
+	// this code should be removed since Initialize will be called by the resource manager.
+	p.Initialize(gossipAdapter, &ccProvider{})
+
+	return p.ForChannel(channelID, dataStore)
+}
+
+// The code below is temporarily added to facilitate the migration to dependency injected resources.
+// This code should be removed once all resources have been converted to use dependency injection.
+
+type ccProvider struct {
+}
+
+func (p *ccProvider) ForChannel(channelID string) supportapi.CollectionConfigRetriever {
+	return support.CollectionConfigRetrieverForChannel(channelID)
 }

--- a/mod/peer/gossip/dispatcher/dispatcher_test.go
+++ b/mod/peer/gossip/dispatcher/dispatcher_test.go
@@ -22,8 +22,8 @@ func TestProvider(t *testing.T) {
 		channelID,
 		&mocks.DataStore{},
 		mocks.NewMockGossipAdapter(),
-		&mocks.Ledger{QueryExecutor: mocks.NewQueryExecutor()},
-		mocks.NewBlockPublisher(),
+		nil,
+		nil,
 	)
 
 	var response *gproto.GossipMessage

--- a/pkg/gossip/dispatcher/provider.go
+++ b/pkg/gossip/dispatcher/provider.go
@@ -1,0 +1,45 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dispatcher
+
+import (
+	storeapi "github.com/hyperledger/fabric/extensions/collections/api/store"
+	collcommon "github.com/trustbloc/fabric-peer-ext/pkg/collections/common"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/requestmgr"
+)
+
+// Provider is a gossip dispatcher provider
+type Provider struct {
+	gossip     gossipAdapter
+	ccProvider collcommon.CollectionConfigProvider
+}
+
+// NewProvider returns a new gossip message dispatcher provider
+func NewProvider() *Provider {
+	return &Provider{}
+}
+
+// Initialize is called at startup by the resource manager
+func (p *Provider) Initialize(gossip gossipAdapter, ccProvider collcommon.CollectionConfigProvider) *Provider {
+	logger.Infof("Initializing gossip dispatcher provider")
+	p.gossip = gossip
+	p.ccProvider = ccProvider
+	return p
+}
+
+// ForChannel returns a new dispatcher for the given channel
+func (p *Provider) ForChannel(channelID string, dataStore storeapi.Store) *Dispatcher {
+	logger.Infof("Returning a new gossip dispatcher for channel [%s]", channelID)
+	return &Dispatcher{
+		ccRetriever: p.ccProvider.ForChannel(channelID),
+		channelID:   channelID,
+		reqMgr:      requestmgr.Get(channelID),
+		dataStore:   dataStore,
+		discovery:   discovery.New(channelID, p.gossip),
+	}
+}


### PR DESCRIPTION
Added collection read/write-set filter and Gossip dispatcher provider resources which may be used as providers to other resources.
Note that the resources are not registered in this commit but will be once all resources have been converted to use dependency injection.

closes #298

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>