### PR TITLE
feat: Added a 'Tags' field to the config value

### DIFF
--- a/pkg/config/ledgerconfig/config/config.go
+++ b/pkg/config/ledgerconfig/config/config.go
@@ -91,6 +91,8 @@ type App struct {
 	Format Format
 	// Config contains the actual configuration
 	Config string
+	// Tags contains optional tags that describe the data
+	Tags []string `json:",omitempty"`
 	// Components zero or more component configs
 	Components []*Component
 }
@@ -130,6 +132,8 @@ type Component struct {
 	Format Format
 	// Config contains the actual configuration
 	Config string
+	// Tags contains optional tags that describe the data
+	Tags []string `json:",omitempty"`
 }
 
 // Validate validates the Component

--- a/pkg/config/ledgerconfig/config/keyvalue.go
+++ b/pkg/config/ledgerconfig/config/keyvalue.go
@@ -132,20 +132,23 @@ type Value struct {
 	Format Format
 	// Config contains the actual configuration
 	Config string
+	// Tags contains an optional set of tags that describe the data
+	Tags []string
 }
 
 // NewValue returns a new config Value
-func NewValue(txID string, config string, format Format) *Value {
+func NewValue(txID string, config string, format Format, tags ...string) *Value {
 	return &Value{
 		TxID:   txID,
 		Config: config,
 		Format: format,
+		Tags:   tags,
 	}
 }
 
 // String returns a readable string for the value
 func (v *Value) String() string {
-	return fmt.Sprintf("(TxID:%s),(Config:%s),(Format:%s)", v.TxID, v.Config, v.Format)
+	return fmt.Sprintf("(TxID:%s),(Config:%s),(Format:%s),(Tags:%s)", v.TxID, v.Config, v.Format, v.Tags)
 }
 
 // KeyValue contains the key and the value for the key

--- a/pkg/config/ledgerconfig/config/keyvalue_test.go
+++ b/pkg/config/ledgerconfig/config/keyvalue_test.go
@@ -81,7 +81,7 @@ func TestKey_String(t *testing.T) {
 
 func TestValue_String(t *testing.T) {
 	kv := NewKeyValue(NewAppKey(msp1, app1, v1), NewValue(tx1, "some config", FormatOther))
-	require.Equal(t, "[(MSP:org1MSP),(Peer:),(AppName:app1),(AppVersion:v1),(Comp:),(CompVersion:)]=[(TxID:tx1),(Config:some config),(Format:OTHER)]", kv.String())
+	require.Equal(t, "[(MSP:org1MSP),(Peer:),(AppName:app1),(AppVersion:v1),(Comp:),(CompVersion:)]=[(TxID:tx1),(Config:some config),(Format:OTHER),(Tags:[])]", kv.String())
 }
 
 func TestKey_Validate(t *testing.T) {

--- a/pkg/config/ledgerconfig/mgr/keyvaluemap.go
+++ b/pkg/config/ledgerconfig/mgr/keyvaluemap.go
@@ -55,7 +55,7 @@ func (c keyValueMap) populateApp(mspID string, app *config.App, txID string) {
 
 	if app.Config != "" {
 		logger.Debugf("[%s] ... adding config for app [%s] ...", txID, app.AppName)
-		c[*config.NewAppKey(mspID, app.AppName, app.Version)] = config.NewValue(txID, app.Config, app.Format)
+		c[*config.NewAppKey(mspID, app.AppName, app.Version)] = config.NewValue(txID, app.Config, app.Format, app.Tags...)
 	}
 }
 
@@ -67,7 +67,7 @@ func (c keyValueMap) populatePeerApp(mspID, peerID string, app *config.App, txID
 
 	if app.Config != "" {
 		logger.Debugf("[%s] ... adding config for peer [%s] and app [%s] ...", txID, peerID, app.AppName)
-		c[*config.NewPeerKey(mspID, peerID, app.AppName, app.Version)] = config.NewValue(txID, app.Config, app.Format)
+		c[*config.NewPeerKey(mspID, peerID, app.AppName, app.Version)] = config.NewValue(txID, app.Config, app.Format, app.Tags...)
 	}
 }
 
@@ -75,7 +75,7 @@ func (c keyValueMap) populateComponents(mspID string, app *config.App, txID stri
 	logger.Debugf("[%s] ... adding components for app [%s] ...", txID, app.AppName)
 	for _, comp := range app.Components {
 		logger.Debugf("[%s] ... adding component [%s:%s] for app [%s] ...", txID, comp.Name, comp.Version, app.AppName)
-		c[*config.NewComponentKey(mspID, app.AppName, app.Version, comp.Name, comp.Version)] = config.NewValue(txID, comp.Config, comp.Format)
+		c[*config.NewComponentKey(mspID, app.AppName, app.Version, comp.Name, comp.Version)] = config.NewValue(txID, comp.Config, comp.Format, comp.Tags...)
 	}
 }
 
@@ -83,6 +83,6 @@ func (c keyValueMap) populatePeerComponents(mspID, peerID string, app *config.Ap
 	logger.Debugf("[%s] ... adding components for peer [%s] and app [%s] ...", txID, peerID, app.AppName)
 	for _, comp := range app.Components {
 		logger.Debugf("[%s] ... adding component [%s:%s] for peer [%s] and app [%s] ...", txID, comp.Name, comp.Version, peerID, app.AppName)
-		c[*config.NewPeerComponentKey(mspID, peerID, app.AppName, app.Version, comp.Name, comp.Version)] = config.NewValue(txID, comp.Config, comp.Format)
+		c[*config.NewPeerComponentKey(mspID, peerID, app.AppName, app.Version, comp.Name, comp.Version)] = config.NewValue(txID, comp.Config, comp.Format, comp.Tags...)
 	}
 }

--- a/pkg/config/ledgerconfig/mgr/updatemgr_test.go
+++ b/pkg/config/ledgerconfig/mgr/updatemgr_test.go
@@ -31,6 +31,8 @@ const (
 	app1 = "app1"
 	app2 = "app2"
 	app3 = "app3"
+	app7 = "app7"
+	app8 = "app8"
 
 	comp1 = "comp1"
 	comp2 = "comp2"
@@ -43,10 +45,12 @@ const (
 	txID2 = "tx2"
 	txID3 = "tx3"
 
-	msp1App1V1Config = "msp1-app1-v1-config"
-	msp1App1V2Config = "msp1-app1-v2-config"
-	msp1App2V1Config = `{"msp":"msp1", key1": "value1"}`
-	msp1App2V2Config = `{"msp":"msp1", "key1_1": "value1"}`
+	msp1App1V1Config        = "msp1-app1-v1-config"
+	msp1App1V2Config        = "msp1-app1-v2-config"
+	msp1App2V1Config        = `{"msp":"msp1", key1": "value1"}`
+	msp1App2V2Config        = `{"msp":"msp1", "key1_1": "value1"}`
+	msp1App7V1Config        = `{"msp":"msp1", "key7": "value7"}`
+	msp1App8V1Comp1V1Config = `{"msp":"msp1", "key7": "value7"}`
 
 	msp2App1V1Config = "msp2-app1-v1-config"
 	msp2App1V2Config = "msp2-app1-v2-config"
@@ -262,6 +266,18 @@ var (
 			},
 		},
 	}
+	appConfigWithTags = &config.Config{
+		MspID: msp1,
+		Apps: []*config.App{
+			{AppName: app7, Version: v1, Config: msp1App7V1Config, Format: config.FormatJSON, Tags: []string{"tag1", "tag2"}},
+			{
+				AppName: app8, Version: v1,
+				Components: []*config.Component{
+					{Name: comp1, Version: v1, Config: msp1App8V1Comp1V1Config, Format: config.FormatJSON, Tags: []string{"tag1"}},
+				},
+			},
+		},
+	}
 )
 
 func TestUpdateManager_StoreError(t *testing.T) {
@@ -384,6 +400,12 @@ func TestUpdateManager_Save(t *testing.T) {
 		require.NoError(t, m.Save(txID2, peerComponentConfigUpdate))
 		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer1, app1, v1, comp1, v1), config.NewValue(txID2, peer1App1V1Comp1V1ConfigUpdate, config.FormatOther))
 		requireEqualValue(t, r, config.NewPeerComponentKey(msp1, peer2, app2, v1, comp1, v1), config.NewValue(txID2, peer2App2V1Comp1V1Config, config.FormatYAML))
+	})
+	t.Run("App with tags", func(t *testing.T) {
+		require.NoError(t, m.Save(txID3, appConfigWithTags))
+
+		requireEqualValue(t, r, config.NewAppKey(msp1, app7, v1), config.NewValue(txID3, msp1App7V1Config, config.FormatJSON, "tag1", "tag2"))
+		requireEqualValue(t, r, config.NewComponentKey(msp1, app8, v1, comp1, v1), config.NewValue(txID3, msp1App8V1Comp1V1Config, config.FormatJSON, "tag1"))
 	})
 }
 

