### PR TITLE
refactor: Asynchronous Gossip app-data request handler

### DIFF
--- a/pkg/gossip/appdata/handlerregistry.go
+++ b/pkg/gossip/appdata/handlerregistry.go
@@ -16,8 +16,13 @@ import (
 
 var logger = flogging.MustGetLogger("ext_dispatcher")
 
+// Responder responds to data requests
+type Responder interface {
+	Respond(data []byte)
+}
+
 // Handler handles an application data request
-type Handler func(channelID string, request *gproto.AppDataRequest) ([]byte, error)
+type Handler func(channelID string, request *gproto.AppDataRequest, responder Responder)
 
 // HandlerRegistry manages handlers for application-specific Gossip messages
 type HandlerRegistry struct {

--- a/pkg/gossip/appdata/handlerregistry_test.go
+++ b/pkg/gossip/appdata/handlerregistry_test.go
@@ -19,9 +19,7 @@ func TestHandlerRegistry(t *testing.T) {
 
 	const dataType = "dataType1"
 
-	handler := func(channelID string, request *gproto.AppDataRequest) ([]byte, error) {
-		return nil, nil
-	}
+	handler := func(channelID string, request *gproto.AppDataRequest, responder Responder) {}
 
 	err := r.Register(dataType, handler)
 	require.NoError(t, err)

--- a/pkg/gossip/appdata/retriever.go
+++ b/pkg/gossip/appdata/retriever.go
@@ -143,7 +143,7 @@ func (r *Retriever) Retrieve(ctxt context.Context, request *Request, responseHan
 			break
 		}
 
-		logger.Infof("[%s] Could not get all values on attempt %d for %s. Got: %s", r.ChannelID(), attempt, request.Payload, values)
+		logger.Infof("[%s] Could not get all values on attempt %d", r.ChannelID(), attempt)
 	}
 
 	return values, nil

--- a/pkg/gossip/state/cacheupdater_test.go
+++ b/pkg/gossip/state/cacheupdater_test.go
@@ -213,9 +213,10 @@ func TestHandleCacheUpdatesRequest(t *testing.T) {
 
 		updateHandler = NewUpdateHandler(providers)
 
-		respBytes, err := updateHandler.handleCacheUpdatesRequest(channel1, req)
-		require.NoError(t, err)
-		require.Nil(t, respBytes)
+		resp := &mockResponder{}
+
+		updateHandler.handleCacheUpdatesRequest(channel1, req, resp)
+		require.Nil(t, resp.data)
 	})
 
 	t.Run("With success response", func(t *testing.T) {
@@ -225,9 +226,11 @@ func TestHandleCacheUpdatesRequest(t *testing.T) {
 
 		require.NotPanics(t, func() { SaveCacheUpdates(channel1, 1001, []byte("cache-updates")) })
 
-		respBytes, err := updateHandler.handleCacheUpdatesRequest(channel1, req)
+		resp := &mockResponder{}
+
+		updateHandler.handleCacheUpdatesRequest(channel1, req, resp)
 		require.NoError(t, err)
-		require.NotNil(t, respBytes)
+		require.NotNil(t, resp.data)
 	})
 
 	t.Run("Cache updates not found", func(t *testing.T) {
@@ -235,9 +238,11 @@ func TestHandleCacheUpdatesRequest(t *testing.T) {
 
 		updateHandler = NewUpdateHandler(providers)
 
-		respBytes, err := updateHandler.handleCacheUpdatesRequest(channel1, req)
+		resp := &mockResponder{}
+
+		updateHandler.handleCacheUpdatesRequest(channel1, req, resp)
 		require.NoError(t, err)
-		require.Nil(t, respBytes)
+		require.Nil(t, resp.data)
 	})
 
 	t.Run("With unmarshal error", func(t *testing.T) {
@@ -251,8 +256,17 @@ func TestHandleCacheUpdatesRequest(t *testing.T) {
 
 		require.NotPanics(t, func() { SaveCacheUpdates(channel1, 1001, []byte("cache-updates")) })
 
-		respBytes, err := updateHandler.handleCacheUpdatesRequest(channel1, req)
-		require.EqualError(t, err, errExpected.Error())
-		require.Nil(t, respBytes)
+		resp := &mockResponder{}
+
+		updateHandler.handleCacheUpdatesRequest(channel1, req, resp)
+		require.Nil(t, resp.data)
 	})
+}
+
+type mockResponder struct {
+	data []byte
+}
+
+func (m *mockResponder) Respond(data []byte) {
+	m.data = data
 }

--- a/test/cc/hellocc/hellocc.go
+++ b/test/cc/hellocc/hellocc.go
@@ -202,13 +202,15 @@ func (h *HelloCC) getHelloMessage(stub shim.ChaincodeStubInterface) pb.Response 
 
 // handleRequest is a server-side handler for the 'Hello!' Gossip request. This function
 // responds to the peer with a hello response.
-func (h *HelloCC) handleRequest(channelID string, req *gproto.AppDataRequest) ([]byte, error) {
+func (h *HelloCC) handleRequest(channelID string, req *gproto.AppDataRequest, responder appdata.Responder) {
 	logger.Infof("[%s] Got hello request: %s", channelID, req.Request)
 
 	var helloRequest helloRequest
 	err := json.Unmarshal(req.Request, &helloRequest)
 	if err != nil {
-		return nil, err
+		logger.Errorf("[%s] Error unmarshalling hello request: %s", channelID, err)
+
+		return
 	}
 
 	response := helloResponse{
@@ -218,12 +220,14 @@ func (h *HelloCC) handleRequest(channelID string, req *gproto.AppDataRequest) ([
 
 	respBytes, err := json.Marshal(response)
 	if err != nil {
-		return nil, err
+		logger.Errorf("[%s] Error marshalling hello request: %s", channelID, err)
+
+		return
 	}
 
 	logger.Infof("[%s] Returning hello response: %s", channelID, respBytes)
 
-	return respBytes, nil
+	responder.Respond(respBytes)
 }
 
 // responseHandler is a client-side handler of a response from a peer. It ensures that


### PR DESCRIPTION
The reqponses for app-data requests are now asynchronous. The request handler is provided a 'responder' to which the handler may respond immediately or in the (near) future.

closes #550

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>