### PR TITLE
feat: Add Cause to visitorError

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ module github.com/trustbloc/fabric-peer-ext
 require (
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
 	github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/pkg/common/blockvisitor/blockvisitor.go
+++ b/pkg/common/blockvisitor/blockvisitor.go
@@ -698,6 +698,10 @@ func (e visitorError) Error() string {
 	return e.cause.Error()
 }
 
+func (e visitorError) Cause() error {
+	return e.cause
+}
+
 // haltOnError returns true if the error was handled by an error handler
 // and processing should halt because of the error
 func haltOnError(err error) bool {

--- a/pkg/common/blockvisitor/blockvisitor_test.go
+++ b/pkg/common/blockvisitor/blockvisitor_test.go
@@ -686,3 +686,10 @@ func mockBlockWithTransactions(t *testing.T) *cb.Block {
 
 	return b.Build()
 }
+
+func TestVisitorError_Cause(t *testing.T) {
+	cause := errors.New("cause of the error")
+	err := newVisitorError(cause)
+	require.NotNil(t, err)
+	require.Equal(t, cause, errors.Cause(err))
+}


### PR DESCRIPTION
Added a Cause() function to visitorError so that a client can use errors.Cause() to extract the cause of the error.

closes #391

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>