### PR TITLE
fix: Support Invoke and ChannelJoined for system chaincode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,10 @@
 module github.com/trustbloc/fabric-peer-ext
 
 require (
+	github.com/Microsoft/hcsshim v0.8.9 // indirect
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
 	github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
@@ -22,7 +24,7 @@ require (
 	google.golang.org/grpc v1.24.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039 h1:55vVUODSuZpvXtrsJgPT/nYZAgZgulSzQ26SSk2M/NE=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039/go.mod h1:+8srdHdWnsQtfulc0TPTXxfCALR2StVv67sAlIftgG4=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973 h1:udrZyLIpyfDrh2aFnHoCfK149LrSerRAqnQqNaocDIo=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973/go.mod h1:+8srdHdWnsQtfulc0TPTXxfCALR2StVv67sAlIftgG4=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973
 
 replace github.com/hyperledger/fabric/extensions => ./
 
@@ -15,6 +15,8 @@ replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-p
 replace github.com/spf13/viper2015 => github.com/spf13/viper v0.0.0-20150908122457-1967d93db724
 
 require (
+	github.com/Microsoft/hcsshim v0.8.9 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -295,8 +295,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039 h1:55vVUODSuZpvXtrsJgPT/nYZAgZgulSzQ26SSk2M/NE=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039/go.mod h1:+8srdHdWnsQtfulc0TPTXxfCALR2StVv67sAlIftgG4=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973 h1:udrZyLIpyfDrh2aFnHoCfK149LrSerRAqnQqNaocDIo=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973/go.mod h1:+8srdHdWnsQtfulc0TPTXxfCALR2StVv67sAlIftgG4=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/pkg/chaincode/scc/scc.go
+++ b/pkg/chaincode/scc/scc.go
@@ -7,35 +7,123 @@ SPDX-License-Identifier: Apache-2.0
 package scc
 
 import (
+	"sync"
+
+	"github.com/hyperledger/fabric/common/flogging"
 	"github.com/hyperledger/fabric/core/scc"
+	"github.com/pkg/errors"
 
 	"github.com/trustbloc/fabric-peer-ext/pkg/common/injectinvoker"
 	"github.com/trustbloc/fabric-peer-ext/pkg/resource"
 )
 
-var sccBuilder = injectinvoker.NewBuilder()
+var logger = flogging.MustGetLogger("ext_scc")
 
-type creator interface{}
-
-// Register registers a System Chaincode creator function. The system chaincode
-// will be initialized during peer startup with all of its declared dependencies.
-func Register(c creator) {
-	sccBuilder.Add(c)
-}
+var instance = newRegistry()
 
 // Create returns a list of system chain codes, initialized with the given providers.
 func Create(providers ...interface{}) []scc.SelfDescribingSysCC {
-	// Merge the given providers with all of the registered resources
-	resources, err := sccBuilder.Build(append(providers, resource.Mgr.Resources()...)...)
+	instance.registerChaincodes(providers)
+
+	return instance.chaincodes()
+}
+
+// Registry maintains a registry of in-process system chaincode
+type Registry struct {
+	mutex    sync.RWMutex
+	creators []interface{}
+	registry map[string]scc.SelfDescribingSysCC
+}
+
+func newRegistry() *Registry {
+	r := &Registry{
+		registry: make(map[string]scc.SelfDescribingSysCC),
+	}
+	resource.Register(r.Initialize)
+	return r
+}
+
+// Register registers a System Chaincode creator function. The system chaincode
+// will be initialized during peer startup with all of its declared dependencies.
+func Register(ccCreator interface{}) {
+	instance.addCreator(ccCreator)
+}
+
+// Initialize is called on peer startup
+func (r *Registry) Initialize() *Registry {
+	logger.Info("Initializing in-process system chaincode registry")
+
+	return r
+}
+
+type channelListener interface {
+	ChannelJoined(channelID string)
+}
+
+// ChannelJoined is called when the peer joins a channel
+func (r *Registry) ChannelJoined(channelID string) {
+	logger.Infof("[%s] Channel joined", channelID)
+
+	for _, cc := range r.chaincodes() {
+		l, ok := cc.(channelListener)
+		if ok {
+			logger.Infof(" [%s] Notifying in-process system chaincode [%s] that channel was joined", channelID, cc.Name())
+
+			l.ChannelJoined(channelID)
+		}
+	}
+}
+
+func (r *Registry) registerChaincodes(providers []interface{}) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	b := injectinvoker.NewBuilder()
+	for _, c := range r.creators {
+		b.Add(c)
+	}
+
+	descs, err := b.Build(append(providers, resource.Mgr.Resources()...)...)
 	if err != nil {
-		panic(err.Error())
+		panic(err)
 	}
 
-	descs := make([]scc.SelfDescribingSysCC, len(resources))
+	logger.Infof("Registering [%d] in-process system chaincodes", len(descs))
 
-	for i, r := range resources {
-		descs[i] = r.(scc.SelfDescribingSysCC)
+	for _, desc := range descs {
+		err = r.register(desc.(scc.SelfDescribingSysCC))
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (r *Registry) addCreator(c interface{}) {
+	r.creators = append(r.creators, c)
+}
+
+func (r *Registry) register(cc scc.SelfDescribingSysCC) error {
+	logger.Infof("Registering in-process system chaincode [%s]", cc.Name())
+
+	_, exists := r.registry[cc.Name()]
+	if exists {
+		return errors.Errorf("system chaincode already registered: [%s]", cc.Name())
 	}
 
-	return descs
+	r.registry[cc.Name()] = cc
+
+	return nil
+}
+
+func (r *Registry) chaincodes() []scc.SelfDescribingSysCC {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	var ccs []scc.SelfDescribingSysCC
+
+	for _, cc := range r.registry {
+		ccs = append(ccs, cc)
+	}
+
+	return ccs
 }

--- a/pkg/chaincode/scc/scc_test.go
+++ b/pkg/chaincode/scc/scc_test.go
@@ -7,20 +7,25 @@ SPDX-License-Identifier: Apache-2.0
 package scc
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/fabric-peer-ext/pkg/common/injectinvoker"
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+)
+
+const (
+	channel1 = "channel1"
 )
 
 func TestCreateSCC(t *testing.T) {
 	t.Run("No dependencies -> Success", func(t *testing.T) {
-		sccBuilder = injectinvoker.NewBuilder()
+		instance = newRegistry()
 		Register(newSCCWithNoDependencies)
 
 		descs := Create()
@@ -28,15 +33,16 @@ func TestCreateSCC(t *testing.T) {
 	})
 
 	t.Run("Dependencies not satisfied -> panic", func(t *testing.T) {
-		sccBuilder = injectinvoker.NewBuilder()
+		instance = newRegistry()
 		Register(newSCCWithDependencies)
 
 		require.Panics(t, func() {
 			Create()
 		})
 	})
+
 	t.Run("Dependencies satisfied -> Success", func(t *testing.T) {
-		sccBuilder = injectinvoker.NewBuilder()
+		instance = newRegistry()
 		Register(newSCCWithDependencies)
 
 		descs := Create(mocks.NewQueryExecutorProvider())
@@ -44,11 +50,34 @@ func TestCreateSCC(t *testing.T) {
 	})
 }
 
+func TestRegistry(t *testing.T) {
+	t.Run("No dependencies -> Success", func(t *testing.T) {
+		r := newRegistry()
+
+		cc := newSCCWithNoDependencies()
+		require.NoError(t, r.register(cc))
+		require.EqualError(t, r.register(cc), "system chaincode already registered: [testscc]")
+
+		require.True(t, r == r.Initialize())
+		r.ChannelJoined(channel1)
+
+		time.Sleep(100 * time.Millisecond)
+
+		channels := cc.joinedChannels()
+		require.Len(t, channels, 1)
+		require.Equal(t, channel1, channels[0])
+	})
+}
+
 type testSCC struct {
+	mutex    sync.Mutex
+	channels map[string]struct{}
 }
 
 func newSCCWithNoDependencies() *testSCC {
-	return &testSCC{}
+	return &testSCC{
+		channels: make(map[string]struct{}),
+	}
 }
 
 type queryExecutorProvider interface {
@@ -68,4 +97,23 @@ func (scc *testSCC) Init(stub shim.ChaincodeStubInterface) pb.Response {
 
 func (scc *testSCC) Invoke(stub shim.ChaincodeStubInterface) pb.Response {
 	return shim.Success(nil)
+}
+
+func (scc *testSCC) ChannelJoined(channelID string) {
+	scc.mutex.Lock()
+	scc.channels[channelID] = struct{}{}
+	scc.mutex.Unlock()
+}
+
+func (scc *testSCC) joinedChannels() []string {
+	scc.mutex.Lock()
+	defer scc.mutex.Unlock()
+
+	var channels []string
+
+	for ch := range scc.channels {
+		channels = append(channels, ch)
+	}
+
+	return channels
 }

--- a/test/bddtests/features/ledger_config.feature
+++ b/test/bddtests/features/ledger_config.feature
@@ -88,64 +88,61 @@ Feature: ledger-config
 
   @ledger_config_s3
   Scenario: Ledger config service - peer-specific config
-    Given "test" chaincode "testcc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    Then we wait 20 seconds
-
     # Save the config
-    Given variable "testCCGeneralConfig" is assigned the JSON value '{"MspID":"general","Apps":[{"AppName":"testcc","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testcc\"}","Format":"JSON","Components":[{"Name":"comp1","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testcc\",\"SubComponent\":\"comp1\"}","Format":"JSON"},{"Name":"comp2","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testcc\",\"SubComponent\":\"comp2\"}","Format":"JSON"}]}]}'
-    Given variable "testCCOrg1Config" is assigned the JSON value '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.example.com","Apps":[{"AppName":"testcc","Version":"v1","Config":"p0-org1-testcc-v1-config","Format":"Other"}]},{"PeerID":"peer1.org1.example.com","Apps":[{"AppName":"testcc","Version":"v1","Config":"p1-org1-testcc-v1-config","Format":"Other"}]}]}'
-    Given variable "testCCOrg2Config" is assigned the JSON value '{"MspID":"Org2MSP","Peers":[{"PeerID":"peer0.org2.example.com","Apps":[{"AppName":"testcc","Version":"v1","Config":"p0-org2-testcc-v1-config","Format":"Other"}]},{"PeerID":"peer1.org2.example.com","Apps":[{"AppName":"testcc","Version":"v1","Config":"p1-org2-testcc-v1-config","Format":"Other"}]}]}'
-    Then client invokes chaincode "configscc" with args "save,${testCCGeneralConfig}" on the "mychannel" channel
-    And client invokes chaincode "configscc" with args "save,${testCCOrg1Config}" on the "mychannel" channel
-    And client invokes chaincode "configscc" with args "save,${testCCOrg2Config}" on the "mychannel" channel
+    Given variable "testSCCGeneralConfig" is assigned the JSON value '{"MspID":"general","Apps":[{"AppName":"testscc","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testscc\"}","Format":"JSON","Components":[{"Name":"comp1","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testscc\",\"SubComponent\":\"comp1\"}","Format":"JSON"},{"Name":"comp2","Version":"v1","Config":"{\"Org\":\"general\",\"Application\":\"testscc\",\"SubComponent\":\"comp2\"}","Format":"JSON"}]}]}'
+    Given variable "testSCCOrg1Config" is assigned the JSON value '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p0-org1-testscc-v1-config","Format":"Other"}]},{"PeerID":"peer1.org1.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p1-org1-testscc-v1-config","Format":"Other"}]}]}'
+    Given variable "testSCCOrg2Config" is assigned the JSON value '{"MspID":"Org2MSP","Peers":[{"PeerID":"peer0.org2.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p0-org2-testscc-v1-config","Format":"Other"}]},{"PeerID":"peer1.org2.example.com","Apps":[{"AppName":"testscc","Version":"v1","Config":"p1-org2-testscc-v1-config","Format":"Other"}]}]}'
+    Then client invokes chaincode "configscc" with args "save,${testSCCGeneralConfig}" on the "mychannel" channel
+    And client invokes chaincode "configscc" with args "save,${testSCCOrg1Config}" on the "mychannel" channel
+    And client invokes chaincode "configscc" with args "save,${testSCCOrg2Config}" on the "mychannel" channel
     # Wait for the transactions to commit and for config update events to fire.
     And we wait 3 seconds
 
     # Get general (global) data which is not specific to an org (tests retrieval of config data using the config service)
-    Given variable "testCCGeneralComp1Criteria" is assigned the JSON value '{"MspID":"general","AppName":"testcc","AppVersion":"v1","ComponentName":"comp1","ComponentVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCGeneralComp1Criteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
+    Given variable "testSCCGeneralComp1Criteria" is assigned the JSON value '{"MspID":"general","AppName":"testscc","AppVersion":"v1","ComponentName":"comp1","ComponentVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCGeneralComp1Criteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
     Then the JSON path "Org" of the response equals "general"
-    Then the JSON path "Application" of the response equals "testcc"
+    Then the JSON path "Application" of the response equals "testscc"
     Then the JSON path "SubComponent" of the response equals "comp1"
 
-    Given variable "testCCGeneralComp2Criteria" is assigned the JSON value '{"MspID":"general","AppName":"testcc","AppVersion":"v1","ComponentName":"comp2","ComponentVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCGeneralComp2Criteria}" on a single peer in the "peerorg2" org on the "mychannel" channel
+    Given variable "testSCCGeneralComp2Criteria" is assigned the JSON value '{"MspID":"general","AppName":"testscc","AppVersion":"v1","ComponentName":"comp2","ComponentVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCGeneralComp2Criteria}" on a single peer in the "peerorg2" org on the "mychannel" channel
     Then the JSON path "Org" of the response equals "general"
-    Then the JSON path "Application" of the response equals "testcc"
+    Then the JSON path "Application" of the response equals "testscc"
     Then the JSON path "SubComponent" of the response equals "comp2"
 
-    Given variable "testCCGeneralCriteria" is assigned the JSON value '{"MspID":"general","AppName":"testcc","AppVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCGeneralCriteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
+    Given variable "testSCCGeneralCriteria" is assigned the JSON value '{"MspID":"general","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCGeneralCriteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
     Then the JSON path "Org" of the response equals "general"
-    Then the JSON path "Application" of the response equals "testcc"
+    Then the JSON path "Application" of the response equals "testscc"
 
-    When client queries chaincode "testcc" with args "queryconfig,${testCCGeneralCriteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
+    When client queries chaincode "testscc" with args "queryconfig,${testSCCGeneralCriteria}" on a single peer in the "peerorg1" org on the "mychannel" channel
     Then the JSON path "#" of the response has 3 items
     And the JSON path "0.MspID" of the response equals "general"
-    And the JSON path "0.AppName" of the response equals "testcc"
+    And the JSON path "0.AppName" of the response equals "testscc"
     And the JSON path "1.MspID" of the response equals "general"
-    And the JSON path "1.AppName" of the response equals "testcc"
+    And the JSON path "1.AppName" of the response equals "testscc"
     And the JSON path "2.MspID" of the response equals "general"
-    And the JSON path "2.AppName" of the response equals "testcc"
+    And the JSON path "2.AppName" of the response equals "testscc"
 
     # Get peer-specific data (tests config update events)
-    Given variable "testCCOrg1Peer0Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer0.org1.example.com","AppName":"testcc","AppVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCOrg1Peer0Criteria}" on peers "peer0.org1.example.com" on the "mychannel" channel
-    Then response from "testcc" to client equal value "p0-org1-testcc-v1-config"
+    Given variable "testSCCOrg1Peer0Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer0.org1.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCOrg1Peer0Criteria}" on peers "peer0.org1.example.com" on the "mychannel" channel
+    Then response from "testscc" to client equal value "p0-org1-testscc-v1-config"
 
-    Given variable "testCCOrg1Peer1Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer1.org1.example.com","AppName":"testcc","AppVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCOrg1Peer1Criteria}" on peers "peer1.org1.example.com" on the "mychannel" channel
-    Then response from "testcc" to client equal value "p1-org1-testcc-v1-config"
+    Given variable "testSCCOrg1Peer1Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer1.org1.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCOrg1Peer1Criteria}" on peers "peer1.org1.example.com" on the "mychannel" channel
+    Then response from "testscc" to client equal value "p1-org1-testscc-v1-config"
 
-    Given variable "testCCOrg2Peer0Criteria" is assigned the JSON value '{"MspID":"Org2MSP","PeerID":"peer0.org2.example.com","AppName":"testcc","AppVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCOrg2Peer0Criteria}" on peers "peer0.org2.example.com" on the "mychannel" channel
-    Then response from "testcc" to client equal value "p0-org2-testcc-v1-config"
+    Given variable "testSCCOrg2Peer0Criteria" is assigned the JSON value '{"MspID":"Org2MSP","PeerID":"peer0.org2.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCOrg2Peer0Criteria}" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "testscc" to client equal value "p0-org2-testscc-v1-config"
 
-    Given variable "testCCOrg2Peer1Criteria" is assigned the JSON value '{"MspID":"Org2MSP","PeerID":"peer1.org2.example.com","AppName":"testcc","AppVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCOrg2Peer1Criteria}" on peers "peer1.org2.example.com" on the "mychannel" channel
-    Then response from "testcc" to client equal value "p1-org2-testcc-v1-config"
+    Given variable "testSCCOrg2Peer1Criteria" is assigned the JSON value '{"MspID":"Org2MSP","PeerID":"peer1.org2.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCOrg2Peer1Criteria}" on peers "peer1.org2.example.com" on the "mychannel" channel
+    Then response from "testscc" to client equal value "p1-org2-testscc-v1-config"
 
     # The following peer-specific data should not be found on foreign peer
-    Given variable "testCCOrg1Peer0Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer0.org1.example.com","AppName":"testcc","AppVersion":"v1"}'
-    When client queries chaincode "testcc" with args "getconfig,${testCCOrg1Peer0Criteria}" on peers "peer1.org1.example.com" on the "mychannel" channel
-    Then response from "testcc" to client equal value ""
+    Given variable "testSCCOrg1Peer0Criteria" is assigned the JSON value '{"MspID":"Org1MSP","PeerID":"peer0.org1.example.com","AppName":"testscc","AppVersion":"v1"}'
+    When client queries chaincode "testscc" with args "getconfig,${testSCCOrg1Peer0Criteria}" on peers "peer1.org1.example.com" on the "mychannel" channel
+    Then response from "testscc" to client equal value ""

--- a/test/bddtests/features/txn.feature
+++ b/test/bddtests/features/txn.feature
@@ -11,7 +11,6 @@ Feature: txn
   Background: Setup
     Given the channel "mychannel" is created and all peers have joined
     And "test" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    And "test" chaincode "testcc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy ""
 
     And collection config "privColl" is defined for collection "collection3" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and blocksToLive=3
     And "test" chaincode "target_cc" is installed from path "github.com/trustbloc/fabric-peer-ext/test/chaincode/e2e_cc" to all peers

--- a/test/bddtests/fixtures/config/fabric/core.yaml
+++ b/test/bddtests/fixtures/config/fabric/core.yaml
@@ -567,7 +567,6 @@ chaincode:
         escc: enable
         vscc: enable
         qscc: enable
-        configscc: enable
         testscc: enable
 
     # System chaincode plugins:

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -5,7 +5,6 @@
 module github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/peer/cmd
 
 require (
-	github.com/Microsoft/hcsshim v0.8.9 // indirect
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/prometheus/procfs v0.0.5 // indirect
@@ -13,7 +12,7 @@ require (
 	github.com/trustbloc/fabric-peer-ext v0.0.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973
 
 replace github.com/hyperledger/fabric/extensions => ../../../../../../mod/peer
 

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.sum
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.sum
@@ -308,8 +308,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039 h1:55vVUODSuZpvXtrsJgPT/nYZAgZgulSzQ26SSk2M/NE=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039/go.mod h1:+8srdHdWnsQtfulc0TPTXxfCALR2StVv67sAlIftgG4=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973 h1:udrZyLIpyfDrh2aFnHoCfK149LrSerRAqnQqNaocDIo=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200613145354-867c36a7b973/go.mod h1:+8srdHdWnsQtfulc0TPTXxfCALR2StVv67sAlIftgG4=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/test/bddtests/fixtures/fabric/peer/cmd/main.go
+++ b/test/bddtests/fixtures/fabric/peer/cmd/main.go
@@ -14,13 +14,14 @@ import (
 	"github.com/hyperledger/fabric/peer/node"
 	viper "github.com/spf13/viper2015"
 
+	"github.com/trustbloc/fabric-peer-ext/pkg/chaincode/scc"
 	"github.com/trustbloc/fabric-peer-ext/pkg/chaincode/ucc"
 	"github.com/trustbloc/fabric-peer-ext/pkg/handler/authfilter"
 	extpeer "github.com/trustbloc/fabric-peer-ext/pkg/peer"
 	"github.com/trustbloc/fabric-peer-ext/test/cc/examplecc"
 	"github.com/trustbloc/fabric-peer-ext/test/cc/hellocc"
 	"github.com/trustbloc/fabric-peer-ext/test/cc/inprocucc"
-	"github.com/trustbloc/fabric-peer-ext/test/cc/testcc"
+	"github.com/trustbloc/fabric-peer-ext/test/cc/testscc"
 	"github.com/trustbloc/fabric-peer-ext/test/handler/exampleauthfilter"
 )
 
@@ -45,9 +46,11 @@ func main() {
 
 	authfilter.Register(exampleauthfilter.New)
 
-	logger.Infof("Registering in-process user chaincodes for BDD tests...")
+	logger.Infof("Registering in-process system chaincodes for BDD tests...")
 
-	ucc.Register(testcc.New)
+	scc.Register(testscc.New)
+
+	logger.Infof("Registering in-process user chaincodes for BDD tests...")
 
 	ucc.Register(inprocucc.NewV1)
 	ucc.Register(inprocucc.NewV1_1)


### PR DESCRIPTION
Updated to the latest fabric-mod which adds ext system chaincodes to the build-in list, allowing them to be invoked.
Also added support for ChannelJoined on ext SCC so that it may be informed when a channel is joined (since Init is no
longer called on system chaincodes).

closes #425

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>