### PR TITLE
fix: Committer should not reject off-ledger data requests

### DIFF
--- a/pkg/common/requestmgr/requestmgr.go
+++ b/pkg/common/requestmgr/requestmgr.go
@@ -119,7 +119,7 @@ func (c *channelMgr) NewRequest() Request {
 
 	reqID := c.newRequestID()
 
-	logger.Debugf("[%s] Subscribing to transient data request %d", c.channelID, reqID)
+	logger.Debugf("[%s] Subscribing to data request %d", c.channelID, reqID)
 
 	s := newRequest(reqID, c.channelID, c.remove)
 	c.requests[reqID] = s
@@ -133,11 +133,11 @@ func (c *channelMgr) Respond(reqID uint64, response *Response) {
 
 	s, ok := c.requests[reqID]
 	if !ok {
-		logger.Debugf("[%s] No transient data requests for %d", c.channelID, reqID)
+		logger.Debugf("[%s] No data requests for %d", c.channelID, reqID)
 		return
 	}
 
-	logger.Debugf("[%s] Publishing transient data response %d", c.channelID, reqID)
+	logger.Debugf("[%s] Publishing data response %d", c.channelID, reqID)
 	s.respond(response)
 }
 
@@ -150,7 +150,7 @@ func (c *channelMgr) remove(reqID uint64) {
 	}
 
 	delete(c.requests, reqID)
-	logger.Debugf("[%s] Unsubscribed from transient data request %d", c.channelID, reqID)
+	logger.Debugf("[%s] Unsubscribed from data request %d", c.channelID, reqID)
 }
 
 func (c *channelMgr) newRequestID() uint64 {

--- a/pkg/gossip/dispatcher/dispatcher.go
+++ b/pkg/gossip/dispatcher/dispatcher.go
@@ -31,6 +31,11 @@ var isEndorser = func() bool {
 	return ledgerconfig.IsEndorser()
 }
 
+// isCommitter should only be overridden for unit testing
+var isCommitter = func() bool {
+	return ledgerconfig.IsCommitter()
+}
+
 // Dispatcher is a Gossip message dispatcher
 type Dispatcher struct {
 	ccProvider collcommon.CollectionConfigProvider
@@ -63,8 +68,8 @@ func (s *Dispatcher) handleDataRequest(msg protoext.ReceivedMessage) {
 		defer logger.Debug("[EXIT] ->  handleDataRequest")
 	}
 
-	if !isEndorser() {
-		logger.Warningf("Non-endorser should not be receiving collection data request messages")
+	if !isEndorser() && !isCommitter() {
+		logger.Warningf("Only endorsers and committers should be receiving collection data request messages")
 		return
 	}
 

--- a/test/bddtests/features/ledger_config.feature
+++ b/test/bddtests/features/ledger_config.feature
@@ -13,7 +13,7 @@ Feature: ledger-config
     And "test" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
 
     # We need to wait a while so that all of the peers' channel membership is Gossip'ed to all other peers.
-    Then we wait 10 seconds
+    Then we wait 20 seconds
 
   @ledger_config_s1
   Scenario: Save, get and delete application config
@@ -87,6 +87,8 @@ Feature: ledger-config
   @ledger_config_s3
   Scenario: Ledger config service - peer-specific config
     Given "test" chaincode "testcc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy ""
+    Then we wait 20 seconds
+
     # Save the config
     Given variable "testCCGeneralConfig" is assigned the JSON value '{"MspID":"general","Apps":[{"AppName":"testcc","Version":"v1","Components":[{"Name":"comp1","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testcc\",\"SubComponent\":\"comp1\"}","Format":"JSON"},{"Name":"comp2","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testcc\",\"SubComponent\":\"comp2\"}","Format":"JSON"}]}]}'
     Given variable "testCCOrg1Config" is assigned the JSON value '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.example.com","Apps":[{"AppName":"testcc","Version":"v1","Config":"p0-org1-testcc-v1-config","Format":"Other"}]},{"PeerID":"peer1.org1.example.com","Apps":[{"AppName":"testcc","Version":"v1","Config":"p1-org1-testcc-v1-config","Format":"Other"}]}]}'

--- a/test/bddtests/features/off_ledger.feature
+++ b/test/bddtests/features/off_ledger.feature
@@ -12,10 +12,10 @@ Feature: off-ledger
     Given the channel "mychannel" is created and all peers have joined
     And the channel "yourchannel" is created and all peers have joined
 
-    And off-ledger collection config "ol_coll1" is defined for collection "collection1" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=1, and timeToLive=10s
-    And DCAS collection config "dcas_coll2" is defined for collection "collection2" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=1, and timeToLive=10m
+    And off-ledger collection config "ol_coll1" is defined for collection "collection1" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=10s
+    And DCAS collection config "dcas_coll2" is defined for collection "collection2" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=10m
     And collection config "coll3" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=3, and blocksToLive=10
-    And DCAS collection config "dcas_accounts" is defined for collection "accounts" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=3, and timeToLive=30m
+    And DCAS collection config "dcas_accounts" is defined for collection "accounts" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=30m
     And "test" chaincode "ol_examplecc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "ol_coll1,dcas_coll2,coll3,dcas_accounts"
     And "test" chaincode "ol_examplecc_2" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "ol_coll1,dcas_accounts"
     And "test" chaincode "ol_examplecc_2" is instantiated from path "in-process" on the "yourchannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "ol_coll1,dcas_accounts"
@@ -35,7 +35,7 @@ Feature: off-ledger
 
     Then container "peer1.org2.example.com" is stopped
     And container "peer1.org2.example.com" is started
-    Then we wait 5 seconds
+    Then we wait 10 seconds
 
   @off_ledger_s1
   Scenario: Put and get off-ledger data
@@ -104,6 +104,8 @@ Feature: off-ledger
     Given off-ledger collection config "ol_coll1_upgrade" is defined for collection "collection1" as policy="OR('Org1MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=1m
     And DCAS collection config "dcas_coll2_upgrade" is defined for collection "collection2" as policy="OR('Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=1m
     And "test" chaincode "ol_examplecc" is upgraded with version "v3" from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "ol_coll1_upgrade,dcas_coll2_upgrade,coll3,dcas_accounts"
+    Then we wait 20 seconds
+
     # Put the data to org2 - the data should be disseminated to org1
     When client queries chaincode "ol_examplecc" with args "putprivate,collection1,keyA,valueA" on a single peer in the "peerorg2" org on the "mychannel" channel
     And we wait 1 seconds

--- a/test/bddtests/features/transient_data.feature
+++ b/test/bddtests/features/transient_data.feature
@@ -21,7 +21,7 @@ Feature:
     And "test" chaincode "tdata_examplecc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "coll3"
 
     # We need to wait a while so that all of the peers' channel membership is Gossip'ed to all other peers.
-    Then we wait 10 seconds
+    Then we wait 20 seconds
 
     # Prove that the transient data collection1 is not there
     When client queries chaincode "tdata_examplecc" with args "putprivate,collection1,key1,value1" on the "mychannel" channel then the error response should contain "collection mychannel/tdata_examplecc/collection1 could not be found"
@@ -32,6 +32,8 @@ Feature:
 
     # Upgrade the chaincode, adding two transient data collections
     Given "test" chaincode "tdata_examplecc" is upgraded with version "v2" from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "tdata_coll1,tdata_coll2,coll3"
+    Given we wait 20 seconds
+
     When client queries chaincode "tdata_examplecc" with args "putprivate,collection1,key1,value1" on the "mychannel" channel
     And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,key1" on the "mychannel" channel
     Then response from "tdata_examplecc" to client equal value "value1"
@@ -113,6 +115,8 @@ Feature:
     #   - Ensure collection Type cannot be changed during chaincode upgrade
     Given transient collection config "coll3_upgrade" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=1m
     And "test" chaincode "tdata_examplecc" is upgraded with version "v999" from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "tdata_coll1,tdata_coll2,coll3_upgrade" then the error response should contain "ENDORSEMENT_POLICY_FAILURE. Description: instantiateOrUpgradeCC failed"
+    Given we wait 20 seconds
+
     #   - When the chaincode is upgraded with a new policy, all caches should be refreshed.
     #     Change the policy of collection1 so that it expires in 1m instead of 3s and
     #     change the policy of collection2 so that it expires in 3s instead of 10m
@@ -120,6 +124,7 @@ Feature:
     And transient collection config "tdata_coll2_upgrade" is defined for collection "collection2" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=3s
     And collection config "coll3" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and blocksToLive=1000
     And "test" chaincode "tdata_examplecc" is upgraded with version "v3" from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "tdata_coll1_upgrade,tdata_coll2_upgrade,coll3"
+    Given we wait 20 seconds
 
     When client queries chaincode "tdata_examplecc" with args "putprivate,collection1,keyA,valueA" on the "mychannel" channel
     And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,keyA" on the "mychannel" channel
@@ -142,6 +147,8 @@ Feature:
 
     # Test chaincode-to-chaincode invocation (same channel)
     Given "test" chaincode "tdata_examplecc_2" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "tdata_coll2"
+    Given we wait 20 seconds
+
     # Set the transient data on the target chaincode using a chaincode-to-chaincode invocation
     When client queries chaincode "tdata_examplecc" with args "invokecc,tdata_examplecc_2,,{`Args`:[`putprivate`|`collection2`|`keyC`|`valueC`]}" on the "mychannel" channel
     # Query the target chaincode directly
@@ -153,6 +160,8 @@ Feature:
 
     # Test chaincode-to-chaincode invocation (different channel)
     Given "test" chaincode "tdata_examplecc_2" is instantiated from path "in-process" on the "yourchannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "tdata_coll2"
+    Given we wait 20 seconds
+
     # Set the transient data on a different channel
     When client queries chaincode "tdata_examplecc_2" with args "putprivate,collection2,keyD,valueD" on the "yourchannel" channel
     # Query the target chaincode directly


### PR DESCRIPTION
When a local peer does not have the off-ledger data stored then it asks for the data from other peers using Gossip. Non-endorsing committers are also being asked for the data but the non-endorser was rejecting the request. This patch changes this logic so that a committing peer will also respond with the data since all endorsers may be unavailable.

closes #327

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>