### PR TITLE
feat: Added option to always persist transient data

### DIFF
--- a/pkg/collections/transientdata/storeprovider/tdstore.go
+++ b/pkg/collections/transientdata/storeprovider/tdstore.go
@@ -48,11 +48,11 @@ type db interface {
 	GetKey(key api.Key) (*api.Value, error)
 }
 
-func newStore(channelID string, cacheSize int, transientDB db, gossip gossipAdapter, identityDeserializer msp.IdentityDeserializer) *store {
+func newStore(channelID string, cacheSize int, alwaysPersist bool, transientDB db, gossip gossipAdapter, identityDeserializer msp.IdentityDeserializer) *store {
 	logger.Debugf("[%s] Creating new store - cacheSize=%d", channelID, cacheSize)
 	return &store{
 		channelID:            channelID,
-		cache:                cache.New(cacheSize, transientDB),
+		cache:                cache.New(channelID, cacheSize, alwaysPersist, transientDB),
 		gossip:               gossip,
 		identityDeserializer: identityDeserializer,
 	}

--- a/pkg/collections/transientdata/storeprovider/tdstore_test.go
+++ b/pkg/collections/transientdata/storeprovider/tdstore_test.go
@@ -61,7 +61,7 @@ var (
 )
 
 func TestStore(t *testing.T) {
-	s := newStore(channelID, 100, newMockDB(), mocks.NewMockGossipAdapter(), &mocks.IdentityDeserializer{})
+	s := newStore(channelID, 100, false, newMockDB(), mocks.NewMockGossipAdapter(), &mocks.IdentityDeserializer{})
 	require.NotNil(t, s)
 	s.Close()
 
@@ -115,7 +115,7 @@ func TestStorePutAndGet(t *testing.T) {
 		Member(org2MSPID, p1Org2).
 		Member(org2MSPID, p2Org2)
 
-	s := newStore(channelID, 1, newMockDB(), gossip, &mocks.IdentityDeserializer{})
+	s := newStore(channelID, 1, false, newMockDB(), gossip, &mocks.IdentityDeserializer{})
 	require.NotNil(t, s)
 	defer s.Close()
 
@@ -234,7 +234,7 @@ func TestStorePutAndGet(t *testing.T) {
 }
 
 func TestStoreInvalidData(t *testing.T) {
-	s := newStore(channelID, 100, newMockDB(), mocks.NewMockGossipAdapter(), &mocks.IdentityDeserializer{})
+	s := newStore(channelID, 100, false, newMockDB(), mocks.NewMockGossipAdapter(), &mocks.IdentityDeserializer{})
 	require.NotNil(t, s)
 	defer s.Close()
 

--- a/pkg/collections/transientdata/storeprovider/tdstoreprovider.go
+++ b/pkg/collections/transientdata/storeprovider/tdstoreprovider.go
@@ -62,7 +62,7 @@ func (sp *StoreProvider) OpenStore(channelID string) (api.Store, error) {
 		return nil, err
 	}
 
-	store := newStore(channelID, config.GetTransientDataCacheSize(), db, sp.gossipProvider.GetGossipService(), sp.idProvider.GetIdentityDeserializer(channelID))
+	store := newStore(channelID, config.GetTransientDataCacheSize(), config.GetTransientDataAlwaysPersist(), db, sp.gossipProvider.GetGossipService(), sp.idProvider.GetIdentityDeserializer(channelID))
 	sp.stores[channelID] = store
 
 	return store, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ const (
 	confTransientDataLeveldb             = "transientDataLeveldb"
 	confTransientDataCleanupIntervalTime = "coll.transientdata.cleanupExpired.Interval"
 	confTransientDataCacheSize           = "coll.transientdata.cacheSize"
+	confTransientDataAlwaysPersist       = "coll.transientdata.alwaysPersist"
 	confTransientDataPullTimeout         = "peer.gossip.transientData.pullTimeout"
 
 	confOLCollLeveldb              = "offLedgerLeveldb"
@@ -38,6 +39,7 @@ const (
 	defaultTransientDataCleanupIntervalTime = 5 * time.Second
 	defaultTransientDataCacheSize           = 100000
 	defaultTransientDataPullTimeout         = 5 * time.Second
+	defaultTransientDataAlwaysPersist       = true
 
 	defaultOLCollCleanupIntervalTime  = 5 * time.Second
 	defaultOLCollMaxPeersForRetrieval = 2
@@ -109,6 +111,15 @@ func GetTransientDataCacheSize() int {
 		return defaultTransientDataCacheSize
 	}
 	return size
+}
+
+// GetTransientDataAlwaysPersist indicates whether transient data is to always be persisted or persisted only when the cache has exceeded its maximum size
+func GetTransientDataAlwaysPersist() bool {
+	if viper.IsSet(confTransientDataAlwaysPersist) {
+		return viper.GetBool(confTransientDataAlwaysPersist)
+	}
+
+	return defaultTransientDataAlwaysPersist
 }
 
 // GetOLCollLevelDBPath returns the filesystem path that is used to maintain the off-ledger level db

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -68,6 +68,13 @@ func TestGetTransientDataCacheSize(t *testing.T) {
 	assert.Equal(t, 10, GetTransientDataCacheSize())
 }
 
+func TestGetTransientDataAlwaysPersist(t *testing.T) {
+	require.Equal(t, defaultTransientDataAlwaysPersist, GetTransientDataAlwaysPersist())
+
+	viper.Set(confTransientDataAlwaysPersist, false)
+	require.Equal(t, false, GetTransientDataAlwaysPersist())
+}
+
 func TestGetOLLevelDBPath(t *testing.T) {
 	oldVal := viper.Get("peer.fileSystemPath")
 	defer viper.Set("peer.fileSystemPath", oldVal)

--- a/test/bddtests/features/lc_transient_data.feature
+++ b/test/bddtests/features/lc_transient_data.feature
@@ -184,6 +184,28 @@ Feature:
     Then response from "tdata_examplecc" to client equal value "ValueB"
     And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_C" on peers "peer0.org2.example.com" on the "mychannel" channel
     Then response from "tdata_examplecc" to client equal value "ValueC"
-    And container "peer0.org1.example.com" is started
+
+    # Restart all peers to test transient data persistence
+    Given container "peer1.org1.example.com" is stopped
+    And container "peer0.org2.example.com" is stopped
+    Then container "peer0.org1.example.com" is started
+    And container "peer1.org1.example.com" is started
+    And container "peer0.org2.example.com" is started
     And container "peer1.org2.example.com" is started
     Then we wait 10 seconds
+
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_A" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueA"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_B" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueB"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_C" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueC"
+    Then we wait 60 seconds
+
+    # The data should have expired
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_A" on peers "peer0.org1.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value ""
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_B" on peers "peer0.org1.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value ""
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_C" on peers "peer0.org1.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value ""

--- a/test/bddtests/features/transient_data.feature
+++ b/test/bddtests/features/transient_data.feature
@@ -193,6 +193,28 @@ Feature:
     Then response from "tdata_examplecc" to client equal value "ValueB"
     And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_C" on peers "peer0.org2.example.com" on the "mychannel" channel
     Then response from "tdata_examplecc" to client equal value "ValueC"
-    And container "peer0.org1.example.com" is started
+
+    # Restart all peers to test transient data persistence
+    Given container "peer1.org1.example.com" is stopped
+    And container "peer0.org2.example.com" is stopped
+    Then container "peer0.org1.example.com" is started
+    And container "peer1.org1.example.com" is started
+    And container "peer0.org2.example.com" is started
     And container "peer1.org2.example.com" is started
     Then we wait 10 seconds
+
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_A" on peers "peer0.org1.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueA"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_B" on peers "peer1.org1.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueB"
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_C" on peers "peer0.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value "ValueC"
+    Then we wait 60 seconds
+
+    # The data should have expired
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_A" on peers "peer1.org2.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value ""
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_B" on peers "peer0.org1.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value ""
+    And client queries chaincode "tdata_examplecc" with args "getprivate,collection1,Key_C" on peers "peer1.org1.example.com" on the "mychannel" channel
+    Then response from "tdata_examplecc" to client equal value ""


### PR DESCRIPTION
Previously transient data was only stored in memory unless the maximum cache size had been exceeded, at which time the oldest entries were offloaded to a database. This commit adds a configuration parameter to allow transient data to always be persisted (as well as cached). This way, if a peer goes down temporarily then the transient data will still be available when it comes back up.

closes #520

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>