### PR TITLE
fix: Retrieve from other peers if transient data not found

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed
 	github.com/hyperledger/fabric-protos-go v0.0.0-20200707132912-fee30f3ccd23
-	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3
+	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b
 	github.com/hyperledger/fabric/extensions v0.0.0
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/viper2015 v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/hyperledger/fabric-config v0.0.5 h1:khRkm8U9Ghdg8VmZfptgzCFlCzrka8bPf
 github.com/hyperledger/fabric-config v0.0.5/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3 h1:9GEaHWF2PoK4HiWUTSdC0IRlxp4MRae6UTvf4A915to=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b h1:p8V3EiEhmXtKqmTTrodIDg/MDK81ivyNN0u8XkXzrAU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/mod/peer/go.sum
+++ b/mod/peer/go.sum
@@ -169,8 +169,8 @@ github.com/hyperledger/fabric-config v0.0.5 h1:khRkm8U9Ghdg8VmZfptgzCFlCzrka8bPf
 github.com/hyperledger/fabric-config v0.0.5/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3 h1:A/hog3Eqz2w3daj5WM99JDDI8KfJFPhw0sKttp1TMc4=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b h1:p8V3EiEhmXtKqmTTrodIDg/MDK81ivyNN0u8XkXzrAU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/test/bddtests/features/transient_data.feature
+++ b/test/bddtests/features/transient_data.feature
@@ -181,3 +181,18 @@ Feature:
     # Query the target chaincode using a chaincode-to-chaincode invocation
     When client queries chaincode "tdata_examplecc" with args "invokecc,tdata_examplecc_2,yourchannel,{`Args`:[`getprivate`|`collection2`|`keyD`]}" on the "mychannel" channel
     Then response from "tdata_examplecc" to client equal value "valueD"
+
+    When client queries chaincode "tdata_examplecc" with args "putprivatemultiple,collection1,Key_A,ValueA,collection1,Key_B,ValueB,collection1,Key_C,ValueC" on peers "peer0.org1.example.com" on the "mychannel" channel
+    # Stop a single peer in each org to test failover logic (i.e. when the deterministic selection algorithm doesn't work)
+    Given container "peer0.org1.example.com" is stopped
+    And container "peer1.org2.example.com" is stopped
+    Then we wait 10 seconds
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_A" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueA"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_B" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueB"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_C" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueC"
+    And container "peer0.org1.example.com" is started
+    And container "peer1.org2.example.com" is started
+    Then we wait 10 seconds

--- a/test/bddtests/fixtures/fabric/peer/cmd/go.sum
+++ b/test/bddtests/fixtures/fabric/peer/cmd/go.sum
@@ -177,8 +177,8 @@ github.com/hyperledger/fabric-config v0.0.5 h1:khRkm8U9Ghdg8VmZfptgzCFlCzrka8bPf
 github.com/hyperledger/fabric-config v0.0.5/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3 h1:A/hog3Eqz2w3daj5WM99JDDI8KfJFPhw0sKttp1TMc4=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b h1:p8V3EiEhmXtKqmTTrodIDg/MDK81ivyNN0u8XkXzrAU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd h1:anPrsicrIi2ColgWTVPk+TrN42hJIWlfPHSBP9S0ZkM=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/test/bddtests/fixtures/fabric/v1.4/config/configtx.yaml
+++ b/test/bddtests/fixtures/fabric/v1.4/config/configtx.yaml
@@ -123,7 +123,7 @@ Organizations:
             # for cross org gossip communication.  Note, this value is only
             # encoded in the genesis block in the Application section context
             - Host: peer0.org2.example.com
-              Port: 8051
+              Port: 7051
 
 
 

--- a/test/bddtests/fixtures/fabric/v2.2/config/configtx.yaml
+++ b/test/bddtests/fixtures/fabric/v2.2/config/configtx.yaml
@@ -123,7 +123,7 @@ Organizations:
             # for cross org gossip communication.  Note, this value is only
             # encoded in the genesis block in the Application section context
             - Host: peer0.org2.example.com
-              Port: 8051
+              Port: 7051
 
 
 

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cucumber/godog v0.8.1
 	github.com/golang/protobuf v1.3.3
 	github.com/hyperledger/fabric-protos-go v0.0.0
-	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3
+	github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/viper v1.1.1
 	github.com/trustbloc/fabric-peer-test-common v0.1.4

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -98,10 +98,9 @@ github.com/hyperledger/fabric-config v0.0.5 h1:khRkm8U9Ghdg8VmZfptgzCFlCzrka8bPf
 github.com/hyperledger/fabric-config v0.0.5/go.mod h1:YpITBI/+ZayA3XWY5lF302K7PAsFYjEEPM/zr3hegA8=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=
 github.com/hyperledger/fabric-lib-go v1.0.0/go.mod h1:H362nMlunurmHwkYqR5uHL2UDWbQdbfz74n8kbCFsqc=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3 h1:A/hog3Eqz2w3daj5WM99JDDI8KfJFPhw0sKttp1TMc4=
 github.com/hyperledger/fabric-sdk-go v1.0.0-beta3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3 h1:9GEaHWF2PoK4HiWUTSdC0IRlxp4MRae6UTvf4A915to=
-github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200901131551-0c18d1aa90c3/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b h1:p8V3EiEhmXtKqmTTrodIDg/MDK81ivyNN0u8XkXzrAU=
+github.com/hyperledger/fabric-sdk-go v1.0.0-beta3.0.20200910184200-a18228fa486b/go.mod h1:qWE9Syfg1KbwNjtILk70bJLilnmCvllIYFCSY/pa1RU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548/go.mod h1:hGT6jSUVzF6no3QaDSMLGLEHtHSBSefs+MgcDWnmhmo=
 github.com/jmoiron/sqlx v0.0.0-20180124204410-05cef0741ade/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=


### PR DESCRIPTION
A deterministic algorithm is used to select a set of orgs and peers within those orgs to which to disseminate transient data. The same algorithm is then used to select the peers from which to retrieve the data. The algorithm is based on using a modulus operator on the hash of the key and the length of the set of orgs and peers within the orgs. If the length of the set of orgs or peers within the orgs changes between the time the data was disseminated and the time it is retrieved then (most likely) one or more peers that do not have the data could be selected.

This commit adds a fallback mechanism such that, if none of the selected peers has the data, then an attempt is made to retrieve the data from the remaining set of peers within each of the orgs that are selected (based on the key hash). If the data is still not found then the peers of the other orgs are queried.

Also:
- bump the fabric-sdk-go version
- fix the anchor peer port for org2 in the BDD tests

closes #518

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>