### PR TITLE
feat: Retry off-ledger data retrieval

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ const (
 	confOLCollLeveldb              = "offLedgerLeveldb"
 	confOLCollCleanupIntervalTime  = "coll.offledger.cleanupExpired.Interval"
 	confOLCollMaxPeersForRetrieval = "coll.offledger.maxpeers"
+	confOLCollMaxRetrievalAttempts = "coll.offledger.maxRetrievalAttempts"
 	confOLCollCacheEnabled         = "coll.offledger.cache.enable"
 	confOLCollCacheSize            = "coll.offledger.cache.size"
 	confOLCollPullTimeout          = "coll.offledger.gossip.pullTimeout"
@@ -42,6 +43,7 @@ const (
 
 	defaultOLCollCleanupIntervalTime  = 5 * time.Second
 	defaultOLCollMaxPeersForRetrieval = 2
+	defaultOLCollMaxRetrievalAttempts = 3
 	defaultOLCollCacheSize            = 10000
 	defaultOLCollPullTimeout          = 5 * time.Second
 
@@ -118,12 +120,24 @@ func GetBlockPublisherBufferSize() int {
 	return size
 }
 
-// GetOLCollMaxPeersForRetrieval returns the number of peers that should be messaged
+// GetOLCollMaxPeersForRetrieval returns the number of peers that should be concurrently messaged
 // to retrieve collection data that is not stored locally.
 func GetOLCollMaxPeersForRetrieval() int {
 	maxPeers := viper.GetInt(confOLCollMaxPeersForRetrieval)
 	if maxPeers <= 0 {
 		maxPeers = defaultOLCollMaxPeersForRetrieval
+	}
+	return maxPeers
+}
+
+// GetOLCollMaxRetrievalAttempts returns the maximum number of attempts to retrieve collection data from remote
+// peers. On each attempt, multiple peers are messaged (up to a maximum number given by confOLCollMaxPeersForRetrieval).
+// If not all data is retrieved on an attempt, then a new set of peers is chosen. This process continues
+// until MaxRetrievalAttempts is reached or no more peers are left (that haven't already been attempted).
+func GetOLCollMaxRetrievalAttempts() int {
+	maxPeers := viper.GetInt(confOLCollMaxRetrievalAttempts)
+	if maxPeers <= 0 {
+		maxPeers = defaultOLCollMaxRetrievalAttempts
 	}
 	return maxPeers
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -144,6 +144,17 @@ func TestGetOLCollMaxPeersForRetrieval(t *testing.T) {
 	assert.Equal(t, 7, GetOLCollMaxPeersForRetrieval())
 }
 
+func TestGetOLCollMaxRetrievalAttempts(t *testing.T) {
+	oldVal := viper.Get(confOLCollMaxRetrievalAttempts)
+	defer viper.Set(confOLCollMaxRetrievalAttempts, oldVal)
+
+	viper.Set(confOLCollMaxRetrievalAttempts, "")
+	assert.Equal(t, defaultOLCollMaxRetrievalAttempts, GetOLCollMaxRetrievalAttempts())
+
+	viper.Set(confOLCollMaxRetrievalAttempts, 7)
+	assert.Equal(t, 7, GetOLCollMaxRetrievalAttempts())
+}
+
 func TestGetOLCollPullTimeout(t *testing.T) {
 	oldVal := viper.Get(confOLCollPullTimeout)
 	defer viper.Set(confOLCollPullTimeout, oldVal)

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -80,6 +80,11 @@ func IsValidator() bool {
 	return HasRole(ValidatorRole)
 }
 
+// IsClustered returns true if we're running in clustered mode
+func IsClustered() bool {
+	return (IsCommitter() && !IsEndorser()) || (IsEndorser() && !IsCommitter())
+}
+
 // GetRoles returns the roles for the peer
 func GetRoles() []Role {
 	var ret []Role

--- a/pkg/roles/roles_test.go
+++ b/pkg/roles/roles_test.go
@@ -58,6 +58,7 @@ func TestLocalRoles(t *testing.T) {
 	require.True(t, IsEndorser())
 	require.True(t, IsValidator())
 	require.False(t, HasRole("newRole"))
+	require.False(t, IsClustered())
 
 	testRole = "committer,endorser,validator"
 	viper.Set(confRoles, testRole)
@@ -67,6 +68,7 @@ func TestLocalRoles(t *testing.T) {
 	require.True(t, IsValidator())
 	require.Equal(t, len(GetRoles()), 3)
 	require.Equal(t, len(AsString()), 3)
+	require.False(t, IsClustered())
 
 	testRole = "CoMMiTTER,  ENDORSER,   validator"
 	viper.Set(confRoles, testRole)
@@ -74,6 +76,7 @@ func TestLocalRoles(t *testing.T) {
 	require.True(t, IsCommitter())
 	require.True(t, IsEndorser())
 	require.True(t, IsValidator())
+	require.False(t, IsClustered())
 
 	testRole = "committer,endorser"
 	viper.Set(confRoles, testRole)
@@ -81,5 +84,13 @@ func TestLocalRoles(t *testing.T) {
 	require.True(t, IsCommitter())
 	require.True(t, IsEndorser())
 	require.False(t, IsValidator())
+	require.False(t, IsClustered())
 
+	testRole = "endorser"
+	viper.Set(confRoles, testRole)
+	roles = initRoles()
+	require.False(t, IsCommitter())
+	require.True(t, IsEndorser())
+	require.False(t, IsValidator())
+	require.True(t, IsClustered())
 }

--- a/test/bddtests/fixtures/docker-compose-base.yml
+++ b/test/bddtests/fixtures/docker-compose-base.yml
@@ -1,0 +1,51 @@
+#
+# Copyright IBM Corp, SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+version: '2'
+
+services:
+  peer:
+    image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
+    environment:
+      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:ext_offledger=debug:info
+      ## the following setting redirects chaincode container logs to the peer container logs
+      - CORE_VM_DOCKER_ATTACHSTDOUT=true
+      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
+      - CORE_PEER_TLS_ENABLED=true
+      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
+      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
+      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
+      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
+      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
+      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
+      # override chaincode images
+      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:latest
+      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
+      # metrics config
+      - CORE_METRICS_PROVIDER=prometheus
+      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
+      # # the following setting starts chaincode containers on the same
+      # # bridge network as the peers
+      # # https://docs.docker.com/compose/networking/
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
+      # CouchDB Settings
+      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
+      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
+      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
+      # All peers in both orgs share the same CouchDB instance. The database names are prefixed by the MSP ID to avoid collisions.
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb.com:5984
+      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=MSP
+      - CORE_PEER_GOSSIP_USELEADERELECTION=false
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    tty: true
+    volumes:
+        - /var/run/:/host/var/run/
+        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
+        - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
+        - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -40,240 +40,90 @@ services:
         - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/ca.crt:/etc/hyperledger/mutual_tls/orderer/ca.crt
 
   peer0.org1.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer0.org1.example.com
-    image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:latest
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      # All peers in both orgs share the same CouchDB instance. The database names are prefixed by the MSP ID to avoid collisions.
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb.com:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=MSP
       - CORE_LEDGER_ROLES=committer
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
       - CORE_PEER_GOSSIP_ORGLEADER=true
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 7051:7051
     volumes:
-        - /var/run/:/host/var/run/
         - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
         - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
-        # Give Snap the orderer CA
-        - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-        - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-        - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
       - shared.couchdb.com
 
   peer1.org1.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer1.org1.example.com
-    image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer1.org1.example.com:7051
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org1.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer1.org1.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:latest
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      # All peers in both orgs share the same CouchDB instance. The database names are prefixed by the MSP ID to avoid collisions.
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb.com:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=MSP
       - CORE_LEDGER_ROLES=endorser
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
       - CORE_PEER_GOSSIP_ORGLEADER=false
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 7151:7051
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls:/etc/hyperledger/fabric/tls
-      # Give Snap the orderer CA
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
       - shared.couchdb.com
 
   peer0.org2.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer0.org2.example.com
-    image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer0.org2.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org2.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:latest
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      # All peers in both orgs share the same CouchDB instance. The database names are prefixed by the MSP ID to avoid collisions.
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb.com:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=MSP
       - CORE_LEDGER_ROLES=committer
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
       - CORE_PEER_GOSSIP_ORGLEADER=true
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 8051:7051
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls:/etc/hyperledger/fabric/tls
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
       - shared.couchdb.com
 
   peer1.org2.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer1.org2.example.com
-    image: ${TRUSTBLOCK_NS}/${FABRIC_PEER_EXT_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:ext_gossip=debug:ext_blockvisitor=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer1.org2.example.com:7051
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org2.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer1.org2.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:latest
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      # All peers in both orgs share the same CouchDB instance. The database names are prefixed by the MSP ID to avoid collisions.
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb.com:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=MSP
       - CORE_LEDGER_ROLES=endorser
-      - CORE_PEER_GOSSIP_USELEADERELECTION=false
       - CORE_PEER_GOSSIP_ORGLEADER=false
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
     ports:
       - 8151:7051
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls:/etc/hyperledger/fabric/tls
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com


### PR DESCRIPTION
If a peer does not have the off-ledger data stored locally then multiple sets of peers are asked for the data until a configurable maximum number of attempts is reached or no more peers are left (that haven't already been attempted).

The peer selection algorithm has also been optimized in the case of clustered peer configuration. If the peers are clustered then only peers in other orgs are asked for the data (since all peers in the same org share the same database).

closes #396

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>