### PR TITLE
feat: Add 'implicit org' policy for off-ledger collections

### DIFF
--- a/pkg/collections/offledger/dissemination/localmspprovider.go
+++ b/pkg/collections/offledger/dissemination/localmspprovider.go
@@ -1,0 +1,32 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dissemination
+
+import (
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/common"
+)
+
+// LocalMSPProvider provides the local peer's MSP ID
+var LocalMSPProvider = &localMSPProvider{}
+
+type localMSPProvider struct {
+	identifierProvider common.IdentifierProvider
+}
+
+// Initialize initialized the local MSP provider with the identifier provider
+func (p *localMSPProvider) Initialize(provider common.IdentifierProvider) *localMSPProvider {
+	logger.Infof("Initializing local MSP provider")
+
+	p.identifierProvider = provider
+
+	return p
+}
+
+// LocalMSP returns the MSP of the local peer
+func (p *localMSPProvider) LocalMSP() (string, error) {
+	return p.identifierProvider.GetIdentifier()
+}

--- a/pkg/collections/offledger/dissemination/localmspprovider_test.go
+++ b/pkg/collections/offledger/dissemination/localmspprovider_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dissemination
+
+import (
+	"testing"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+func TestLocalMSPProvider(t *testing.T) {
+	ip := &mocks.IdentifierProvider{}
+
+	LocalMSPProvider.Initialize(ip)
+}

--- a/pkg/collections/offledger/storeprovider/olstore.go
+++ b/pkg/collections/offledger/storeprovider/olstore.go
@@ -21,6 +21,7 @@ import (
 	collcommon "github.com/trustbloc/fabric-peer-ext/pkg/collections/common"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/api"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/storeprovider/store/cache"
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/implicitpolicy"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config"
 )
 
@@ -361,7 +362,12 @@ func (s *store) loadPolicy(ns string, config *pb.StaticCollectionConfig) (privda
 		return nil, errors.Wrapf(err, "error setting up collection policy %s", config.Name)
 	}
 
-	return colAP, nil
+	localMSP, err := s.identifierProvider.GetIdentifier()
+	if err != nil {
+		return nil, errors.WithMessagef(err, "unable to get local MSP ID")
+	}
+
+	return implicitpolicy.NewResolver(localMSP, colAP), nil
 }
 
 func (s *store) getExpirationTime(config *pb.StaticCollectionConfig) (time.Time, error) {

--- a/pkg/common/implicitpolicy/implicitcollpolicy.go
+++ b/pkg/common/implicitpolicy/implicitcollpolicy.go
@@ -1,0 +1,49 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package implicitpolicy
+
+import (
+	"github.com/hyperledger/fabric/core/common/privdata"
+)
+
+const (
+	// ImplicitOrg is used in the collection policy to indicate that the
+	// collection policy is for the local peer's MSP
+	ImplicitOrg = "IMPLICIT-ORG"
+)
+
+// Resolver wraps a collection policy and resolves any occurrence of 'IMPLICIT-ORG' to the local MSP
+type Resolver struct {
+	privdata.CollectionAccessPolicy
+	localMSP string
+}
+
+// NewResolver returns a new implicit collection policy resolver
+func NewResolver(localMSP string, policy privdata.CollectionAccessPolicy) *Resolver {
+	return &Resolver{
+		localMSP:               localMSP,
+		CollectionAccessPolicy: policy,
+	}
+}
+
+// MemberOrgs returns the collection's members as MSP IDs. If any of the orgs is set to 'IMPLICIT-ORG' then it
+// is replaced with the ID of the local MSP.
+func (p *Resolver) MemberOrgs() []string {
+	memberOrgs := p.CollectionAccessPolicy.MemberOrgs()
+
+	orgs := make([]string, len(memberOrgs))
+
+	for i, org := range memberOrgs {
+		if org == ImplicitOrg {
+			org = p.localMSP
+		}
+
+		orgs[i] = org
+	}
+
+	return orgs
+}

--- a/pkg/common/implicitpolicy/implicitcollpolicy_test.go
+++ b/pkg/common/implicitpolicy/implicitcollpolicy_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package implicitpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+func TestResolver(t *testing.T) {
+	const org1 = "msp1"
+
+	policy := &mocks.MockAccessPolicy{
+		Orgs: []string{ImplicitOrg},
+	}
+
+	p := NewResolver(org1, policy)
+	require.NotNil(t, p)
+
+	orgs := p.MemberOrgs()
+	require.Len(t, orgs, 1)
+	require.Equal(t, org1, orgs[0])
+}

--- a/pkg/common/support/collconfigretriever_test.go
+++ b/pkg/common/support/collconfigretriever_test.go
@@ -44,9 +44,14 @@ func TestConfigRetriever(t *testing.T) {
 
 	qe := mocks.NewQueryExecutor().WithState(lscc, privdata.BuildCollectionKVSKey(ns1), configPkgBytes)
 
-	r := newCollectionConfigRetriever(channelID, &mocks.Ledger{
-		QueryExecutor: qe,
-	}, blockPublisher, &mocks.IdentityDeserializer{})
+	r := newCollectionConfigRetriever(
+		channelID, &mocks.Ledger{
+			QueryExecutor: qe,
+		},
+		blockPublisher,
+		&mocks.IdentityDeserializer{},
+		&mocks.IdentifierProvider{},
+	)
 	require.NotNil(t, r)
 
 	t.Run("Policy", func(t *testing.T) {
@@ -120,9 +125,15 @@ func TestConfigRetrieverError(t *testing.T) {
 	blockPublisher := mocks.NewBlockPublisher()
 
 	expectedErr := fmt.Errorf("injected error")
-	r := newCollectionConfigRetriever(channelID, &mocks.Ledger{
-		QueryExecutor: mocks.NewQueryExecutor().WithError(expectedErr),
-	}, blockPublisher, &mocks.IdentityDeserializer{})
+	r := newCollectionConfigRetriever(
+		channelID,
+		&mocks.Ledger{
+			QueryExecutor: mocks.NewQueryExecutor().WithError(expectedErr),
+		},
+		blockPublisher,
+		&mocks.IdentityDeserializer{},
+		&mocks.IdentifierProvider{},
+	)
 	require.NotNil(t, r)
 
 	t.Run("Policy", func(t *testing.T) {
@@ -156,6 +167,7 @@ func TestCollectionConfigRetrieverForChannel(t *testing.T) {
 		&mocks.LedgerProvider{},
 		mocks.NewBlockPublisherProvider(),
 		&mocks.IdentityDeserializerProvider{},
+		&mocks.IdentifierProvider{},
 	)
 	require.NotNil(t, p)
 

--- a/pkg/endorser/endorser_test.go
+++ b/pkg/endorser/endorser_test.go
@@ -80,7 +80,7 @@ func TestFilterPubSimulationResults(t *testing.T) {
 	lp.GetLedgerReturns(&mocks.Ledger{
 		QueryExecutor: newMockQueryExecutor(pvtBuilder.BuildCollectionConfigs()),
 	})
-	f := NewCollRWSetFilter().Initialize(support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}))
+	f := NewCollRWSetFilter().Initialize(support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}, &mocks.IdentifierProvider{}))
 
 	filteredResults, err := f.Filter(channelID, results)
 	assert.NoError(t, err)
@@ -114,7 +114,7 @@ func TestFilterPubSimulationResults_NoCollections(t *testing.T) {
 		QueryExecutor: newMockQueryExecutor(pvtBuilder.BuildCollectionConfigs()),
 	})
 
-	f := NewCollRWSetFilter().Initialize(support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}))
+	f := NewCollRWSetFilter().Initialize(support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}, &mocks.IdentifierProvider{}))
 	filteredResults, err := f.Filter(channelID, results)
 	assert.NoError(t, err)
 	assert.Equal(t, results, filteredResults)