--- a/test/bddtests/config_steps.go
+++ b/test/bddtests/config_steps.go
@@ -122,6 +122,7 @@ func (cp *configPreprocessor) visitApps(srcApps []*App) ([]*App, error) {
 			AppName:    a.AppName,
 			Version:    a.Version,
 			Format:     a.Format,
+			Tags:       a.Tags,
 			Config:     config,
 			Components: components,
 		}
@@ -140,6 +141,7 @@ func (cp *configPreprocessor) visitComponents(srcComponents []*Component) ([]*Co
 			Name:    c.Name,
 			Version: c.Version,
 			Format:  c.Format,
+			Tags:    c.Tags,
 			Config:  config,
 		}
 	}
@@ -221,6 +223,8 @@ type App struct {
 	Format Format
 	// Config contains the actual configuration
 	Config string
+	// Tags contains optional tags that describe the data
+	Tags []string `json:",omitempty"`
 	// Components zero or more component configs
 	Components []*Component `json:",omitempty"`
 }
@@ -235,4 +239,6 @@ type Component struct {
 	Format Format
 	// Config contains the actual configuration
 	Config string
+	// Tags contains optional tags that describe the data
+	Tags []string `json:",omitempty"`
 }

--- a/test/bddtests/features/ledger_config.feature
+++ b/test/bddtests/features/ledger_config.feature
@@ -18,13 +18,15 @@ Feature: ledger-config
   @ledger_config_s1
   Scenario: Save, get and delete application config
     # Save and query app1 v1 config
