### PR TITLE
fix: Enable cache for DCAS collections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23
-	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3
+	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/viper2015 v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/hyperledger/fabric-config v0.0.5 h1:khRkm8U9Ghdg8VmZfptgzCFlCzrka8bPf
 github.com/hyperledger/fabric-config v0.0.5/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3 h1:A/hog3Eqz2w3daj5WM99JDDI8KfJFPhw0sKttp1TMc4=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3 h1:9GEaHWF2PoK4HiWUTSdC0IRlxp4MRae6UTvf4A915to=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
+++ b/pkg/collections/offledger/storeprovider/olstoreprovider_test.go
@@ -18,6 +18,7 @@ import (
 	viper "github.com/spf13/viper2015"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 )
 
@@ -25,7 +26,7 @@ func TestStoreProvider_OpenStore(t *testing.T) {
 	channel1 := "channel1"
 	channel2 := "channel2"
 
-	f := New(&mocks.IdentifierProvider{}, &mocks.IdentityDeserializerProvider{})
+	f := New(&mocks.IdentifierProvider{}, &mocks.IdentityDeserializerProvider{}, &mocks.CollectionConfigProvider{})
 	require.NotNil(t, f)
 
 	s1, err := f.OpenStore(channel1)
@@ -47,10 +48,13 @@ func TestStoreProvider_OpenStore(t *testing.T) {
 
 func TestStoreProvider_WithDecorator(t *testing.T) {
 	f := New(
-		&mocks.IdentifierProvider{}, &mocks.IdentityDeserializerProvider{},
+		&mocks.IdentifierProvider{},
+		&mocks.IdentityDeserializerProvider{},
+		&mocks.CollectionConfigProvider{},
 		WithCollectionType(
 			pb.CollectionType_COL_DCAS,
 			WithDecorator(&mockDecorator{}),
+			WithCacheEnabled(),
 		))
 	require.NotNil(t, f)
 	config, ok := f.collConfigs[pb.CollectionType_COL_DCAS]

--- a/pkg/collections/storeprovider/storeprovider.go
+++ b/pkg/collections/storeprovider/storeprovider.go
@@ -87,13 +87,15 @@ func (sp *StoreProvider) Close() {
 }
 
 // NewOffLedgerProvider creates a new off-ledger store provider that supports DCAS
-func NewOffLedgerProvider(identifierProvider collcommon.IdentifierProvider, idDProvider collcommon.IdentityDeserializerProvider) olapi.StoreProvider {
+func NewOffLedgerProvider(identifierProvider collcommon.IdentifierProvider, idDProvider collcommon.IdentityDeserializerProvider, collConfigProvider collcommon.CollectionConfigProvider) olapi.StoreProvider {
 	logger.Infof("Creating off-ledger store provider with DCAS")
+
 	return olstoreprovider.New(
-		identifierProvider, idDProvider,
+		identifierProvider, idDProvider, collConfigProvider,
 		olstoreprovider.WithCollectionType(
 			pb.CollectionType_COL_DCAS,
 			olstoreprovider.WithDecorator(dcas.Decorator),
+			olstoreprovider.WithCacheEnabled(),
 		),
 	)
 }

--- a/pkg/collections/storeprovider/storeprovider_test.go
+++ b/pkg/collections/storeprovider/storeprovider_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestStoreProvider(t *testing.T) {
 	tdataProvider := spmocks.NewTransientDataStoreProvider()
-	olProvider := NewOffLedgerProvider(&mocks.IdentifierProvider{}, &mocks.IdentityDeserializerProvider{})
+	olProvider := NewOffLedgerProvider(&mocks.IdentifierProvider{}, &mocks.IdentityDeserializerProvider{}, &mocks.CollectionConfigProvider{})
 
 	t.Run("OpenStore - success", func(t *testing.T) {
 		p := New().Initialize(tdataProvider, olProvider)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,6 @@ const (
 	confOLCollCleanupIntervalTime  = "coll.offledger.cleanupExpired.Interval"
 	confOLCollMaxPeersForRetrieval = "coll.offledger.maxpeers"
 	confOLCollMaxRetrievalAttempts = "coll.offledger.maxRetrievalAttempts"
-	confOLCollCacheEnabled         = "coll.offledger.cache.enable"
 	confOLCollCacheSize            = "coll.offledger.cache.size"
 	confOLCollPullTimeout          = "coll.offledger.gossip.pullTimeout"
 
@@ -159,17 +158,11 @@ func GetOLCollMaxRetrievalAttempts() int {
 
 // GetOLCollCacheSize returns the size of the off-ledger cache
 func GetOLCollCacheSize() int {
-	size := viper.GetInt(confOLCollCacheSize)
-	if size <= 0 {
+	if !viper.IsSet(confOLCollCacheSize) {
 		return defaultOLCollCacheSize
 	}
-	return size
-}
 
-// GetOLCollCacheEnabled returns if off-ledger cache is enabled
-func GetOLCollCacheEnabled() bool {
-	enabled := viper.GetBool(confOLCollCacheEnabled)
-	return enabled
+	return viper.GetInt(confOLCollCacheSize)
 }
 
 // GetOLCollPullTimeout is the amount of time a peer waits for a response from another peer for transient data.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -92,24 +92,13 @@ func TestGetOLCacheSize(t *testing.T) {
 	oldVal := viper.Get(confOLCollCacheSize)
 	defer viper.Set(confOLCollCacheSize, oldVal)
 
+	require.Equal(t, defaultOLCollCacheSize, GetOLCollCacheSize())
+
 	viper.Set(confOLCollCacheSize, 0)
-	assert.Equal(t, defaultOLCollCacheSize, GetOLCollCacheSize())
+	require.Equal(t, 0, GetOLCollCacheSize())
 
 	viper.Set(confOLCollCacheSize, 10)
 	assert.Equal(t, 10, GetOLCollCacheSize())
-}
-
-func TestGetOLCacheEnabled(t *testing.T) {
-	oldVal := viper.Get(confOLCollCacheEnabled)
-	defer viper.Set(confOLCollCacheEnabled, oldVal)
-
-	assert.False(t, GetOLCollCacheEnabled())
-
-	viper.Set(confOLCollCacheEnabled, true)
-	assert.True(t, GetOLCollCacheEnabled())
-
-	viper.Set(confOLCollCacheEnabled, false)
-	assert.False(t, GetOLCollCacheEnabled())
 }
 
 func TestGetTransientDataPullTimeout(t *testing.T) {

--- a/pkg/mocks/mockrwsetbuilder.go
+++ b/pkg/mocks/mockrwsetbuilder.go
@@ -208,7 +208,7 @@ func (b *NamespaceBuilder) BuildCollectionHashedRWSets() []*rwset.CollectionHash
 func (b *NamespaceBuilder) BuildCollectionConfig() *peer.CollectionConfigPackage {
 	cp := &peer.CollectionConfigPackage{}
 	for _, coll := range b.collections {
-		config := coll.buildConfig()
+		config := coll.BuildConfig()
 		cp.Config = append(cp.Config, config)
 	}
 	return cp
@@ -328,7 +328,8 @@ func (c *CollectionBuilder) buildReadWriteSet() []byte {
 	return bytes
 }
 
-func (c *CollectionBuilder) buildConfig() *peer.CollectionConfig {
+// BuildConfig builds the collection configuration
+func (c *CollectionBuilder) BuildConfig() *peer.CollectionConfig {
 	signaturePolicyEnvelope, err := policydsl.FromString(c.policy)
 	if err != nil {
 		panic(err.Error())

--- a/test/bddtests/features/lc_off_ledger.feature
+++ b/test/bddtests/features/lc_off_ledger.feature
@@ -73,14 +73,6 @@ Feature: Lifecycle off-ledger
     When client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on the "mychannel" channel
     Then response from "ol_examplecc" to client equal value "value2"
 
-#  Disable this test since deleting from an off-ledger collection doesn't work anymore since the introduction of a state cache in Fabric 2.0.
-#    # Delete the data on one peer - should be deleted from both peers (TODO: need to be tested with cache enabled)
-#    When client queries chaincode "ol_examplecc" with args "delprivate,collection2,${key2}" on a single peer in the "peerorg1" org on the "mychannel" channel
-#    And client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on a single peer in the "peerorg1" org on the "mychannel" channel
-#    Then response from "ol_examplecc" to client equal value ""
-#    And client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on a single peer in the "peerorg2" org on the "mychannel" channel
-#    Then response from "ol_examplecc" to client equal value ""
-
     # Test to make sure private data collections still persist in a transaction and that off-ledger reads/writes work with transactions
     Given variable "pvtKey2" is assigned the CAS key of value "pvtVal2"
     When client invokes chaincode "ol_examplecc" with args "putprivatemultiple,collection1,pvtKey1,pvtVal1,collection2,${pvtKey2},pvtVal2,collection3,pvtKey3,pvtVal3" on the "mychannel" channel

--- a/test/bddtests/features/off_ledger.feature
+++ b/test/bddtests/features/off_ledger.feature
@@ -75,14 +75,6 @@ Feature: off-ledger
     When client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on the "mychannel" channel
     Then response from "ol_examplecc" to client equal value "value2"
 
-#  Disable this test since deleting from an off-ledger collection doesn't work anymore since the introduction of a state cache in Fabric 2.0.
-#    # Delete the data on one peer - should be deleted from both peers (TODO: need to be tested with cache enabled)
-#    When client queries chaincode "ol_examplecc" with args "delprivate,collection2,${key2}" on a single peer in the "peerorg1" org on the "mychannel" channel
-#    And client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on a single peer in the "peerorg1" org on the "mychannel" channel
-#    Then response from "ol_examplecc" to client equal value ""
-#    And client queries chaincode "ol_examplecc" with args "getprivate,collection2,${key2}" on a single peer in the "peerorg2" org on the "mychannel" channel
-#    Then response from "ol_examplecc" to client equal value ""
-
     # Test to make sure private data collections still persist in a transaction and that off-ledger reads/writes work with transactions
     Given variable "pvtKey2" is assigned the CAS key of value "pvtVal2"
     When client invokes chaincode "ol_examplecc" with args "putprivatemultiple,collection1,pvtKey1,pvtVal1,collection2,${pvtKey2},pvtVal2,collection3,pvtKey3,pvtVal3" on the "mychannel" channel

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cucumber/godog v0.8.1
 	github.com/golang/protobuf v1.3.3
 	github.com/hyperledger/fabric-protos-go v0.0.0
-	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3
+	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/viper v1.1.1
 	github.com/trustbloc/fabric-peer-test-common v0.1.4

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -100,6 +100,8 @@ github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1Q
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
 github.com/hyperledger/fabric-sdk-go v1.0.0-beta3 h1:A/hog3Eqz2w3daj5WM99JDDI8KfJFPhw0sKttp1TMc4=
 github.com/hyperledger/fabric-sdk-go v1.0.0-beta3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3 h1:9GEaHWF2PoK4HiWUTSdC0IRlxp4MRae6UTvf4A915to=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548/go.mod h1:hGT6jSUVzF6no3QaDSMLGLEHtHSBSefs+MgcDWnmhmo=
 github.com/jmoiron/sqlx v0.0.0-20180124204410-05cef0741ade/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=


### PR DESCRIPTION
Off-ledger collections cannot reliably cache data since updates to a key may not be propagated to all peers and a subsequent Get may retrieve stale data from the cache. Although, DCAS collections can reliably cache data, since an update to a DCAS value will always result in the same value. Deletes are still a problem since a DCAS value may still be cached on one or more peers. Support for delete of a DCAS key should be deprecated.

This commit (by default) enables the cache for DCAS collection types and disables the cache for off-ledger collection types. (Note that the cache may still be disabled for DCAS collection types by setting the off-ledger cache size to 0.)

This commit also updates to the latest fabric-sdk-go.

closes #382

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>