--- a/pkg/gossip/dispatcher/dispatcher_test.go
+++ b/pkg/gossip/dispatcher/dispatcher_test.go
@@ -137,7 +137,7 @@ func TestDispatchDataRequest(t *testing.T) {
 
 	dispatcher := NewProvider().Initialize(
 		gossipProvider,
-		support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}),
+		support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}, &mocks.IdentifierProvider{}),
 	).ForChannel(
 		channelID,
 		mocks.NewDataStore().TransientData(key1, value1).TransientData(key2, value2).Data(key3, value3).Data(key4, value4),
@@ -358,7 +358,7 @@ func TestDispatchDataResponse(t *testing.T) {
 
 	dispatcher := NewProvider().Initialize(
 		gossipProvider,
-		support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}),
+		support.NewCollectionConfigRetrieverProvider(lp, mocks.NewBlockPublisherProvider(), &mocks.IdentityDeserializerProvider{}, &mocks.IdentifierProvider{}),
 	).ForChannel(
 		channelID,
 		mocks.NewDataStore().TransientData(key1, value1).TransientData(key2, value2),

--- a/pkg/peer/init.go
+++ b/pkg/peer/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/trustbloc/fabric-peer-ext/pkg/chaincode/ucc"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/client"
 	dcasclient "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas/client"
+	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dissemination"
 	extretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/retriever"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/storeprovider"
 	tretriever "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/retriever"
@@ -47,6 +48,7 @@ func registerResources() {
 	resource.Register(configvalidator.NewRegistry)
 	resource.Register(newConfig)
 	resource.Register(txn.NewProvider)
+	resource.Register(dissemination.LocalMSPProvider.Initialize)
 }
 
 func registerChaincodes() {

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -5,6 +5,8 @@
 module github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/peer/cmd
 
 require (
+	github.com/Microsoft/hcsshim v0.8.7 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/spf13/viper2015 v1.3.2


### PR DESCRIPTION
An implicit-org collection policy is defined as ORG('IMPLICIT-ORG.member'), which indicates that data for the collection are stored and distributed only within the peer's local org.

closes #377

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>