### PR TITLE
fix: Deadlock in ledger config

### DIFF
--- a/mod/peer/endorser/api/endorser.go
+++ b/mod/peer/endorser/api/endorser.go
@@ -7,19 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package api
 
 import (
-	"github.com/hyperledger/fabric/core/ledger"
 	xgossipapi "github.com/hyperledger/fabric/extensions/gossip/api"
 )
-
-// QueryExecutorProvider returns a query executor
-type QueryExecutorProvider interface {
-	NewQueryExecutor() (ledger.QueryExecutor, error)
-}
-
-// QueryExecutorProviderFactory returns a query executor provider for a given channel
-type QueryExecutorProviderFactory interface {
-	GetQueryExecutorProvider(channelID string) QueryExecutorProvider
-}
 
 // BlockPublisherProvider returns a block publisher for a given channel
 type BlockPublisherProvider interface {

--- a/pkg/config/ledgerconfig/service/service_test.go
+++ b/pkg/config/ledgerconfig/service/service_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/stretchr/testify/require"
+
+	cmocks "github.com/trustbloc/fabric-peer-ext/pkg/common/mocks"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mgr"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/mocks"
@@ -299,10 +301,9 @@ func TestConfigService_AddUpdateHandler(t *testing.T) {
 }
 
 func TestManager(t *testing.T) {
-	lp := &mocks2.LedgerProvider{}
-	lp.GetLedgerReturns(&mocks2.Ledger{QueryExecutor: mocks2.NewQueryExecutor()})
-
-	manager := NewSvcMgr(lp, mocks2.NewBlockPublisherProvider())
+	dbp := &cmocks.StateDBProvider{}
+	dbp.StateDBForChannelReturns(&mocks2.StateDB{})
+	manager := NewSvcMgr(dbp, mocks2.NewBlockPublisherProvider())
 
 	svc := manager.ForChannel(channelID)
 	require.NotNil(t, svc)

--- a/pkg/config/ledgerconfig/state/kvresultsiter.go
+++ b/pkg/config/ledgerconfig/state/kvresultsiter.go
@@ -9,18 +9,19 @@ package state
 import (
 	"github.com/hyperledger/fabric-protos-go/ledger/queryresult"
 	commonledger "github.com/hyperledger/fabric/common/ledger"
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/pkg/errors"
 )
 
 // KVResultsIter is a key-value results iterator
 type KVResultsIter struct {
-	it      commonledger.ResultsIterator
+	it      statedb.ResultsIterator
 	next    commonledger.QueryResult
 	nextErr error
 }
 
 // NewKVResultsIter returns a new KVResultsIter
-func NewKVResultsIter(it commonledger.ResultsIterator) *KVResultsIter {
+func NewKVResultsIter(it statedb.ResultsIterator) *KVResultsIter {
 	return &KVResultsIter{it: it}
 }
 
@@ -60,7 +61,8 @@ func (it *KVResultsIter) Next() (*queryresult.KV, error) {
 		return nil, errors.New("Next() called when there is no next")
 	}
 
-	versionedKV := queryResult.(*queryresult.KV)
+	versionedKV := queryResult.(*statedb.VersionedKV)
+
 	return &queryresult.KV{
 		Namespace: versionedKV.Namespace,
 		Key:       versionedKV.Key,

--- a/pkg/config/ledgerconfig/state/qestateretriever.go
+++ b/pkg/config/ledgerconfig/state/qestateretriever.go
@@ -8,64 +8,54 @@ package state
 
 import (
 	"github.com/hyperledger/fabric/common/flogging"
-	"github.com/hyperledger/fabric/core/ledger"
+
 	"github.com/trustbloc/fabric-peer-ext/pkg/common/compositekey"
 	"github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/state/api"
+	extstatedb "github.com/trustbloc/fabric-peer-ext/pkg/statedb"
 )
 
 var logger = flogging.MustGetLogger("ledgerconfig")
 
 // QERetrieverProvider is a RetrieverProvider using a QueryExecutor
 type QERetrieverProvider struct {
-	channelID  string
-	qeProvider qeProvider
-}
-
-type qeProvider interface {
-	GetQueryExecutorForLedger(cid string) (ledger.QueryExecutor, error)
+	qeRetriever *qeRetriever
 }
 
 // NewQERetrieverProvider returns a new state qeRetriever provider
-func NewQERetrieverProvider(channelID string, qeProvider qeProvider) *QERetrieverProvider {
+func NewQERetrieverProvider(stateDB extstatedb.StateDB) *QERetrieverProvider {
 	return &QERetrieverProvider{
-		channelID:  channelID,
-		qeProvider: qeProvider,
+		qeRetriever: &qeRetriever{stateDB: stateDB},
 	}
 }
 
 // GetStateRetriever returns the state qeRetriever
 func (p *QERetrieverProvider) GetStateRetriever() (api.StateRetriever, error) {
-	qe, err := p.qeProvider.GetQueryExecutorForLedger(p.channelID)
-	if err != nil {
-		return nil, err
-	}
-	return &qeRetriever{
-		qe: qe,
-	}, nil
+	return p.qeRetriever, nil
 }
 
 // qeRetriever implements the StateRetriever interface
 type qeRetriever struct {
-	qe ledger.QueryExecutor
+	stateDB extstatedb.StateDB
 }
 
 // GetState returns the value for the given key
 func (s *qeRetriever) GetState(namespace, key string) ([]byte, error) {
-	return s.qe.GetState(namespace, key)
+	return s.stateDB.GetState(namespace, key)
 }
 
 // GetStateByPartialCompositeKey returns an iterator for the given index and attributes
 func (s *qeRetriever) GetStateByPartialCompositeKey(namespace, objectType string, attributes []string) (api.ResultsIterator, error) {
 	startKey, endKey := compositekey.CreateRangeKeysForPartialCompositeKey(objectType, attributes)
 	logger.Debugf("Namespace [%s], StartKey [%s], EndKey [%s]", namespace, startKey, endKey)
-	it, err := s.qe.GetStateRangeScanIterator(namespace, startKey, endKey)
+
+	it, err := s.stateDB.GetStateRangeScanIterator(namespace, startKey, endKey)
 	if err != nil {
 		return nil, err
 	}
+
 	return NewKVResultsIter(it), nil
 }
 
-// Done releases resources occupied by the StateRetriever
 func (s *qeRetriever) Done() {
-	s.qe.Done()
+	// Nothing to do
 }

--- a/pkg/config/ledgerconfig/state/qestateretriever_test.go
+++ b/pkg/config/ledgerconfig/state/qestateretriever_test.go
@@ -10,27 +10,27 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb"
 	"github.com/stretchr/testify/require"
+
 	"github.com/trustbloc/fabric-peer-ext/pkg/common/compositekey"
+	cmocks "github.com/trustbloc/fabric-peer-ext/pkg/common/mocks"
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
 const (
-	channelID = "testchannel"
-
 	index   = "index1"
 	prefix1 = "prefix1"
-	prefix2 = "prefix2"
 )
 
 func TestQERetriever_GetState(t *testing.T) {
 	v1 := []byte("v1")
 
 	t.Run("Success", func(t *testing.T) {
-		rp := NewQERetrieverProvider(channelID,
-			mocks.NewQueryExecutorProvider().
-				WithMockQueryExecutor(mocks.NewQueryExecutor().WithState(ns1, key1, v1)),
-		)
+		db := &mocks.StateDB{}
+		db.GetStateReturns(v1, nil)
+
+		rp := NewQERetrieverProvider(db)
 
 		r, err := rp.GetStateRetriever()
 		require.NoError(t, err)
@@ -39,25 +39,14 @@ func TestQERetriever_GetState(t *testing.T) {
 		v, err := r.GetState(ns1, key1)
 		require.NoError(t, err)
 		require.Equal(t, v1, v)
-
-		require.NotPanics(t, func() { r.Done() })
 	})
-	t.Run("QueryExecutorProvider error", func(t *testing.T) {
-		errExpected := errors.New("query executor error")
-		rp := NewQERetrieverProvider(channelID,
-			mocks.NewQueryExecutorProvider().WithError(errExpected),
-		)
 
-		r, err := rp.GetStateRetriever()
-		require.EqualError(t, err, errExpected.Error())
-		require.Nil(t, r)
-	})
 	t.Run("Iterator error", func(t *testing.T) {
 		errExpected := errors.New("iterator error")
-		rp := NewQERetrieverProvider(channelID,
-			mocks.NewQueryExecutorProvider().
-				WithMockQueryExecutor(mocks.NewQueryExecutor().WithQueryError(errExpected)),
-		)
+		db := &mocks.StateDB{}
+		db.GetStateRangeScanIteratorReturns(nil, errExpected)
+
+		rp := NewQERetrieverProvider(db)
 
 		r, err := rp.GetStateRetriever()
 		require.NoError(t, err)
@@ -70,19 +59,16 @@ func TestQERetriever_GetState(t *testing.T) {
 }
 
 func TestQERetriever_GetStateByPartialCompositeKey(t *testing.T) {
-	qe := mocks.NewQueryExecutor()
-	rp := NewQERetrieverProvider(
-		channelID, mocks.NewQueryExecutorProvider().WithMockQueryExecutor(qe),
-	)
+	db := &mocks.StateDB{}
+	mit := &cmocks.ResultsIterator{}
+	db.GetStateRangeScanIteratorReturns(mit, nil)
+
+	rp := NewQERetrieverProvider(db)
 
 	ck1 := compositekey.Create(index, []string{prefix1, key1})
-	qe.WithState(ns1, ck1, []byte("{}"))
-
+	mit.NextReturnsOnCall(0, newVersionedKV(ns1, ck1, []byte("{}")), nil)
 	ck2 := compositekey.Create(index, []string{prefix1, key2})
-	qe.WithState(ns1, ck2, []byte("{}"))
-
-	ck3 := compositekey.Create(index, []string{prefix2, key3})
-	qe.WithState(ns1, ck3, []byte("{}"))
+	mit.NextReturnsOnCall(1, newVersionedKV(ns1, ck2, []byte("{}")), nil)
 
 	r, err := rp.GetStateRetriever()
 	require.NoError(t, err)
@@ -119,36 +105,16 @@ func TestQERetriever_GetStateByPartialCompositeKey(t *testing.T) {
 	require.EqualError(t, err, "Next() called when there is no next")
 	require.Nil(t, kv)
 	require.NoError(t, it.Close())
-
-	it, err = r.GetStateByPartialCompositeKey(ns1, index, []string{prefix2})
-	require.NoError(t, err)
-	require.NotNil(t, it)
-
-	require.True(t, it.HasNext())
-	kv, err = it.Next()
-	require.NoError(t, err)
-	require.NotNil(t, kv)
-
-	indexName, keys = compositekey.Split(kv.Key)
-	require.Equal(t, index, indexName)
-	require.Equal(t, 2, len(keys))
-	require.Equal(t, key3, keys[1])
-
-	require.False(t, it.HasNext())
-	require.NoError(t, it.Close())
 }
 
 func TestQERetriever_GetStateByPartialCompositeKey_Error(t *testing.T) {
 	errExpected := errors.New("iterator error")
-	rp := NewQERetrieverProvider(
-		channelID, mocks.NewQueryExecutorProvider().WithMockQueryExecutor(
-			mocks.NewQueryExecutor().WithIteratorProvider(
-				func() *mocks.ResultsIterator {
-					return mocks.NewResultsIterator().WithError(errExpected)
-				},
-			),
-		),
-	)
+	db := &mocks.StateDB{}
+	mit := &cmocks.ResultsIterator{}
+	mit.NextReturns(nil, errExpected)
+	db.GetStateRangeScanIteratorReturns(mit, nil)
+
+	rp := NewQERetrieverProvider(db)
 
 	r, err := rp.GetStateRetriever()
 	require.NoError(t, err)
@@ -163,4 +129,16 @@ func TestQERetriever_GetStateByPartialCompositeKey_Error(t *testing.T) {
 	kv, err := it.Next()
 	require.EqualError(t, err, errExpected.Error())
 	require.Nil(t, kv)
+}
+
+func newVersionedKV(ns, key string, value []byte) *statedb.VersionedKV {
+	return &statedb.VersionedKV{
+		CompositeKey: statedb.CompositeKey{
+			Namespace: ns,
+			Key:       key,
+		},
+		VersionedValue: statedb.VersionedValue{
+			Value: value,
+		},
+	}
 }

--- a/pkg/txn/proprespvalidator/validator_test.go
+++ b/pkg/txn/proprespvalidator/validator_test.go
@@ -18,7 +18,6 @@ import (
 	lb "github.com/hyperledger/fabric-protos-go/peer/lifecycle"
 	"github.com/hyperledger/fabric/common/policydsl"
 	"github.com/hyperledger/fabric/core/chaincode/lifecycle"
-	"github.com/hyperledger/fabric/core/ledger"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/require"
 
@@ -686,21 +685,6 @@ func TestValidator_ValidateProposalResponses(t *testing.T) {
 		require.Equal(t, pb.TxValidationCode_VALID, code)
 		require.NoError(t, err)
 	})
-}
-
-type qeProvider struct {
-	qe  *mocks.QueryExecutor
-	err error
-}
-
-func newQueryExecutorProvider(qe *mocks.QueryExecutor) *qeProvider {
-	return &qeProvider{
-		qe: qe,
-	}
-}
-
-func (p *qeProvider) NewQueryExecutor() (ledger.QueryExecutor, error) {
-	return p.qe, nil
 }
 
 type mockPolicyEvaluator struct {


### PR DESCRIPTION
During an endorsement if a chaincode invokes the ledger config service then an intermittent deadlock results. The scenario is as follows:

- Chaincode is invoked so a ledger read lock is acquired
- Block is being committed so a write lock on the ledger is attempted. This call blocks until the read lock is released.
- Chaincode invokes ledger config service which invokes NewQueryExecutor on the ledger. This function attempts to acquire a read lock and therefore a deadlock occurs.

This fix uses the state database provider instead of the query executor to retrieve ledger configuration so that a ledger lock is not required.

closes #515

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>