### PR TITLE
feat: Support for collection hash r/w sets in block publisher

### DIFF
--- a/mod/peer/gossip/api/gossipapi.go
+++ b/mod/peer/gossip/api/gossipapi.go
@@ -31,6 +31,12 @@ type WriteHandler func(txMetadata TxMetadata, namespace string, kvWrite *kvrwset
 // ReadHandler handles a KV read
 type ReadHandler func(txMetadata TxMetadata, namespace string, kvRead *kvrwset.KVRead) error
 
+// CollHashWriteHandler handles a KV collection hash write
+type CollHashWriteHandler func(txMetadata TxMetadata, namespace, collection string, kvWrite *kvrwset.KVWriteHash) error
+
+// CollHashReadHandler handles a KV collection hash read
+type CollHashReadHandler func(txMetadata TxMetadata, namespace, collection string, kvRead *kvrwset.KVReadHash) error
+
 // ChaincodeEventHandler handles a chaincode event
 type ChaincodeEventHandler func(txMetadata TxMetadata, event *pb.ChaincodeEvent) error
 
@@ -50,6 +56,10 @@ type BlockHandler interface {
 	AddWriteHandler(handler WriteHandler)
 	// AddReadHandler adds a handler for KV reads
 	AddReadHandler(handler ReadHandler)
+	// AddCollHashReadHandler adds a new handler for KV collection hash reads
+	AddCollHashReadHandler(handler CollHashReadHandler)
+	// AddCollHashWriteHandler adds a new handler for KV collection hash writes
+	AddCollHashWriteHandler(handler CollHashWriteHandler)
 	// AddLSCCWriteHandler adds a handler for LSCC writes (for chaincode instantiate/upgrade)
 	AddLSCCWriteHandler(handler LSCCWriteHandler)
 	// AddCCEventHandler adds a handler for chaincode events

--- a/mod/peer/gossip/mocks/blockpublisher.go
+++ b/mod/peer/gossip/mocks/blockpublisher.go
@@ -45,6 +45,16 @@ func (m *BlockPublisher) AddReadHandler(handler api.ReadHandler) {
 	// Not implemented
 }
 
+// AddCollHashWriteHandler adds a handler for KV collection hash writes
+func (m *BlockPublisher) AddCollHashWriteHandler(handler api.CollHashWriteHandler) {
+	// Not implemented
+}
+
+// AddCollHashReadHandler adds a handler for KV collection hash reads
+func (m *BlockPublisher) AddCollHashReadHandler(handler api.CollHashReadHandler) {
+	// Not implemented
+}
+
 // AddCCEventHandler adds a handler for chaincode events
 func (m *BlockPublisher) AddCCEventHandler(handler api.ChaincodeEventHandler) {
 	// Not implemented

--- a/pkg/common/blockvisitor/context.go
+++ b/pkg/common/blockvisitor/context.go
@@ -23,6 +23,12 @@ const (
 	// WriteHandlerErr indicates that the write handler returned an error
 	WriteHandlerErr Category = "WRITE_HANDLER_ERROR"
 
+	// CollHashReadHandlerErr indicates that the collection hash read handler returned an error
+	CollHashReadHandlerErr Category = "COLL_HASH_READ_HANDLER_ERROR"
+
+	// CollHashWriteHandlerErr indicates that the collection hash write handler returned an error
+	CollHashWriteHandlerErr Category = "COLL_HASH_WRITE_HANDLER_ERROR"
+
 	// LSCCWriteHandlerErr indicates that the LSCC write handler returned an error
 	LSCCWriteHandlerErr Category = "LSCCWRITE_HANDLER_ERROR"
 
@@ -35,16 +41,18 @@ const (
 
 // Context holds the context at the time of a Visitor error
 type Context struct {
-	Category     Category
-	ChannelID    string
-	BlockNum     uint64
-	TxNum        uint64
-	TxID         string
-	Read         *Read
-	Write        *Write
-	CCEvent      *CCEvent
-	LSCCWrite    *LSCCWrite
-	ConfigUpdate *ConfigUpdate
+	Category      Category
+	ChannelID     string
+	BlockNum      uint64
+	TxNum         uint64
+	TxID          string
+	Read          *Read
+	Write         *Write
+	CollHashRead  *CollHashRead
+	CollHashWrite *CollHashWrite
+	CCEvent       *CCEvent
+	LSCCWrite     *LSCCWrite
+	ConfigUpdate  *ConfigUpdate
 }
 
 func newContext(category Category, channelID string, blockNum uint64, opts ...ctxOpt) *Context {
@@ -115,6 +123,18 @@ func withRead(r *Read) ctxOpt {
 func withWrite(w *Write) ctxOpt {
 	return func(ctx *Context) {
 		ctx.Write = w
+	}
+}
+
+func withCollHashRead(r *CollHashRead) ctxOpt {
+	return func(ctx *Context) {
+		ctx.CollHashRead = r
+	}
+}
+
+func withCollHashWrite(w *CollHashWrite) ctxOpt {
+	return func(ctx *Context) {
+		ctx.CollHashWrite = w
 	}
 }
 

--- a/pkg/mocks/mockblockhandler.go
+++ b/pkg/mocks/mockblockhandler.go
@@ -20,6 +20,8 @@ import (
 type MockBlockHandler struct {
 	numReads           int32
 	numWrites          int32
+	numCollHashReads   int32
+	numCollHashWrites  int32
 	numCCEvents        int32
 	numCCUpgradeEvents int32
 	numConfigUpdates   int32
@@ -46,6 +48,16 @@ func (m *MockBlockHandler) NumReads() int {
 // NumWrites returns the number of writes handled
 func (m *MockBlockHandler) NumWrites() int {
 	return int(atomic.LoadInt32(&m.numWrites))
+}
+
+// NumCollHashReads returns the number of collection hash reads handled
+func (m *MockBlockHandler) NumCollHashReads() int {
+	return int(atomic.LoadInt32(&m.numCollHashReads))
+}
+
+// NumCollHashWrites returns the number of collection hash writes handled
+func (m *MockBlockHandler) NumCollHashWrites() int {
+	return int(atomic.LoadInt32(&m.numCollHashWrites))
 }
 
 // NumLSCCWrites returns the number of LSCC writes handled
@@ -77,6 +89,18 @@ func (m *MockBlockHandler) HandleRead(txMetadata api.TxMetadata, namespace strin
 // HandleWrite handles a write event by incrementing the write counter
 func (m *MockBlockHandler) HandleWrite(txMetadata api.TxMetadata, namespace string, kvWrite *kvrwset.KVWrite) error {
 	atomic.AddInt32(&m.numWrites, 1)
+	return m.err
+}
+
+// HandleCollHashRead handles a collection hash read event by incrementing the read counter
+func (m *MockBlockHandler) HandleCollHashRead(txMetadata api.TxMetadata, namespace, collection string, kvRead *kvrwset.KVReadHash) error {
+	atomic.AddInt32(&m.numCollHashReads, 1)
+	return m.err
+}
+
+// HandleCollHashWrite handles a collection hash write event by incrementing the write counter
+func (m *MockBlockHandler) HandleCollHashWrite(txMetadata api.TxMetadata, namespace, collection string, kvWrite *kvrwset.KVWriteHash) error {
+	atomic.AddInt32(&m.numCollHashWrites, 1)
 	return m.err
 }
 

--- a/pkg/mocks/mockblockpublisher.go
+++ b/pkg/mocks/mockblockpublisher.go
@@ -13,12 +13,14 @@ import (
 
 // MockBlockPublisher is a mock block publisher
 type MockBlockPublisher struct {
-	HandleUpgrade      gossipapi.ChaincodeUpgradeHandler
-	HandleConfigUpdate gossipapi.ConfigUpdateHandler
-	HandleWrite        gossipapi.WriteHandler
-	HandleRead         gossipapi.ReadHandler
-	HandleLSCCWrite    gossipapi.LSCCWriteHandler
-	HandleCCEvent      gossipapi.ChaincodeEventHandler
+	HandleUpgrade       gossipapi.ChaincodeUpgradeHandler
+	HandleConfigUpdate  gossipapi.ConfigUpdateHandler
+	HandleWrite         gossipapi.WriteHandler
+	HandleRead          gossipapi.ReadHandler
+	HandleCollHashWrite gossipapi.CollHashWriteHandler
+	HandleCollHashRead  gossipapi.CollHashReadHandler
+	HandleLSCCWrite     gossipapi.LSCCWriteHandler
+	HandleCCEvent       gossipapi.ChaincodeEventHandler
 }
 
 // NewBlockPublisher returns a mock block publisher
@@ -44,6 +46,16 @@ func (m *MockBlockPublisher) AddWriteHandler(handler gossipapi.WriteHandler) {
 // AddReadHandler adds a read handler
 func (m *MockBlockPublisher) AddReadHandler(handler gossipapi.ReadHandler) {
 	m.HandleRead = handler
+}
+
+// AddCollHashWriteHandler adds a collection hash write handler
+func (m *MockBlockPublisher) AddCollHashWriteHandler(handler gossipapi.CollHashWriteHandler) {
+	m.HandleCollHashWrite = handler
+}
+
+// AddCollHashReadHandler adds a read handler
+func (m *MockBlockPublisher) AddCollHashReadHandler(handler gossipapi.CollHashReadHandler) {
+	m.HandleCollHashRead = handler
 }
 
 // AddLSCCWriteHandler adds a write handler

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -5,8 +5,6 @@
 module github.com/trustbloc/fabric-peer-ext/test/bddtests/fixtures/fabric/peer/cmd
 
 require (
-	github.com/Microsoft/hcsshim v0.8.9 // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/prometheus/procfs v0.0.5 // indirect


### PR DESCRIPTION
Clients can now register for collection hash read and write block events.

closes #431

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>