### PR TITLE
feat: Convert ledger config service to be a resource

### DIFF
--- a/cmd/chaincode/configscc/configscc_test.go
+++ b/cmd/chaincode/configscc/configscc_test.go
@@ -17,7 +17,6 @@ import (
 	configmocks "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mocks"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/service"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
-	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
 const (
@@ -26,30 +25,20 @@ const (
 )
 
 func TestConfigSCC_New(t *testing.T) {
-	t.Run("Unresolved dependency: QE Provider", func(t *testing.T) {
-		require.Panics(t, func() { New(nil, mocks.NewBlockPublisherProvider()) })
-	})
-	t.Run("Unresolved dependency: Block Publisher", func(t *testing.T) {
-		require.Panics(t, func() { New(mocks.NewQueryExecutorProvider(), nil) })
-	})
-	t.Run("Success", func(t *testing.T) {
-		qep := mocks.NewQueryExecutorProvider()
-		cc := New(qep, mocks.NewBlockPublisherProvider())
-		require.NotNil(t, cc)
+	cc := New()
+	require.NotNil(t, cc)
 
-		require.Equal(t, service.ConfigNS, cc.Name())
-		require.Equal(t, sccPath, cc.Path())
-		require.Nil(t, cc.InitArgs())
-		require.Equal(t, cc, cc.Chaincode())
-		require.True(t, cc.Enabled())
-		require.True(t, cc.InvokableCC2CC())
-		require.True(t, cc.InvokableExternal())
-	})
+	require.Equal(t, service.ConfigNS, cc.Name())
+	require.Equal(t, sccPath, cc.Path())
+	require.Nil(t, cc.InitArgs())
+	require.Equal(t, cc, cc.Chaincode())
+	require.True(t, cc.Enabled())
+	require.True(t, cc.InvokableCC2CC())
+	require.True(t, cc.InvokableExternal())
 }
 
 func TestConfigSCC_Init(t *testing.T) {
-	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep, mocks.NewBlockPublisherProvider())
+	cc := New()
 	require.NotNil(t, cc)
 
 	t.Run("System channel", func(t *testing.T) {
@@ -64,8 +53,6 @@ func TestConfigSCC_Init(t *testing.T) {
 	t.Run("With channel", func(t *testing.T) {
 		const channelID = "testchannel"
 
-		require.Nil(t, service.GetSvcMgr().ForChannel(channelID))
-
 		stub := shim.NewMockStub("mock_stub", cc.Chaincode())
 		stub.ChannelID = channelID
 		r := stub.MockInit(tx1, nil)
@@ -73,20 +60,11 @@ func TestConfigSCC_Init(t *testing.T) {
 		require.Equal(t, shim.OK, int(r.Status))
 		require.Nil(t, r.Payload)
 		require.Empty(t, r.Message)
-
-		require.NotNil(t, service.GetSvcMgr().ForChannel(channelID))
-
-		r = stub.MockInit(tx1, nil)
-		require.NotNil(t, r)
-		require.Equal(t, shim.ERROR, int(r.Status))
-		require.Nil(t, r.Payload)
-		require.Contains(t, r.Message, "Config service already exists for channel")
 	})
 }
 
 func TestConfigSCC_Invoke_Invalid(t *testing.T) {
-	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep, mocks.NewBlockPublisherProvider())
+	cc := New()
 	require.NotNil(t, cc)
 
 	t.Run("No func arg", func(t *testing.T) {
@@ -107,8 +85,7 @@ func TestConfigSCC_Invoke_Invalid(t *testing.T) {
 }
 
 func TestConfigSCC_Invoke_Save(t *testing.T) {
-	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep, mocks.NewBlockPublisherProvider())
+	cc := New()
 	require.NotNil(t, cc)
 
 	t.Run("Empty config", func(t *testing.T) {
@@ -163,8 +140,7 @@ func TestConfigSCC_Invoke_Save(t *testing.T) {
 }
 
 func TestConfigSCC_Invoke_Get(t *testing.T) {
-	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep, mocks.NewBlockPublisherProvider())
+	cc := New()
 	require.NotNil(t, cc)
 
 	t.Run("No criteria", func(t *testing.T) {
@@ -259,8 +235,7 @@ func TestConfigSCC_Invoke_Get(t *testing.T) {
 }
 
 func TestConfigSCC_Invoke_Delete(t *testing.T) {
-	qep := mocks.NewQueryExecutorProvider()
-	cc := New(qep, mocks.NewBlockPublisherProvider())
+	cc := New()
 	require.NotNil(t, cc)
 
 	t.Run("No criteria", func(t *testing.T) {

--- a/pkg/config/ledgerconfig/config/service.go
+++ b/pkg/config/ledgerconfig/config/service.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+// UpdateHandler handles updates/deletes of config keys
+type UpdateHandler func(kv *KeyValue)
+
+// Service defines the operations of a configuration service
+type Service interface {
+	Get(key *Key) (*Value, error)
+	AddUpdateHandler(handler UpdateHandler)
+}

--- a/pkg/config/ledgerconfig/service/service.go
+++ b/pkg/config/ledgerconfig/service/service.go
@@ -35,15 +35,12 @@ type configMgr interface {
 	Query(criteria *config.Criteria) ([]*config.KeyValue, error)
 }
 
-// ConfigUpdateHandler handles updates/deletes of config keys
-type ConfigUpdateHandler func(kv *config.KeyValue)
-
 // ConfigService manages configuration data for a given channel
 type ConfigService struct {
 	channelID  string
 	configMgr  configMgr
 	cache      gcache.Cache
-	handlers   []ConfigUpdateHandler
+	handlers   []config.UpdateHandler
 	mutex      sync.RWMutex
 	updateChan chan *config.KeyValue
 }
@@ -97,7 +94,7 @@ func (s *ConfigService) Get(key *config.Key) (*config.Value, error) {
 }
 
 // AddUpdateHandler adds a handler that is notified of config updates/deletes
-func (s *ConfigService) AddUpdateHandler(handler ConfigUpdateHandler) {
+func (s *ConfigService) AddUpdateHandler(handler config.UpdateHandler) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -166,11 +163,11 @@ func (s *ConfigService) listen() {
 	}
 }
 
-func (s *ConfigService) getHandlers() []ConfigUpdateHandler {
+func (s *ConfigService) getHandlers() []config.UpdateHandler {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	handlers := make([]ConfigUpdateHandler, len(s.handlers))
+	handlers := make([]config.UpdateHandler, len(s.handlers))
 	copy(handlers, s.handlers)
 	return handlers
 }

--- a/pkg/config/ledgerconfig/service/service_test.go
+++ b/pkg/config/ledgerconfig/service/service_test.go
@@ -253,16 +253,15 @@ func TestConfigService_AddUpdateHandler(t *testing.T) {
 }
 
 func TestManager(t *testing.T) {
-	rp := mocks.NewStateRetrieverProvider()
+	lp := &mocks2.LedgerProvider{}
+	lp.GetLedgerReturns(&mocks2.Ledger{QueryExecutor: mocks2.NewQueryExecutor()})
 
-	svc := GetSvcMgr().ForChannel(channelID)
-	require.Nil(t, svc)
+	manager := NewSvcMgr(lp, mocks2.NewBlockPublisherProvider())
 
-	err := GetSvcMgr().Init(channelID, rp, mocks2.NewBlockPublisher())
-	require.NoError(t, err)
-
-	svc = GetSvcMgr().ForChannel(channelID)
+	svc := manager.ForChannel(channelID)
 	require.NotNil(t, svc)
 
-	require.EqualError(t, GetSvcMgr().Init(channelID, rp, mocks2.NewBlockPublisher()), "Config service already exists for channel [testchannel]")
+	value, err := svc.Get(&config.Key{MspID: msp1, AppName: app2, AppVersion: v1})
+	require.EqualError(t, err, ErrConfigNotFound.Error())
+	require.Nil(t, value)
 }

--- a/pkg/config/ledgerconfig/service/servicemgr.go
+++ b/pkg/config/ledgerconfig/service/servicemgr.go
@@ -7,48 +7,63 @@ SPDX-License-Identifier: Apache-2.0
 package service
 
 import (
-	"sync"
-
-	"github.com/pkg/errors"
-	state "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+	"github.com/bluele/gcache"
+	"github.com/hyperledger/fabric/core/ledger"
+	"github.com/hyperledger/fabric/extensions/endorser/api"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/common"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state"
 )
 
 // Manager manages a set of configuration services - one per channel
 type Manager struct {
-	serviceByChannel map[string]*ConfigService
-	mutex            sync.RWMutex
+	ledgerProvider   common.LedgerProvider
+	bpProvider       api.BlockPublisherProvider
+	serviceByChannel gcache.Cache
 }
 
-var svcMgr = newSvcMgr()
+// NewSvcMgr creates a new config service manager
+func NewSvcMgr(ledgerProvider common.LedgerProvider, blockPublisherProvider api.BlockPublisherProvider) *Manager {
+	logger.Infof("Creating configuration service manager")
 
-// GetSvcMgr returns the config service manager
-func GetSvcMgr() *Manager {
-	return svcMgr
-}
-
-func newSvcMgr() *Manager {
-	return &Manager{
-		serviceByChannel: make(map[string]*ConfigService),
-	}
-}
-
-// Init initializes the ConfigService for the given channel
-func (c *Manager) Init(channelID string, provider state.RetrieverProvider, publisher blockPublisher) error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	if _, ok := c.serviceByChannel[channelID]; ok {
-		return errors.Errorf("Config service already exists for channel [%s]", channelID)
+	m := &Manager{
+		ledgerProvider: ledgerProvider,
+		bpProvider:     blockPublisherProvider,
 	}
 
-	c.serviceByChannel[channelID] = New(channelID, provider, publisher)
-	return nil
+	m.serviceByChannel = gcache.New(0).LoaderFunc(func(channelID interface{}) (i interface{}, e error) {
+		return m.newService(channelID.(string)), nil
+	}).Build()
+
+	return m
 }
 
 // ForChannel returns a config service for the given channel.
-func (c *Manager) ForChannel(channelID string) *ConfigService {
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
+func (c *Manager) ForChannel(channelID string) config.Service {
+	s, err := c.serviceByChannel.Get(channelID)
+	if err != nil {
+		// This should never happen since the loader func never returns an error
+		panic(err)
+	}
+	return s.(config.Service)
+}
 
-	return c.serviceByChannel[channelID]
+func (c *Manager) newService(channelID string) config.Service {
+	return New(
+		channelID,
+		state.NewQERetrieverProvider(channelID, c.newQEProvider(channelID)),
+		c.bpProvider.ForChannel(channelID),
+	)
+}
+
+type qeProvider struct {
+	ledger ledger.PeerLedger
+}
+
+func (c *Manager) newQEProvider(channelID string) *qeProvider {
+	return &qeProvider{ledger: c.ledgerProvider.GetLedger(channelID)}
+}
+
+func (p *qeProvider) GetQueryExecutorForLedger(cid string) (ledger.QueryExecutor, error) {
+	return p.ledger.NewQueryExecutor()
 }

--- a/pkg/peer/init.go
+++ b/pkg/peer/init.go
@@ -16,6 +16,7 @@ import (
 	tretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/retriever"
 	tdatastore "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/storeprovider"
 	"github.com/trustbloc/fabric-peer-ext/pkg/common/support"
+	cfgservice "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/service"
 	"github.com/trustbloc/fabric-peer-ext/pkg/resource"
 )
 
@@ -33,6 +34,7 @@ func registerResources() {
 	resource.Register(extretriever.NewOffLedgerProvider)
 	resource.Register(client.NewProvider)
 	resource.Register(dcasclient.NewProvider)
+	resource.Register(cfgservice.NewSvcMgr)
 }
 
 func registerSystemChaincodes() {

--- a/pkg/peer/init_test.go
+++ b/pkg/peer/init_test.go
@@ -7,14 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 package peer
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 	"github.com/trustbloc/fabric-peer-ext/pkg/resource"
 )
 
 func TestInitialize(t *testing.T) {
+	defer removeDBPath(t)
+
 	require.NotPanics(t, Initialize)
 
 	require.NoError(t, resource.Mgr.Initialize(
@@ -25,4 +29,14 @@ func TestInitialize(t *testing.T) {
 		&mocks.IdentifierProvider{},
 		&mocks.IdentityProvider{},
 	))
+}
+
+func removeDBPath(t testing.TB) {
+	removePath(t, config.GetTransientDataLevelDBPath())
+}
+
+func removePath(t testing.TB, path string) {
+	if err := os.RemoveAll(path); err != nil {
+		t.Fatalf(err.Error())
+	}
 }


### PR DESCRIPTION
The config service is now registered as a resource and may be injected as a dependency to other resources/system chaincodes that require it.

The static function GetSvcMgr() was removed.

closes #311

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>