### PR TITLE
fix: Don't purge off-ledger data whose expiry is set to 0

### DIFF
--- a/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore.go
+++ b/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore.go
@@ -34,17 +34,9 @@ const (
 )
 
 const (
-	fetchExpiryDataQuery = `
-	{
-		"selector": {
-			"` + expiryField + `": {
-				"$lt": %v
-			}
-		},
-		"fields": [
-			"` + idField + `",
-			"` + revField + `"
-		],
+	fetchExpiryDataQuery = `{
+		"selector": {"$and": [{"` + expiryField + `": {"$gt": 0}},{"` + expiryField + `": {"$lt": %v}}]},
+		"fields": ["` + idField + `","` + revField + `"],
 		"use_index": ["_design/` + expiryIndexDoc + `", "` + expiryIndexName + `"]
 	}`
 )
@@ -148,8 +140,8 @@ func (s *dbstore) DeleteExpiredKeys() error {
 	if err != nil {
 		return err
 	}
+
 	if len(data) == 0 {
-		logger.Debugf("No keys to delete from db")
 		return nil
 	}
 

--- a/test/bddtests/features/off_ledger.feature
+++ b/test/bddtests/features/off_ledger.feature
@@ -12,10 +12,14 @@ Feature: off-ledger
     Given the channel "mychannel" is created and all peers have joined
     And the channel "yourchannel" is created and all peers have joined
 
+    # Data in collection1 are purged after 10s
     And off-ledger collection config "ol_coll1" is defined for collection "collection1" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=10s
-    And DCAS collection config "dcas_coll2" is defined for collection "collection2" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=10m
+    # Data in collection2 are never purged
+    And DCAS collection config "dcas_coll2" is defined for collection "collection2" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
+    # Data in collection3 are purged after 10 blocks of being added
     And collection config "coll3" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=3, and blocksToLive=10
-    And DCAS collection config "dcas_accounts" is defined for collection "accounts" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=30m
+    # Data in accounts are never purged
+    And DCAS collection config "dcas_accounts" is defined for collection "accounts" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
     And "test" chaincode "ol_examplecc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "ol_coll1,dcas_coll2,coll3,dcas_accounts"
     And "test" chaincode "ol_examplecc_2" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "ol_coll1,dcas_accounts"
     And "test" chaincode "ol_examplecc_2" is instantiated from path "in-process" on the "yourchannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "ol_coll1,dcas_accounts"


### PR DESCRIPTION
An expiry time of 0 indicates that the data should never be purged. The CouchDB query was modified to exclude those documents.

closes #373

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>