### PR TITLE
fix: Cache config block only if newer

### DIFF
--- a/pkg/blkstorage/cdbblkstorage/blockcache.go
+++ b/pkg/blkstorage/cdbblkstorage/blockcache.go
@@ -117,6 +117,14 @@ func (c *blockCache) setConfigBlock(b *common.Block) {
 		return
 	}
 
+	cb := c.getConfigBlock()
+	if cb != nil && cb.Header.Number >= b.Header.Number {
+		// We already have the latest config block
+		logger.Debugf("[%s] Not caching config block [%d] since we already have config block [%d] cached", c.ledgerID, b.Header.Number, cb.Header.Number)
+
+		return
+	}
+
 	logger.Debugf("[%s] Caching config block [%d]", c.ledgerID, b.Header.Number)
 
 	c.configBlock.Store(b)

--- a/pkg/blkstorage/cdbblkstorage/blockcache_test.go
+++ b/pkg/blkstorage/cdbblkstorage/blockcache_test.go
@@ -92,6 +92,16 @@ func TestCache(t *testing.T) {
 		b, err = c.getBlockByHash(protoutil.BlockHeaderHash(configBlock.Header))
 		require.NoError(t, err)
 		require.Equal(t, configBlock, b)
+
+		builder = mocks.NewBlockBuilder(channel1, 10)
+		builder.ConfigUpdate()
+		configBlock = builder.Build()
+
+		// Should not update config block since the block number is lower than the existing config block number
+		c.put(configBlock)
+		cb := c.getConfigBlock()
+		require.NotNil(t, cb)
+		require.Equal(t, uint64(1000), cb.Header.Number)
 	})
 
 	t.Run("Load from retriever", func(t *testing.T) {


### PR DESCRIPTION
Ensure that the new block height of the loaded config block is greater than the existing config block before pinning it.

closes #543

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>