### PR TITLE
refactor: Refactor the config validator interface

### DIFF
--- a/cmd/chaincode/configcc/configcc.go
+++ b/cmd/chaincode/configcc/configcc.go
@@ -37,16 +37,16 @@ type configMgr interface {
 type function func(shim.ChaincodeStubInterface, [][]byte) pb.Response
 
 type configCC struct {
-	validatorRegistry configValidatorRegistry
+	validatorRegistry configValidator
 	functionRegistry  map[string]function
 }
 
-type configValidatorRegistry interface {
-	ValidatorForKey(key *config.Key) config.Validator
+type configValidator interface {
+	Validate(kv *config.KeyValue) error
 }
 
-// New returns a new configuration system chaincode
-func New(validatorRegistry configValidatorRegistry) ccapi.UserCC {
+// New returns a new configuration chaincode
+func New(validatorRegistry configValidator) ccapi.UserCC {
 	cc := &configCC{validatorRegistry: validatorRegistry}
 	cc.initFunctionRegistry()
 	return cc
@@ -189,7 +189,7 @@ func unmarshalCriteria(bytes []byte) (*config.Criteria, error) {
 }
 
 // getConfigMgr returns the config manager. This variable may be overridden by unit tests.
-var getConfigMgr = func(ns string, sp api.StoreProvider, cfgValidatorRegistry configValidatorRegistry) configMgr {
+var getConfigMgr = func(ns string, sp api.StoreProvider, cfgValidatorRegistry configValidator) configMgr {
 	return ledgerconfig.NewUpdateManager(ns, sp, cfgValidatorRegistry)
 }
 

--- a/cmd/chaincode/configcc/configcc_test.go
+++ b/cmd/chaincode/configcc/configcc_test.go
@@ -26,7 +26,7 @@ const (
 )
 
 func TestConfigCC_New(t *testing.T) {
-	cc := New(&configmocks.ValidatorRegistry{})
+	cc := New(&configmocks.Validator{})
 	require.NotNil(t, cc)
 
 	require.Equal(t, service.ConfigNS, cc.Name())
@@ -34,7 +34,7 @@ func TestConfigCC_New(t *testing.T) {
 }
 
 func TestConfigCC_Init(t *testing.T) {
-	cc := New(&configmocks.ValidatorRegistry{})
+	cc := New(&configmocks.Validator{})
 	require.NotNil(t, cc)
 
 	t.Run("System channel", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestConfigCC_Init(t *testing.T) {
 }
 
 func TestConfigCC_Invoke_Invalid(t *testing.T) {
-	cc := New(&configmocks.ValidatorRegistry{})
+	cc := New(&configmocks.Validator{})
 	require.NotNil(t, cc)
 
 	t.Run("No func arg", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestConfigCC_Invoke_Invalid(t *testing.T) {
 }
 
 func TestConfigCC_Invoke_Save(t *testing.T) {
-	cc := New(&configmocks.ValidatorRegistry{})
+	cc := New(&configmocks.Validator{})
 	require.NotNil(t, cc)
 
 	t.Run("Empty config", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestConfigCC_Invoke_Save(t *testing.T) {
 		prevProvider := getConfigMgr
 		defer func() { getConfigMgr = prevProvider }()
 
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr()
 		}
 
@@ -109,7 +109,7 @@ func TestConfigCC_Invoke_Save(t *testing.T) {
 		prevProvider := getConfigMgr
 		defer func() { getConfigMgr = prevProvider }()
 
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr()
 		}
 
@@ -124,7 +124,7 @@ func TestConfigCC_Invoke_Save(t *testing.T) {
 		defer func() { getConfigMgr = prevProvider }()
 
 		errExpected := errors.New("config mgr error")
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr().WithError(errExpected)
 		}
 
@@ -136,7 +136,7 @@ func TestConfigCC_Invoke_Save(t *testing.T) {
 }
 
 func TestConfigCC_Invoke_Get(t *testing.T) {
-	cc := New(&configmocks.ValidatorRegistry{})
+	cc := New(&configmocks.Validator{})
 	require.NotNil(t, cc)
 
 	t.Run("No criteria", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestConfigCC_Invoke_Get(t *testing.T) {
 		prevProvider := getConfigMgr
 		defer func() { getConfigMgr = prevProvider }()
 
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr()
 		}
 		r := shimtest.NewMockStub("mock_stub", cc.Chaincode()).MockInvoke(tx1, [][]byte{[]byte("get"), {}})
@@ -169,7 +169,7 @@ func TestConfigCC_Invoke_Get(t *testing.T) {
 			Key:   &config.Key{},
 			Value: config.NewValue(tx1, "config_value", config.FormatOther),
 		}
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr().WithQueryResults(criteria, []*config.KeyValue{result})
 		}
 
@@ -194,7 +194,7 @@ func TestConfigCC_Invoke_Get(t *testing.T) {
 
 		criteria := &config.Criteria{MspID: org1MSP}
 		result := config.NewKeyValue(&config.Key{}, config.NewValue(tx1, "config_value", config.FormatOther))
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr().WithQueryResults(criteria, []*config.KeyValue{result})
 		}
 
@@ -216,7 +216,7 @@ func TestConfigCC_Invoke_Get(t *testing.T) {
 		defer func() { getConfigMgr = prevProvider }()
 
 		errExpected := errors.New("config mgr error")
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr().WithError(errExpected)
 		}
 
@@ -231,7 +231,7 @@ func TestConfigCC_Invoke_Get(t *testing.T) {
 }
 
 func TestConfigCC_Invoke_Delete(t *testing.T) {
-	cc := New(&configmocks.ValidatorRegistry{})
+	cc := New(&configmocks.Validator{})
 	require.NotNil(t, cc)
 
 	t.Run("No criteria", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestConfigCC_Invoke_Delete(t *testing.T) {
 		prevProvider := getConfigMgr
 		defer func() { getConfigMgr = prevProvider }()
 
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr()
 		}
 		r := shimtest.NewMockStub("mock_stub", cc.Chaincode()).MockInvoke(tx1, [][]byte{[]byte("delete"), {}})
@@ -259,7 +259,7 @@ func TestConfigCC_Invoke_Delete(t *testing.T) {
 		prevProvider := getConfigMgr
 		defer func() { getConfigMgr = prevProvider }()
 
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr()
 		}
 
@@ -277,7 +277,7 @@ func TestConfigCC_Invoke_Delete(t *testing.T) {
 		defer func() { getConfigMgr = prevProvider }()
 
 		errExpected := errors.New("config mgr error")
-		getConfigMgr = func(string, api.StoreProvider, configValidatorRegistry) configMgr {
+		getConfigMgr = func(string, api.StoreProvider, configValidator) configMgr {
 			return configmocks.NewConfigMgr().WithError(errExpected)
 		}
 

--- a/pkg/config/ledgerconfig/config/service.go
+++ b/pkg/config/ledgerconfig/config/service.go
@@ -18,8 +18,6 @@ type Service interface {
 
 // Validator validates application-specific configuration
 type Validator interface {
-	// Validate validates the key and value and returns an error in the case of invalid config
-	Validate(key *Key, value *Value) error
-	// CanValidate returns true if the validator is able to validate the given config key
-	CanValidate(key *Key) bool
+	// Validate validates the key/value and returns an error in the case of invalid config
+	Validate(kv *KeyValue) error
 }

--- a/pkg/config/ledgerconfig/mgr/querymgr_test.go
+++ b/pkg/config/ledgerconfig/mgr/querymgr_test.go
@@ -215,8 +215,7 @@ func TestManager_QueryExecutorError(t *testing.T) {
 }
 
 func TestManager_Search_AppConfig(t *testing.T) {
-	vr := &configmocks.ValidatorRegistry{}
-	m := NewUpdateManager(configNamespace, configmocks.NewStoreProvider(), vr)
+	m := NewUpdateManager(configNamespace, configmocks.NewStoreProvider(), &configmocks.Validator{})
 	require.NotNil(t, m)
 
 	require.NoError(t, m.Save(txID1, msp1App1ComponentsConfig))
@@ -302,7 +301,7 @@ func TestManager_Search_AppConfig(t *testing.T) {
 }
 
 func TestManager_Search_PeerConfig(t *testing.T) {
-	m := NewUpdateManager(configNamespace, configmocks.NewStoreProvider(), &configmocks.ValidatorRegistry{})
+	m := NewUpdateManager(configNamespace, configmocks.NewStoreProvider(), &configmocks.Validator{})
 	require.NotNil(t, m)
 	require.NoError(t, m.Save(txID1, msp1PeerConfig))
 

--- a/pkg/config/ledgerconfig/mocks/validator.gen.go
+++ b/pkg/config/ledgerconfig/mocks/validator.gen.go
@@ -8,11 +8,10 @@ import (
 )
 
 type Validator struct {
-	ValidateStub        func(key *config.Key, value *config.Value) error
+	ValidateStub        func(kv *config.KeyValue) error
 	validateMutex       sync.RWMutex
 	validateArgsForCall []struct {
-		key   *config.Key
-		value *config.Value
+		kv *config.KeyValue
 	}
 	validateReturns struct {
 		result1 error
@@ -20,32 +19,20 @@ type Validator struct {
 	validateReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CanValidateStub        func(key *config.Key) bool
-	canValidateMutex       sync.RWMutex
-	canValidateArgsForCall []struct {
-		key *config.Key
-	}
-	canValidateReturns struct {
-		result1 bool
-	}
-	canValidateReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Validator) Validate(key *config.Key, value *config.Value) error {
+func (fake *Validator) Validate(kv *config.KeyValue) error {
 	fake.validateMutex.Lock()
 	ret, specificReturn := fake.validateReturnsOnCall[len(fake.validateArgsForCall)]
 	fake.validateArgsForCall = append(fake.validateArgsForCall, struct {
-		key   *config.Key
-		value *config.Value
-	}{key, value})
-	fake.recordInvocation("Validate", []interface{}{key, value})
+		kv *config.KeyValue
+	}{kv})
+	fake.recordInvocation("Validate", []interface{}{kv})
 	fake.validateMutex.Unlock()
 	if fake.ValidateStub != nil {
-		return fake.ValidateStub(key, value)
+		return fake.ValidateStub(kv)
 	}
 	if specificReturn {
 		return ret.result1
@@ -59,10 +46,10 @@ func (fake *Validator) ValidateCallCount() int {
 	return len(fake.validateArgsForCall)
 }
 
-func (fake *Validator) ValidateArgsForCall(i int) (*config.Key, *config.Value) {
+func (fake *Validator) ValidateArgsForCall(i int) *config.KeyValue {
 	fake.validateMutex.RLock()
 	defer fake.validateMutex.RUnlock()
-	return fake.validateArgsForCall[i].key, fake.validateArgsForCall[i].value
+	return fake.validateArgsForCall[i].kv
 }
 
 func (fake *Validator) ValidateReturns(result1 error) {
@@ -84,61 +71,11 @@ func (fake *Validator) ValidateReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Validator) CanValidate(key *config.Key) bool {
-	fake.canValidateMutex.Lock()
-	ret, specificReturn := fake.canValidateReturnsOnCall[len(fake.canValidateArgsForCall)]
-	fake.canValidateArgsForCall = append(fake.canValidateArgsForCall, struct {
-		key *config.Key
-	}{key})
-	fake.recordInvocation("CanValidate", []interface{}{key})
-	fake.canValidateMutex.Unlock()
-	if fake.CanValidateStub != nil {
-		return fake.CanValidateStub(key)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.canValidateReturns.result1
-}
-
-func (fake *Validator) CanValidateCallCount() int {
-	fake.canValidateMutex.RLock()
-	defer fake.canValidateMutex.RUnlock()
-	return len(fake.canValidateArgsForCall)
-}
-
-func (fake *Validator) CanValidateArgsForCall(i int) *config.Key {
-	fake.canValidateMutex.RLock()
-	defer fake.canValidateMutex.RUnlock()
-	return fake.canValidateArgsForCall[i].key
-}
-
-func (fake *Validator) CanValidateReturns(result1 bool) {
-	fake.CanValidateStub = nil
-	fake.canValidateReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *Validator) CanValidateReturnsOnCall(i int, result1 bool) {
-	fake.CanValidateStub = nil
-	if fake.canValidateReturnsOnCall == nil {
-		fake.canValidateReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.canValidateReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
 func (fake *Validator) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.validateMutex.RLock()
 	defer fake.validateMutex.RUnlock()
-	fake.canValidateMutex.RLock()
-	defer fake.canValidateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
@@ -157,5 +94,3 @@ func (fake *Validator) recordInvocation(key string, args []interface{}) {
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
-
-var _ config.Validator = new(Validator)

--- a/pkg/config/ledgerconfig/service/service_test.go
+++ b/pkg/config/ledgerconfig/service/service_test.go
@@ -127,7 +127,7 @@ func TestConfigService_Get(t *testing.T) {
 
 func TestConfigService_Query(t *testing.T) {
 	sp := configmocks.NewStoreProvider()
-	m := mgr.NewUpdateManager(ConfigNS, sp, &mocks.ValidatorRegistry{})
+	m := mgr.NewUpdateManager(ConfigNS, sp, &mocks.Validator{})
 	require.NotNil(t, m)
 	require.NoError(t, m.Save("tx1", msp1App1ComponentsConfig))
 

--- a/pkg/config/ledgerconfig/validator/validator_test.go
+++ b/pkg/config/ledgerconfig/validator/validator_test.go
@@ -7,10 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package validator
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mocks"
 )
 
 const (
@@ -19,72 +21,42 @@ const (
 	v1   = "v1"
 )
 
-func TestNewRegistry(t *testing.T) {
+func TestKeyValueValidation(t *testing.T) {
+	k1 := config.NewAppKey(msp1, app1, v1)
+
 	r := NewRegistry()
 	require.NotNil(t, r)
 
-	val1 := &mockValidator{
-		canValidate: false,
-	}
-	val2 := &mockValidator{
-		canValidate: true,
-	}
+	t.Run("No MspID", func(t *testing.T) {
+		kv1 := config.NewKeyValue(&config.Key{}, &config.Value{})
+		require.EqualError(t, r.Validate(kv1), "field [MspID] is required")
+	})
 
+	t.Run("No Format", func(t *testing.T) {
+		kv := config.NewKeyValue(k1, &config.Value{})
+		require.EqualError(t, r.Validate(kv), "field 'Format' must not be empty")
+	})
+
+	t.Run("No Config", func(t *testing.T) {
+		kv := config.NewKeyValue(k1, &config.Value{Format: config.FormatJSON})
+		require.EqualError(t, r.Validate(kv), "field 'Config' must not be empty")
+	})
+
+	t.Run("Valid Config", func(t *testing.T) {
+		kv := config.NewKeyValue(k1, &config.Value{Format: config.FormatJSON, Config: "{}"})
+		require.NoError(t, r.Validate(kv))
+	})
+}
+
+func TestAppValidation(t *testing.T) {
+	r := NewRegistry()
+	require.NotNil(t, r)
+
+	val1 := &mocks.Validator{}
+	errExpected := errors.New("injected validation error")
+	val1.ValidateReturns(errExpected)
 	r.Register(val1)
 
-	k1 := config.NewAppKey(msp1, app1, v1)
-
-	t.Run("Key-Value validation", func(t *testing.T) {
-		k := &config.Key{}
-		v1 := &config.Value{}
-		v := r.ValidatorForKey(k)
-		require.NotNil(t, v)
-		require.EqualError(t, v.Validate(k, v1), "field [MspID] is required")
-
-		v = r.ValidatorForKey(k1)
-		require.NotNil(t, v)
-		require.EqualError(t, v.Validate(k1, &config.Value{}), "field 'Format' must not be empty")
-		require.EqualError(t, v.Validate(k1, &config.Value{Format: config.FormatJSON}), "field 'Config' must not be empty")
-		require.NoError(t, v.Validate(k1, &config.Value{Format: config.FormatJSON, Config: "{}"}))
-	})
-
-	t.Run("Without app validator", func(t *testing.T) {
-		v := r.ValidatorForKey(k1)
-		require.NotNil(t, v)
-		kv, ok := v.(*keyValueValidator)
-		require.True(t, ok)
-		require.Nil(t, kv.appValidator)
-	})
-
-	t.Run("With app validator", func(t *testing.T) {
-		r.Register(val2)
-		v := r.ValidatorForKey(k1)
-		require.NotNil(t, v)
-		kv, ok := v.(*keyValueValidator)
-		require.True(t, ok)
-		require.Equal(t, val2, kv.appValidator)
-		require.NoError(t, v.Validate(k1, &config.Value{Format: config.FormatJSON, Config: "{}"}))
-	})
-}
-
-func TestKeyValueValidator(t *testing.T) {
-	v := &keyValueValidator{}
-
-	k1 := config.NewAppKey(msp1, app1, v1)
-	v1 := &config.Value{}
-
-	require.True(t, v.CanValidate(k1))
-	require.Error(t, v.Validate(k1, v1))
-}
-
-type mockValidator struct {
-	canValidate bool
-}
-
-func (v *mockValidator) Validate(key *config.Key, value *config.Value) error {
-	return nil
-}
-
-func (v *mockValidator) CanValidate(key *config.Key) bool {
-	return v.canValidate
+	kv := config.NewKeyValue(config.NewAppKey(msp1, app1, v1), &config.Value{Format: config.FormatJSON, Config: "{}"})
+	require.EqualError(t, r.Validate(kv), errExpected.Error())
 }


### PR DESCRIPTION
Removed the CanValidate function. All validators will be invoked for every config update.

closes #364

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>