-    Given variable "msp1App1V1Config" is assigned the JSON value '{"MspID":"MSP1","Apps":[{"AppName":"app1","Version":"v1","Config":"msp1-app1-v1-config","Format":"Other"}]}'
+    Given variable "msp1App1V1Config" is assigned the JSON value '{"MspID":"MSP1","Apps":[{"AppName":"app1","Version":"v1","Config":"msp1-app1-v1-config","Format":"Other","Tags":["tag1","tag2"]}]}'
     When client invokes chaincode "configscc" with args "save,${msp1App1V1Config}" on the "mychannel" channel
     And we wait 1 seconds
     Given variable "msp1App1Criteria" is assigned the JSON value '{"MspID":"MSP1","AppName":"app1"}'
     When client queries chaincode "configscc" with args "get,${msp1App1Criteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
     Then the JSON path "#" of the response has 1 items
     And the JSON path "0.Config" of the response equals "msp1-app1-v1-config"
+    And the JSON path "0.Tags.0" of the response equals "tag1"
+    And the JSON path "0.Tags.1" of the response equals "tag2"
 
     # Save and query app1 v2 config
     Given variable "msp1App1V2Config" is assigned the JSON value '{"MspID":"MSP1","Apps":[{"AppName":"app1","Version":"v2","Config":"msp1-app1-v2-config","Format":"Other"}]}'


### PR DESCRIPTION
The 'Tags' field was added to a config value so that config validators may differentiate between config types that they are capable of validating.

closes #365

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>