### PR TITLE
feat: Remove priority during resource registration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800 h1:4G+/M8oKKLmff6/9ceUFPAnb3htNe7kaQxpou+ycs/I=
-github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385 h1:7szFajmwRoTQg9M5/lv4C+nlp9yYyl9GUdqH5gceEqs=
+github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/collections/retriever/retriever.go
+++ b/mod/peer/collections/retriever/retriever.go
@@ -14,6 +14,6 @@ import (
 // NewProvider returns a new private data Retriever provider
 func NewProvider() *extretriever.Provider {
 	p := extretriever.NewProvider()
-	resource.Register(p.Initialize, resource.PriorityAboveNormal)
+	resource.Register(p.Initialize)
 	return p
 }

--- a/mod/peer/collections/storeprovider/storeprovider.go
+++ b/mod/peer/collections/storeprovider/storeprovider.go
@@ -14,6 +14,6 @@ import (
 // NewProviderFactory returns a new store provider factory
 func NewProviderFactory() *extstoreprovider.StoreProvider {
 	p := extstoreprovider.New()
-	resource.Register(p.Initialize, resource.PriorityAboveNormal)
+	resource.Register(p.Initialize)
 	return p
 }

--- a/mod/peer/endorser/endorser.go
+++ b/mod/peer/endorser/endorser.go
@@ -15,6 +15,6 @@ import (
 // read-write sets from the simulation results so that they won't be included in the block.
 func NewCollRWSetFilter() *extendorser.CollRWSetFilter {
 	f := extendorser.NewCollRWSetFilter()
-	resource.Register(f.Initialize, resource.PriorityAboveNormal)
+	resource.Register(f.Initialize)
 	return f
 }

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -200,8 +200,8 @@ github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965/go.mod h1:9OrXJhf
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800 h1:4G+/M8oKKLmff6/9ceUFPAnb3htNe7kaQxpou+ycs/I=
-github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385 h1:7szFajmwRoTQg9M5/lv4C+nlp9yYyl9GUdqH5gceEqs=
+github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=

--- a/mod/peer/gossip/dispatcher/dispatcher.go
+++ b/mod/peer/gossip/dispatcher/dispatcher.go
@@ -14,6 +14,6 @@ import (
 // New returns a new Gossip message dispatcher provider
 func NewProvider() *extdispatcher.Provider {
 	p := extdispatcher.NewProvider()
-	resource.Register(p.Initialize, resource.PriorityAboveNormal)
+	resource.Register(p.Initialize)
 	return p
 }

--- a/pkg/peer/init.go
+++ b/pkg/peer/init.go
@@ -26,13 +26,13 @@ func Initialize() {
 }
 
 func registerResources() {
-	resource.Register(support.NewCollectionConfigRetrieverProvider, resource.PriorityHighest)
-	resource.Register(tdatastore.New, resource.PriorityHigh)
-	resource.Register(storeprovider.NewOffLedgerProvider, resource.PriorityHigh)
-	resource.Register(tretriever.NewProvider, resource.PriorityAboveNormal)
-	resource.Register(extretriever.NewOffLedgerProvider, resource.PriorityAboveNormal)
-	resource.Register(client.NewProvider, resource.PriorityNormal)
-	resource.Register(dcasclient.NewProvider, resource.PriorityNormal)
+	resource.Register(support.NewCollectionConfigRetrieverProvider)
+	resource.Register(tdatastore.New)
+	resource.Register(storeprovider.NewOffLedgerProvider)
+	resource.Register(tretriever.NewProvider)
+	resource.Register(extretriever.NewOffLedgerProvider)
+	resource.Register(client.NewProvider)
+	resource.Register(dcasclient.NewProvider)
 }
 
 func registerSystemChaincodes() {

--- a/pkg/testutil/ext_test_env.go
+++ b/pkg/testutil/ext_test_env.go
@@ -49,11 +49,11 @@ func SetupExtTestEnv() (addr string, cleanup func(string), stop func()) {
 	updateConfig(couchDB.Address())
 
 	// Register all of the dependent (mock) resources
-	resource.Register(func() *mocks.CollectionConfigProvider { return &mocks.CollectionConfigProvider{} }, resource.PriorityHighest)
-	resource.Register(func() *storemocks.TransientDataStoreProvider { return storemocks.NewTransientDataStoreProvider() }, resource.PriorityHigh)
-	resource.Register(func() *storemocks.StoreProvider { return storemocks.NewOffLedgerStoreProvider() }, resource.PriorityHigh)
-	resource.Register(func() *tdretriever.TransientDataProvider { return &tdretriever.TransientDataProvider{} }, resource.PriorityAboveNormal)
-	resource.Register(func() *olretriever.Provider { return &olretriever.Provider{} }, resource.PriorityAboveNormal)
+	resource.Register(func() *mocks.CollectionConfigProvider { return &mocks.CollectionConfigProvider{} })
+	resource.Register(func() *storemocks.TransientDataStoreProvider { return storemocks.NewTransientDataStoreProvider() })
+	resource.Register(func() *storemocks.StoreProvider { return storemocks.NewOffLedgerStoreProvider() })
+	resource.Register(func() *tdretriever.TransientDataProvider { return &tdretriever.TransientDataProvider{} })
+	resource.Register(func() *olretriever.Provider { return &olretriever.Provider{} })
 
 	if err := resource.Mgr.Initialize(
 		mocks.NewBlockPublisherProvider(),

--- a/scripts/pull_fabric.sh
+++ b/scripts/pull_fabric.sh
@@ -12,7 +12,7 @@ cp -r . $GOPATH/src/github.com/hyperledger/fabric/fabric-peer-ext
 cd $GOPATH/src/github.com/hyperledger/fabric
 git config advice.detachedHead false
 # fabric-mod (Nov 6, 2019)
-git checkout 59cf3006b800ec1b2653bab2de7d2847a8960652
+git checkout 84db05f49385242bf99cf6d98b86357493552a3e
 
 # Rewrite viper import to allow plugins to load different version of viper
 sed 's/\github.com\/spf13\/viper.*/github.com\/spf13\/oldviper v0.0.0/g' -i fabric-peer-ext/mod/peer/go.mod

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/trustbloc/fabric-peer-ext v0.0.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385
 
 replace github.com/hyperledger/fabric/extensions => ../../../../../../mod/peer
 

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.sum
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.sum
@@ -230,6 +230,7 @@ github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3 h1:akLCiFI1Um
 github.com/trustbloc/fabric-mod v0.0.0-20191017151307-dbb9e53d90a3/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-mod v0.1.1-0.20191111152942-df7071104249/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-mod v0.1.1-0.20191112212227-59cf3006b800/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
+github.com/trustbloc/fabric-mod v0.1.1-0.20191115184302-84db05f49385/go.mod h1:LxTDde3l64j/c3QAlxxkkTc3TT70rrU5fDDej92Y9oI=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20191017182554-d11444dac65c/go.mod h1:jJ4XeGSXDsQ6PjRMNHrizu/CibiMGATnJnfA8B1ZghI=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20191030134454-451f83bd8d70/go.mod h1:jJ4XeGSXDsQ6PjRMNHrizu/CibiMGATnJnfA8B1ZghI=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20191108193100-ebf066ade812/go.mod h1:TfkXiV2pNdjfTl5/JmGP12IBay/YaozkH67UkxA4q2o=


### PR DESCRIPTION
Enhanced the resource manager to deduce the order in which resources are registered and therefore specifying a priority is not necessary.

closes #308

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>