### PR TITLE
feat: Added CommitEndorsements to Txn service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/willf/bitset v1.1.10
 	go.uber.org/zap v1.10.0
+	google.golang.org/grpc v1.24.0
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -15,7 +15,6 @@ replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-p
 replace github.com/spf13/viper2015 => github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
 
 require (
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/pkg/txn/api/api.go
+++ b/pkg/txn/api/api.go
@@ -9,10 +9,11 @@ package api
 import (
 	"errors"
 
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
 	"github.com/hyperledger/fabric-sdk-go/pkg/common/providers/fab"
 )
 
-// Request contains the data required for endorsments
+// Request contains the data required for endorsements
 type Request struct {
 	// ChaincodeID identifies the chaincode to invoke
 	ChaincodeID string
@@ -50,6 +51,18 @@ type Request struct {
 
 	//Nonce nonce
 	Nonce []byte
+}
+
+// CommitRequest contains the endorsements to be committed along with options
+type CommitRequest struct {
+	// EndorsementResponse is the response received from an endorsement request
+	EndorsementResponse *channel.Response
+
+	// CommitType specifies how commits should be handled (default CommitOnWrite)
+	CommitType CommitType
+
+	// IgnoreNameSpaces ignore these namespaces in the write set when CommitType is CommitOnWrite
+	IgnoreNameSpaces []Namespace
 }
 
 // ChaincodeCall ...

--- a/pkg/txn/api/service.go
+++ b/pkg/txn/api/service.go
@@ -19,6 +19,10 @@ type Service interface {
 	// Returns the response and true if the transaction was committed.
 	EndorseAndCommit(req *Request) (resp *channel.Response, committed bool, err error)
 
+	// CommitEndorsements commits the provided endorsements. First the endorsements are verified for signature and policy,
+	// and then the endorsements are sent to the Orderer.
+	CommitEndorsements(req *CommitRequest) (*channel.Response, bool, error)
+
 	// SigningIdentity returns the serialized identity of the proposal signer
 	SigningIdentity() ([]byte, error)
 }

--- a/pkg/txn/handler/checkforcommit.go
+++ b/pkg/txn/handler/checkforcommit.go
@@ -20,8 +20,8 @@ import (
 var logger = flogging.MustGetLogger("ext_txn")
 
 //NewCheckForCommitHandler returns a handler that check if there is need to commit
-func NewCheckForCommitHandler(rwSetIgnoreNameSpace []api.Namespace, commitType api.CommitType, next ...invoke.Handler) *CheckForCommitHandler {
-	return newCheckForCommitHandler(rwSetIgnoreNameSpace, commitType, proto.Unmarshal, next...)
+func NewCheckForCommitHandler(ignoreNameSpaces []api.Namespace, commitType api.CommitType, next ...invoke.Handler) *CheckForCommitHandler {
+	return newCheckForCommitHandler(ignoreNameSpaces, commitType, proto.Unmarshal, next...)
 }
 
 func newCheckForCommitHandler(rwSetIgnoreNameSpace []api.Namespace, commitType api.CommitType, protoUnmarshal func(buf []byte, pb proto.Message) error, next ...invoke.Handler) *CheckForCommitHandler {

--- a/pkg/txn/handler/preendorsed.go
+++ b/pkg/txn/handler/preendorsed.go
@@ -1,0 +1,41 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package handler
+
+import (
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel/invoke"
+)
+
+// NewPreEndorsedHandler returns a handler that populates the Endorsement Response to the request context
+func NewPreEndorsedHandler(endorsementResponse *channel.Response, next ...invoke.Handler) *PreEndorsedHandler {
+	return &PreEndorsedHandler{endorsementResponse: endorsementResponse, next: getNext(next)}
+}
+
+// PreEndorsedHandler holds the Endorsement response
+type PreEndorsedHandler struct {
+	next                invoke.Handler
+	endorsementResponse *channel.Response
+}
+
+// Handle for endorsing transactions
+func (i *PreEndorsedHandler) Handle(requestContext *invoke.RequestContext, clientContext *invoke.ClientContext) {
+	requestContext.Response = getResponse(i.endorsementResponse)
+	if i.next != nil {
+		i.next.Handle(requestContext, clientContext)
+	}
+}
+
+func getResponse(res *channel.Response) invoke.Response {
+	return invoke.Response{
+		ChaincodeStatus:  res.ChaincodeStatus,
+		TransactionID:    res.TransactionID,
+		Responses:        res.Responses,
+		TxValidationCode: res.TxValidationCode,
+		Proposal:         res.Proposal,
+	}
+}

--- a/pkg/txn/handler/preendorsed_test.go
+++ b/pkg/txn/handler/preendorsed_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel"
+	"github.com/hyperledger/fabric-sdk-go/pkg/client/channel/invoke"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/txn/handler/mocks"
+)
+
+func TestPreEndorsedHandler(t *testing.T) {
+	resp := &channel.Response{}
+	reqCtx := &invoke.RequestContext{
+		Request:  invoke.Request{},
+		Opts:     invoke.Opts{},
+		Response: invoke.Response{},
+	}
+
+	clientCtx := &invoke.ClientContext{}
+
+	t.Run("No next handler", func(t *testing.T) {
+		h := NewPreEndorsedHandler(resp)
+		require.NotNil(t, h)
+
+		h.Handle(reqCtx, clientCtx)
+	})
+
+	t.Run("With next handler", func(t *testing.T) {
+		h := NewPreEndorsedHandler(resp, &mocks.InvokeHandler{})
+		require.NotNil(t, h)
+
+		h.Handle(reqCtx, clientCtx)
+	})
+}

--- a/pkg/txn/service_test.go
+++ b/pkg/txn/service_test.go
@@ -194,6 +194,15 @@ func TestClient(t *testing.T) {
 		require.Nil(t, resp)
 	})
 
+	t.Run("CommitEndorsements -> success", func(t *testing.T) {
+		req := &api.CommitRequest{}
+
+		cliReturned.InvokeHandlerReturns(channel.Response{}, nil)
+		resp, _, err := s.CommitEndorsements(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
 	t.Run("SigningIdentity -> success", func(t *testing.T) {
 		identity := []byte("identity")
 		cliReturned.InvokeHandlerReturns(channel.Response{}, nil)

--- a/test/bddtests/features/step_definitions/txn_steps.js
+++ b/test/bddtests/features/step_definitions/txn_steps.js
@@ -19,4 +19,7 @@ defineSupportCode(function ({And, But, Given, Then, When}) {
     And(/^variable "([^"]*)" is assigned the base64 URL-encoded value "([^"]*)"$/, function (arg1, arg2, callback) {
         callback.pending();
     });
+    And(/^the endorsement response is saved to variable "([^"]*)"$/, function (arg1, callback) {
+        callback.pending();
+    });
 });

--- a/test/bddtests/features/txn.feature
+++ b/test/bddtests/features/txn.feature
@@ -152,6 +152,22 @@ Feature: txn
     And txn service is invoked on channel "mychannel" with chaincode "e2e_cc" with args "endorse,${endorseRequest}" on peers "peer1.org2.example.com"
     Then the JSON path "Payload" of the response equals "valueX"
 
+    # CommitEndorsements
+    Given variable "endorseRequest" is assigned the JSON value '{"cc_id":"target_cc","args":["put","key1002","value1002"]}'
+    When txn service is invoked on channel "mychannel" with chaincode "e2e_cc" with args "endorse,${endorseRequest}" on peers "peer1.org2.example.com"
+    Then the JSON path "Committed" of the boolean response equals "false"
+    And the JSON path "EndorsementResponse" of the response is saved to variable "endorsementResponse"
+
+    Given variable "commitRequest" is assigned the JSON value '{"endorsement_response":"${endorsementResponse}"}'
+    When txn service is invoked on channel "mychannel" with chaincode "e2e_cc" with args "commit,${commitRequest}" on peers "peer1.org2.example.com"
+    Then the JSON path "Committed" of the boolean response equals "true"
+
+    And we wait 5 seconds
+
+    Given variable "endorseRequest" is assigned the JSON value '{"cc_id":"target_cc","args":["get","key1002"]}'
+    And txn service is invoked on channel "mychannel" with chaincode "e2e_cc" with args "endorse,${endorseRequest}" on peers "peer1.org2.example.com"
+    Then the JSON path "Payload" of the response equals "value1002"
+
   @txn_s2
   Scenario: Configuration validation errors
     Given variable "org1ConfigUpdateInvalidTxn" is assigned config from file "./fixtures/config/fabric/org1-config-invalid-txn.json"

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -6,7 +6,6 @@ module github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/peer/c
 
 require (
 	github.com/Microsoft/hcsshim v0.8.9 // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/prometheus/procfs v0.0.5 // indirect

--- a/test/bddtests/txn_steps.go
+++ b/test/bddtests/txn_steps.go
@@ -183,11 +183,6 @@ func computeTxnID(creator, nonce []byte) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-type creatorResponse struct {
-	// Identity is the base64-raw-URL-encoded identity of the peer
-	Identity string `json:"identity,omitempty"`
-}
-
 // RegisterSteps registers off-ledger steps
 func (d *TxnSteps) RegisterSteps(s *godog.Suite) {
 	s.BeforeScenario(d.BDDContext.BeforeScenario)


### PR DESCRIPTION
The CommitEndorsements function accepts a set of signed endorsements from the client and sends the endorsements to the orderer.

closes #407

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>