### PR TITLE
feat: Added block handler to Block Publisher

### DIFF
--- a/mod/peer/gossip/api/gossipapi.go
+++ b/mod/peer/gossip/api/gossipapi.go
@@ -46,6 +46,9 @@ type ChaincodeUpgradeHandler func(txMetadata TxMetadata, chaincodeName string) e
 // LSCCWriteHandler handles chaincode instantiation/upgrade events
 type LSCCWriteHandler func(txMetadata TxMetadata, chaincodeName string, ccData *ccprovider.ChaincodeData, ccp *pb.CollectionConfigPackage) error
 
+// PublishedBlockHandler handles a published block
+type PublishedBlockHandler func(block *cb.Block) error
+
 // BlockHandler allows clients to add handlers for various block events
 type BlockHandler interface {
 	// AddCCUpgradeHandler adds a handler for chaincode upgrades
@@ -64,6 +67,8 @@ type BlockHandler interface {
 	AddLSCCWriteHandler(handler LSCCWriteHandler)
 	// AddCCEventHandler adds a handler for chaincode events
 	AddCCEventHandler(handler ChaincodeEventHandler)
+	// AddBlockHandler adds a handler for published blocks
+	AddBlockHandler(handler PublishedBlockHandler)
 	//LedgerHeight returns current in memory ledger height
 	LedgerHeight() uint64
 }

--- a/pkg/common/blockvisitor/context.go
+++ b/pkg/common/blockvisitor/context.go
@@ -37,6 +37,9 @@ const (
 
 	// ConfigUpdateHandlerErr indicates that the configuration update handler returned an error
 	ConfigUpdateHandlerErr Category = "CONFIG_UPDATE_HANDLER_ERROR"
+
+	// BlockHandlerErr indicates that the block handler returned an error
+	BlockHandlerErr Category = "BLOCK_HANDLER_ERROR"
 )
 
 // Context holds the context at the time of a Visitor error

--- a/pkg/gossip/blockpublisher/blockpublisher_test.go
+++ b/pkg/gossip/blockpublisher/blockpublisher_test.go
@@ -398,3 +398,22 @@ func TestPublisher_Error(t *testing.T) {
 
 	assert.EqualValues(t, 1101, p.LedgerHeight())
 }
+
+func TestPublisher_PublishBlockEvents(t *testing.T) {
+	p := New(channel1)
+	require.NotNil(t, p)
+	defer p.Close()
+
+	handler := mocks.NewMockBlockHandler().WithError(fmt.Errorf("injected error"))
+	p.AddBlockHandler(handler.HandleBlock)
+
+	b := mocks.NewBlockBuilder(channel1, 1100)
+
+	p.Publish(b.Build(), nil)
+
+	// Wait a bit for the events to be published
+	time.Sleep(500 * time.Millisecond)
+
+	require.Equal(t, 1, handler.NumBlocks())
+	require.EqualValues(t, 1101, p.LedgerHeight())
+}

--- a/pkg/mocks/mockblockhandler.go
+++ b/pkg/mocks/mockblockhandler.go
@@ -26,6 +26,7 @@ type MockBlockHandler struct {
 	numCCUpgradeEvents int32
 	numConfigUpdates   int32
 	numLSCCWrites      int32
+	numBlocks          int32
 	err                error
 }
 
@@ -80,6 +81,11 @@ func (m *MockBlockHandler) NumConfigUpdates() int {
 	return int(atomic.LoadInt32(&m.numConfigUpdates))
 }
 
+// NumBlocks returns the number of blocks handled
+func (m *MockBlockHandler) NumBlocks() int {
+	return int(atomic.LoadInt32(&m.numBlocks))
+}
+
 // HandleRead handles a read event by incrementing the read counter
 func (m *MockBlockHandler) HandleRead(txMetadata api.TxMetadata, namespace string, kvRead *kvrwset.KVRead) error {
 	atomic.AddInt32(&m.numReads, 1)
@@ -125,5 +131,11 @@ func (m *MockBlockHandler) HandleConfigUpdate(blockNum uint64, configUpdate *cb.
 // HandleLSCCWrite handles an LSCC write by incrementing the LSCC write counter
 func (m *MockBlockHandler) HandleLSCCWrite(txMetadata api.TxMetadata, chaincodeName string, ccData *ccprovider.ChaincodeData, ccp *pb.CollectionConfigPackage) error {
 	atomic.AddInt32(&m.numLSCCWrites, 1)
+	return m.err
+}
+
+// HandleBlock handles a block by incrementing the block counter
+func (m *MockBlockHandler) HandleBlock(block *cb.Block) error {
+	atomic.AddInt32(&m.numBlocks, 1)
 	return m.err
 }

--- a/pkg/mocks/mockblockpublisher.go
+++ b/pkg/mocks/mockblockpublisher.go
@@ -22,6 +22,7 @@ type MockBlockPublisher struct {
 	HandleCollHashRead  gossipapi.CollHashReadHandler
 	HandleLSCCWrite     gossipapi.LSCCWriteHandler
 	HandleCCEvent       gossipapi.ChaincodeEventHandler
+	HandleBlock         gossipapi.PublishedBlockHandler
 }
 
 // NewBlockPublisher returns a mock block publisher
@@ -67,6 +68,11 @@ func (m *MockBlockPublisher) AddLSCCWriteHandler(handler gossipapi.LSCCWriteHand
 // AddCCEventHandler adds a chaincode event handler
 func (m *MockBlockPublisher) AddCCEventHandler(handler gossipapi.ChaincodeEventHandler) {
 	m.HandleCCEvent = handler
+}
+
+// AddBlockHandler adds a block handler
+func (m *MockBlockPublisher) AddBlockHandler(handler gossipapi.PublishedBlockHandler) {
+	m.HandleBlock = handler
 }
 
 // Publish is not implemented and panics if invoked


### PR DESCRIPTION
Clients may now register to handle entire published blocks.

closes #552

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>