### PR TITLE
fix: Non-committing peer returns error when handling private data state request

### DIFF
--- a/pkg/pvtdatastorage/cdbpvtdatastore/test_exports.go
+++ b/pkg/pvtdatastorage/cdbpvtdatastore/test_exports.go
@@ -15,16 +15,16 @@ import (
 	couchdb "github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/statedb/statecouchdb"
 	"github.com/hyperledger/fabric/core/ledger/pvtdatapolicy"
 	"github.com/hyperledger/fabric/core/ledger/pvtdatastorage"
-	xstorageapi "github.com/hyperledger/fabric/extensions/storage/api"
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/fabric-peer-ext/pkg/pvtdatastorage/common"
 	"github.com/trustbloc/fabric-peer-ext/pkg/testutil"
 )
 
 // StoreEnv provides the  store env for testing
 type StoreEnv struct {
 	t                 testing.TB
-	TestStoreProvider xstorageapi.PrivateDataProvider
+	TestStoreProvider common.Provider
 	TestStore         *store
 	ledgerid          string
 	btlPolicy         pvtdatapolicy.BTLPolicy

--- a/pkg/pvtdatastorage/common/api.go
+++ b/pkg/pvtdatastorage/common/api.go
@@ -1,0 +1,28 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	xstorageapi "github.com/hyperledger/fabric/extensions/storage/api"
+)
+
+// StoreExt extends PrivateDataStore with additional functions
+type StoreExt interface {
+	xstorageapi.PrivateDataStore
+	UpdateLastCommittedBlockNum(blockNum uint64)
+}
+
+// Provider manages a private data store
+type Provider interface {
+	OpenStore(ledgerID string) (StoreExt, error)
+	Close()
+}
+
+// CacheProvider manages a private data cache
+type CacheProvider interface {
+	Create(ledgerID string, lastCommittedBlockNum uint64) StoreExt
+}


### PR DESCRIPTION
When a non-committing peer receives a Gossip request for private data for a specific block it would return an error that the last committed block was not at the desired height. This was because the 'lastCommittedBlockNum' is cached and only updated in the Commit function. Since Commit is never called on a non-committing peer, the value for 'lastCommittedBlockNum' was stuck at the value it was set to when the peer was started.

This commit registers a block handler with the Block Publisher in the CouchDB private data store to update 'lastCommittedBlockNum' when it receives a published block.

closes #547

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>