### PR TITLE
fix: Call Done() on query executor in CC notifier

### DIFF
--- a/pkg/chaincode/notifier/notifier.go
+++ b/pkg/chaincode/notifier/notifier.go
@@ -80,6 +80,7 @@ func (cci channelNotifier) handleWrite(metadata xgossipapi.TxMetadata, namespace
 	if err != nil {
 		return err
 	}
+	defer qe.Done()
 
 	return cci.HandleStateUpdates(&ledger.StateUpdateTrigger{
 		LedgerID:                cci.channelID,
@@ -104,6 +105,7 @@ func (cci channelNotifier) handleHashWrite(metadata xgossipapi.TxMetadata, names
 	if err != nil {
 		return err
 	}
+	defer qe.Done()
 
 	return cci.HandleStateUpdates(&ledger.StateUpdateTrigger{
 		LedgerID:                cci.channelID,


### PR DESCRIPTION
closes #498

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>