### PR TITLE
feat: Added configurable, retryable chaincode error codes

### DIFF
--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -15,6 +15,7 @@ replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-p
 replace github.com/spf13/viper2015 => github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
 
 require (
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/pkg/txn/service.go
+++ b/pkg/txn/service.go
@@ -280,6 +280,7 @@ type txnConfig struct {
 	InitialBackoff string
 	MaxBackoff     string
 	BackoffFactor  float64
+	RetryableCodes []int
 }
 
 func (s *Service) client() channelClient {
@@ -405,12 +406,21 @@ func newRetryOpts(cfg *txnConfig) retry.Opts {
 		factor = retry.DefaultBackoffFactor
 	}
 
+	retryableCodes := make(map[status.Group][]status.Code)
+	for key, value := range retry.ChannelClientRetryableCodes {
+		retryableCodes[key] = value
+	}
+
+	for _, code := range cfg.RetryableCodes {
+		retryableCodes[status.ChaincodeStatus] = append(retryableCodes[status.ChaincodeStatus], status.Code(code))
+	}
+
 	return retry.Opts{
 		Attempts:       attempts,
 		InitialBackoff: initialBackoff,
 		MaxBackoff:     maxBackoff,
 		BackoffFactor:  factor,
-		RetryableCodes: retry.ChannelClientRetryableCodes,
+		RetryableCodes: retryableCodes,
 	}
 }
 

--- a/test/bddtests/fixtures/config/fabric/txn-config.json
+++ b/test/bddtests/fixtures/config/fabric/txn-config.json
@@ -3,5 +3,6 @@
   "RetryAttempts":  3,
   "InitialBackoff": "500ms",
   "MaxBackoff":     "1s",
-  "BackoffFactor":  1.5
+  "BackoffFactor":  1.5,
+  "RetryableCodes": [404]
 }

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -6,6 +6,7 @@ module github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/peer/c
 
 require (
 	github.com/Microsoft/hcsshim v0.8.9 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/prometheus/procfs v0.0.5 // indirect


### PR DESCRIPTION
The Txn config now has an array of retryable chaincode error codes.

closes #416

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>