### PR TITLE
feat: Allow non-committing peers to persist off-ledger data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ module github.com/trustbloc/fabric-peer-ext
 require (
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
 	github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -15,6 +15,7 @@ replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-p
 replace github.com/spf13/viper2015 => github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
 
 require (
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/pkg/collections/offledger/dissemination/disseminator.go
+++ b/pkg/collections/offledger/dissemination/disseminator.go
@@ -43,16 +43,15 @@ func (d *Disseminator) resolvePeersForDissemination() discovery.PeerGroup {
 
 	logger.Debugf("[%s] MaximumPeerCount: %d, RequiredPeerCount: %d, Member orgs: %s", d.ChannelID(), maxPeerCount, d.policy.RequiredPeerCount(), orgs)
 
-	var committers discovery.PeerGroup
+	if maxPeerCount == 0 {
+		logger.Debugf("[%s] MaximumPeerCount is 0. No need to disseminate.", d.ChannelID())
 
-	logger.Debugf("maxPeerCount: %d, Roles: %s", maxPeerCount, d.Self().Roles())
-	if maxPeerCount == 0 && !d.Self().HasRole(roles.CommitterRole) {
-		logger.Debugf("[%s] MaximumPeerCount is 0 and I am not a committer. Getting a random peer for dissemination from orgs %s", d.ChannelID(), orgs)
-		committers = getRandomPeers(d.getPeersWithRole(roles.CommitterRole, orgs).Remote(), 1)
-	} else {
-		logger.Debugf("[%s] Getting %d random peer(s) with the 'committer' role for dissemination from orgs %s", d.ChannelID(), maxPeerCount, orgs)
-		committers = getRandomPeers(d.getPeersWithRole(roles.CommitterRole, orgs).Remote(), maxPeerCount)
+		return nil
 	}
+
+	logger.Debugf("[%s] Getting %d random peer(s) with the 'committer' role for dissemination from orgs %s", d.ChannelID(), maxPeerCount, orgs)
+
+	committers := getRandomPeers(d.getPeersWithRole(roles.CommitterRole, orgs).Remote(), maxPeerCount)
 
 	if len(committers) < maxPeerCount {
 		logger.Debugf("[%s] MaximumPeerCount in collection policy is %d and we only have %d peer(s) with the 'committer' role. Adding some endorsers too...", d.ChannelID(), maxPeerCount, len(committers))

--- a/pkg/collections/offledger/dissemination/disseminator_test.go
+++ b/pkg/collections/offledger/dissemination/disseminator_test.go
@@ -114,6 +114,26 @@ func TestDisseminator_ResolvePeersForDissemination(t *testing.T) {
 		assert.Equal(t, 3, numCommitters)
 	})
 
+	t.Run("More than enough committers", func(t *testing.T) {
+		d := New(channelID, ns1, coll1,
+			&mocks.MockAccessPolicy{
+				ReqPeerCount: 1,
+				MaxPeerCount: 3,
+				Orgs:         []string{org1MSPID, org2MSPID, org3MSPID, org4MSPID},
+			}, gossip)
+
+		peers := d.resolvePeersForDissemination()
+		require.Equal(t, 3, len(peers))
+
+		var numCommitters int
+		for _, p := range peers {
+			if p.HasRole(roles.CommitterRole) {
+				numCommitters++
+			}
+		}
+		assert.Equal(t, 3, numCommitters)
+	})
+
 	t.Run("Not enough committers", func(t *testing.T) {
 		d := New(channelID, ns1, coll1,
 			&mocks.MockAccessPolicy{
@@ -170,7 +190,7 @@ func TestDisseminator_ResolvePeersForDissemination(t *testing.T) {
 			}, gossip)
 
 		peers := d.resolvePeersForDissemination()
-		require.Equal(t, 1, len(peers))
+		require.Empty(t, peers)
 	})
 }
 

--- a/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore.go
+++ b/pkg/collections/offledger/storeprovider/store/couchdbstore/dbstore.go
@@ -75,6 +75,8 @@ func (s *dbstore) Put(keyVal ...*api.KeyValue) error {
 		return errors.WithMessage(err, fmt.Sprintf("BatchUpdateDocuments failed for [%d] documents", len(docs)))
 	}
 
+	logger.Debugf("[%s] Successfully persisted %d documents", s.dbName, len(docs))
+
 	return nil
 }
 

--- a/pkg/collections/storeprovider/store.go
+++ b/pkg/collections/storeprovider/store.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	olapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/api"
 	tdapi "github.com/trustbloc/fabric-peer-ext/pkg/collections/transientdata/api"
-	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
 )
 
 type targetStores struct {
@@ -39,11 +38,8 @@ func (d *store) Persist(txID string, privateSimulationResultsWithConfig *proto.T
 		return errors.WithMessage(err, "error persisting transient data")
 	}
 
-	// Off-ledger data should only be persisted on committers
-	if isCommitter() {
-		if err := d.offLedgerStore.Persist(txID, privateSimulationResultsWithConfig); err != nil {
-			return errors.WithMessage(err, "error persisting off-ledger data")
-		}
+	if err := d.offLedgerStore.Persist(txID, privateSimulationResultsWithConfig); err != nil {
+		return errors.WithMessage(err, "error persisting off-ledger data")
 	}
 
 	return nil
@@ -83,9 +79,4 @@ func (d *store) Query(key *storeapi.QueryKey) (storeapi.ResultsIterator, error) 
 func (d *store) Close() {
 	d.transientDataStore.Close()
 	d.offLedgerStore.Close()
-}
-
-// isCommitter may be overridden in unit tests
-var isCommitter = func() bool {
-	return roles.IsCommitter()
 }

--- a/pkg/collections/storeprovider/storeprovider_test.go
+++ b/pkg/collections/storeprovider/storeprovider_test.go
@@ -120,8 +120,6 @@ func TestStore_PutAndGetData(t *testing.T) {
 	})
 
 	t.Run("Persist", func(t *testing.T) {
-		isCommitter = func() bool { return true }
-
 		err := s.Persist(tx1, mocks.NewPvtReadWriteSetBuilder().Build())
 		assert.NoError(t, err)
 

--- a/test/bddtests/features/off_ledger.feature
+++ b/test/bddtests/features/off_ledger.feature
@@ -159,8 +159,8 @@ Feature: off-ledger
 
   @off_ledger_s3
   Scenario: Test for off-ledger collections with implicit policy, i.e. data is stored and distributed only within the peer's local org.
-    When client queries chaincode "ol_examplecc" with args "putprivate,implicitcoll,key1,org1value" on a single peer in the "peerorg1" org on the "mychannel" channel
-    And client queries chaincode "ol_examplecc" with args "putprivate,implicitcoll,key1,org2value" on a single peer in the "peerorg2" org on the "mychannel" channel
+    When client queries chaincode "ol_examplecc" with args "putprivate,implicitcoll,key1,org1value" on peers "peer1.org1.example.com" on the "mychannel" channel
+    And client queries chaincode "ol_examplecc" with args "putprivate,implicitcoll,key1,org2value" on peers "peer1.org2.example.com" on the "mychannel" channel
 
     When client queries chaincode "ol_examplecc" with args "getprivate,implicitcoll,key1" on peers "peer0.org1.example.com,peer1.org1.example.com" on the "mychannel" channel
     Then response from "ol_examplecc" to client equal value "org1value"


### PR DESCRIPTION
In the special case where the collection policy specifies 0 for MaximumPeers, the data is not disseminated to a committing peer, but the data is persisted directly by the non-committing peer.

closes #399

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>