### PR TITLE
fix: Delete collection hash entries from cache on update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	google.golang.org/grpc v1.29.1
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf
 
 replace github.com/hyperledger/fabric/extensions => ./mod/peer
 

--- a/go.sum
+++ b/go.sum
@@ -314,8 +314,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2 h1:P9L1eDQOlaBhmUp/dvRARqz+43Nz7+7EStm5e6gJN+U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2/go.mod h1:cQj569lHHCUYI44EtWmJ7Sa2Iqw/K5Hst1l9P0hsTPw=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf h1:NHJTzMPO6fOB6wscoT7Zn75L2lsK0Jb/Nk/EoymAFaM=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf/go.mod h1:cQj569lHHCUYI44EtWmJ7Sa2Iqw/K5Hst1l9P0hsTPw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/mod/peer/go.mod
+++ b/mod/peer/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/fabric-peer-ext/mod/peer
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf
 
 replace github.com/hyperledger/fabric/extensions => ./
 

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -298,8 +298,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2 h1:P9L1eDQOlaBhmUp/dvRARqz+43Nz7+7EStm5e6gJN+U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2/go.mod h1:cQj569lHHCUYI44EtWmJ7Sa2Iqw/K5Hst1l9P0hsTPw=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf h1:NHJTzMPO6fOB6wscoT7Zn75L2lsK0Jb/Nk/EoymAFaM=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf/go.mod h1:cQj569lHHCUYI44EtWmJ7Sa2Iqw/K5Hst1l9P0hsTPw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=

--- a/test/bddtests/features/e2e.feature
+++ b/test/bddtests/features/e2e.feature
@@ -57,16 +57,21 @@ Feature:
     And client queries chaincode "e2e_cc" with args "get,k1" on a single peer in the "peerorg1" org on the "mychannel" channel
     Then response from "e2e_cc" to client equal value ""
 
-
     # Test private data collection transactions
     When client invokes chaincode "e2e_cc" with args "putprivate,collection3,pvtKey,pvtVal" on the "mychannel" channel
     And we wait 2 seconds
-    And client queries chaincode "e2e_cc" with args "getprivate,collection3,pvtKey" on a single peer in the "peerorg1" org on the "mychannel" channel
+    And client queries chaincode "e2e_cc" with args "getprivate,collection3,pvtKey" on the "mychannel" channel
     Then response from "e2e_cc" to client equal value "pvtVal"
+
+    # Update the value to ensure that the state cache is updated/invalidated
+    When client invokes chaincode "e2e_cc" with args "putprivate,collection3,pvtKey,pvtVal2" on the "mychannel" channel
+    And we wait 2 seconds
+    And client queries chaincode "e2e_cc" with args "getprivate,collection3,pvtKey" on the "mychannel" channel
+    Then response from "e2e_cc" to client equal value "pvtVal2"
 
     When client invokes chaincode "e2e_cc" with args "delprivate,collection3,pvtKey" on the "mychannel" channel
     And we wait 2 seconds
-    And client queries chaincode "e2e_cc" with args "getprivate,collection3,pvtKey" on a single peer in the "peerorg1" org on the "mychannel" channel
+    And client queries chaincode "e2e_cc" with args "getprivate,collection3,pvtKey" on the "mychannel" channel
     Then response from "e2e_cc" to client equal value ""
 
   @e2e_s2

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.mod
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/trustbloc/fabric-peer-ext v0.0.0
 )
 
-replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2
+replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf
 
 replace github.com/hyperledger/fabric/extensions => ../../../../../../mod/peer
 

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.sum
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.sum
@@ -305,8 +305,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc h1:LUUe4cdABGrIJAhl1P1ZpWY76AwukVszFdwkVFVLwIk=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2 h1:P9L1eDQOlaBhmUp/dvRARqz+43Nz7+7EStm5e6gJN+U=
-github.com/trustbloc/fabric-mod v0.1.4-0.20200716181456-0f6536be4fe2/go.mod h1:cQj569lHHCUYI44EtWmJ7Sa2Iqw/K5Hst1l9P0hsTPw=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf h1:NHJTzMPO6fOB6wscoT7Zn75L2lsK0Jb/Nk/EoymAFaM=
+github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf/go.mod h1:cQj569lHHCUYI44EtWmJ7Sa2Iqw/K5Hst1l9P0hsTPw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=


### PR DESCRIPTION
Updated to latest fabric-mod which fixes the issue of stale collection hash cache entries.

closes #463

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>