### PR TITLE
fix: Ignore unvalidated blocks from Gossip at non-committing peer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ module github.com/trustbloc/fabric-peer-ext
 require (
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
 	github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed
@@ -20,7 +21,7 @@ require (
 	go.uber.org/zap v1.10.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230 h1:E0vsdhxeKNkgw6c5PF5TPaYNpAuRjyhkzXQgGzmVkRo=
-github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
+github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50 h1:9RFVqWlVHlygbVY33iW0M6K4WupuR+tm/qnxIoNtZM8=
+github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -297,8 +297,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230 h1:E0vsdhxeKNkgw6c5PF5TPaYNpAuRjyhkzXQgGzmVkRo=
-github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
+github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50 h1:9RFVqWlVHlygbVY33iW0M6K4WupuR+tm/qnxIoNtZM8=
+github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/mod/peer/gossip/state/state_test.go
+++ b/mod/peer/gossip/state/state_test.go
@@ -9,25 +9,21 @@ package state
 import (
 	"testing"
 
-	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
-
-	"github.com/hyperledger/fabric/extensions/gossip/api"
-
-	"github.com/hyperledger/fabric/gossip/protoext"
-
-	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
-
-	"github.com/pkg/errors"
-
 	"github.com/hyperledger/fabric-protos-go/common"
 	proto "github.com/hyperledger/fabric-protos-go/gossip"
 	"github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/hyperledger/fabric/gossip/protoext"
 	"github.com/hyperledger/fabric/gossip/util"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric/extensions/gossip/api"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
 )
 
 func TestProviderExtension(t *testing.T) {
-
 	//all roles
 	rolesValue := make(map[roles.Role]struct{})
 	roles.SetRoles(rolesValue)
@@ -45,8 +41,12 @@ func TestProviderExtension(t *testing.T) {
 
 	extension := NewGossipStateProviderExtension("test", nil, &api.Support{}, false)
 
+	payload := &proto.Payload{
+		SeqNum: 1000,
+	}
+
 	//test extension.AddPayload
-	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(nil, false))
+	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(payload, false))
 
 	//test extension.StoreBlock
 	require.Error(t, sampleError, extension.StoreBlock(handleStoreBlock)(nil, util.PvtDataCollections{}))
@@ -116,11 +116,21 @@ func TestProviderByEndorser(t *testing.T) {
 		Ledger: &mockPeerLedger{&mocks.Ledger{}},
 	}, false)
 
+	payload := &proto.Payload{
+		SeqNum: 1000,
+	}
+
+	block := &common.Block{
+		Header: &common.BlockHeader{
+			Number: 1000,
+		},
+	}
+
 	//test extension.AddPayload
-	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(nil, false))
+	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(payload, false))
 
 	//test extension.StoreBlock
-	require.Nil(t, extension.StoreBlock(handleStoreBlock)(nil, util.PvtDataCollections{}))
+	require.Nil(t, extension.StoreBlock(handleStoreBlock)(block, util.PvtDataCollections{}))
 
 	//test extension.AntiEntropy
 	handled := make(chan bool, 1)
@@ -196,8 +206,12 @@ func TestProviderByCommitter(t *testing.T) {
 
 	extension := NewGossipStateProviderExtension("test", nil, &api.Support{}, false)
 
+	payload := &proto.Payload{
+		SeqNum: 1000,
+	}
+
 	//test extension.AddPayload
-	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(nil, false))
+	require.Error(t, sampleError, extension.AddPayload(handleAddPayload)(payload, false))
 
 	//test extension.StoreBlock
 	require.Error(t, sampleError, extension.StoreBlock(handleStoreBlock)(nil, util.PvtDataCollections{}))

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
+      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
       ## the following setting redirects chaincode container logs to the peer container logs
       - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
@@ -105,7 +105,7 @@ services:
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
+      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
       ## the following setting redirects chaincode container logs to the peer container logs
       - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
@@ -166,7 +166,7 @@ services:
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
+      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
       ## the following setting redirects chaincode container logs to the peer container logs
       - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP
@@ -225,7 +225,7 @@ services:
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:info
+      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
       ## the following setting redirects chaincode container logs to the peer container logs
       - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -6,13 +6,14 @@ module github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/peer/c
 
 require (
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/spf13/viper2015 v1.3.2
 	github.com/trustbloc/fabric-peer-ext v0.0.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50
 
 replace github.com/hyperledger/fabric/extensions => ../../../../../../mod/peer
 

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.sum
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.sum
@@ -309,8 +309,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230 h1:E0vsdhxeKNkgw6c5PF5TPaYNpAuRjyhkzXQgGzmVkRo=
-github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
+github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50 h1:9RFVqWlVHlygbVY33iW0M6K4WupuR+tm/qnxIoNtZM8=
+github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=


### PR DESCRIPTION
When a non-committing peer receives an unvalidated block, it is ignored before it is added to the payload buffer. Otherwise a mismatch results between the peer's current block number and the payload buffer's sequence number, and subsequent blocks are rejected.

closes #388

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>