### PR TITLE
feat: Add error handler to block visitor

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -22,7 +22,9 @@ jobs:
         cp -R pkg/testutil/sampleconfig ${GOPATH}/src/github.com/trustbloc/fabric-peer-ext/pkg/testutil
         make unit-test
       displayName: Run checks and unit test
-    - script: bash <(curl https://codecov.io/bash)
+    - script: bash <(curl https://codecov.io/bash) -t $CODECOV_UPLOAD_TOKEN
+      env:
+        CODECOV_UPLOAD_TOKEN: $(CODECOV_UPLOAD_TOKEN)
       displayName: Upload coverage to Codecov
 
   - job: BDDTest

--- a/pkg/common/blockvisitor/context.go
+++ b/pkg/common/blockvisitor/context.go
@@ -1,0 +1,137 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockvisitor
+
+import (
+	"fmt"
+)
+
+// Category defines the error category
+type Category string
+
+const (
+	// UnmarshalErr indicates that an error occurred while attempting to unmarshal block data
+	UnmarshalErr Category = "UNMARSHAL_ERROR"
+
+	// ReadHandlerErr indicates that the read handler returned an error
+	ReadHandlerErr Category = "READ_HANDLER_ERROR"
+
+	// WriteHandlerErr indicates that the write handler returned an error
+	WriteHandlerErr Category = "WRITE_HANDLER_ERROR"
+
+	// LSCCWriteHandlerErr indicates that the LSCC write handler returned an error
+	LSCCWriteHandlerErr Category = "LSCCWRITE_HANDLER_ERROR"
+
+	// CCEventHandlerErr indicates that the chaincode event handler returned an error
+	CCEventHandlerErr Category = "CCEVENT_HANDLER_ERROR"
+
+	// ConfigUpdateHandlerErr indicates that the configuration update handler returned an error
+	ConfigUpdateHandlerErr Category = "CONFIG_UPDATE_HANDLER_ERROR"
+)
+
+// Context holds the context at the time of a Visitor error
+type Context struct {
+	Category     Category
+	ChannelID    string
+	BlockNum     uint64
+	TxNum        uint64
+	TxID         string
+	Read         *Read
+	Write        *Write
+	CCEvent      *CCEvent
+	LSCCWrite    *LSCCWrite
+	ConfigUpdate *ConfigUpdate
+}
+
+func newContext(category Category, channelID string, blockNum uint64, opts ...ctxOpt) *Context {
+	ctx := &Context{
+		Category:  category,
+		ChannelID: channelID,
+		BlockNum:  blockNum,
+	}
+
+	for _, opt := range opts {
+		opt(ctx)
+	}
+
+	return ctx
+}
+
+// String returns the string representation of Context
+func (c *Context) String() string {
+	s := fmt.Sprintf("ChannelID: %s, Category: %s, Block: %d, TxNum: %d", c.ChannelID, c.Category, c.BlockNum, c.TxNum)
+
+	if c.TxID != "" {
+		s += fmt.Sprintf(", TxID: %s", c.TxID)
+	}
+
+	if c.Read != nil {
+		s += fmt.Sprintf(", Read: %+v", c.Read)
+	}
+
+	if c.Write != nil {
+		s += fmt.Sprintf(", Write: %+v", c.Write)
+	}
+
+	if c.CCEvent != nil {
+		s += fmt.Sprintf(", CCEvent: %+v", c.CCEvent)
+	}
+
+	if c.LSCCWrite != nil {
+		s += fmt.Sprintf(", LSCCWrite: %+v", c.LSCCWrite)
+	}
+
+	if c.ConfigUpdate != nil {
+		s += fmt.Sprintf(", ConfigUpdate: %+v", c.ConfigUpdate)
+	}
+
+	return s
+}
+
+type ctxOpt func(ctx *Context)
+
+func withTxID(txID string) ctxOpt {
+	return func(ctx *Context) {
+		ctx.TxID = txID
+	}
+}
+
+func withTxNum(num uint64) ctxOpt {
+	return func(ctx *Context) {
+		ctx.TxNum = num
+	}
+}
+
+func withRead(r *Read) ctxOpt {
+	return func(ctx *Context) {
+		ctx.Read = r
+	}
+}
+
+func withWrite(w *Write) ctxOpt {
+	return func(ctx *Context) {
+		ctx.Write = w
+	}
+}
+
+func withLSCCWrite(w *LSCCWrite) ctxOpt {
+	return func(ctx *Context) {
+		ctx.LSCCWrite = w
+	}
+}
+
+func withCCEvent(ccEvent *CCEvent) ctxOpt {
+	return func(ctx *Context) {
+		ctx.CCEvent = ccEvent
+	}
+}
+
+func withConfigUpdate(u *ConfigUpdate) ctxOpt {
+	return func(ctx *Context) {
+		ctx.ConfigUpdate = u
+	}
+}

--- a/pkg/common/blockvisitor/context_test.go
+++ b/pkg/common/blockvisitor/context_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockvisitor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContext(t *testing.T) {
+	ccEvent := &CCEvent{
+		BlockNum: 1000,
+		TxID:     txID1,
+		TxNum:    12,
+	}
+
+	lsccWrite := &LSCCWrite{
+		BlockNum: 1000,
+		TxID:     txID1,
+		TxNum:    12,
+	}
+
+	configUpdate := &ConfigUpdate{
+		BlockNum: 1000,
+	}
+
+	read := &Read{
+		BlockNum: 1000,
+		TxID:     txID1,
+		TxNum:    12,
+	}
+
+	write := &Write{
+		BlockNum: 1000,
+		TxID:     txID1,
+		TxNum:    12,
+	}
+
+	ctx := newContext(
+		UnmarshalErr, channelID, 1000,
+		withTxID(txID1),
+		withTxNum(12),
+		withCCEvent(ccEvent),
+		withConfigUpdate(configUpdate),
+		withLSCCWrite(lsccWrite),
+		withRead(read),
+		withWrite(write),
+	)
+	require.NotNil(t, ctx)
+	require.Equal(t, UnmarshalErr, ctx.Category)
+	require.Equal(t, channelID, ctx.ChannelID)
+	require.Equal(t, uint64(1000), ctx.BlockNum)
+	require.Equal(t, txID1, ctx.TxID)
+	require.Equal(t, ccEvent, ctx.CCEvent)
+	require.Equal(t, configUpdate, ctx.ConfigUpdate)
+	require.Equal(t, lsccWrite, ctx.LSCCWrite)
+	require.Equal(t, read, ctx.Read)
+	require.Equal(t, write, ctx.Write)
+
+	s := ctx.String()
+	require.Contains(t, s, "ChannelID: testchannel")
+	require.Contains(t, s, "Category: UNMARSHAL_ERROR")
+	require.Contains(t, s, "Block: 1000")
+	require.Contains(t, s, "TxNum: 12")
+	require.Contains(t, s, "TxID: tx1")
+	require.Contains(t, s, "Read:")
+	require.Contains(t, s, "Write:")
+	require.Contains(t, s, "CCEvent:")
+	require.Contains(t, s, "TxID:tx1")
+	require.Contains(t, s, "TxNum:12")
+	require.Contains(t, s, "ConfigUpdate:")
+}


### PR DESCRIPTION
Clients may add a custom error handler to the block visitor which may handle the error by indicating whether further processing of the block should be halted.

closes #374

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>