### PR TITLE
feat: Validation Policy

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,6 +89,12 @@ const (
 
 	defaultStateCacheGossipTimeout = 500 * time.Millisecond
 	defaultStateCacheRetentionSize = 20
+
+	confValidationCommitterTransactionThreshold  = "peer.validation.transactionThreshold.committer"
+	confValidationSinglePeerTransactionThreshold = "peer.validation.transactionThreshold.validator"
+
+	defaultValidationCommitterTransactionThreshold  = 5
+	defaultValidationSinglePeerTransactionThreshold = 30
 )
 
 // DBType is the database type
@@ -362,4 +368,27 @@ func GetStateCacheRetentionSize() int {
 // would still be performed during validation.
 func IsSkipCheckForDupTxnID() bool {
 	return viper.GetBool(confSkipCheckForDupTxnID)
+}
+
+// GetValidationCommitterTransactionThreshold returns the transaction threshold at which the committer will validate the block.
+// If the number of transactions is less than this threshold (even if the committer does not have the validator role) it will
+// still validate the block. If set to 0 then the committer won't perform validation unless there are no validators available.
+func GetValidationCommitterTransactionThreshold() int {
+	threshold := viper.GetInt(confValidationCommitterTransactionThreshold)
+	if threshold <= 0 {
+		return defaultValidationCommitterTransactionThreshold
+	}
+
+	return threshold
+}
+
+// GetValidationSinglePeerTransactionThreshold returns the transaction threshold at which only a single peer with the validator role will
+// validate the block, i.e. if the number of transactions is less than this threshold then only a single validator is chosen.
+func GetValidationSinglePeerTransactionThreshold() int {
+	threshold := viper.GetInt(confValidationSinglePeerTransactionThreshold)
+	if threshold <= 0 {
+		return defaultValidationSinglePeerTransactionThreshold
+	}
+
+	return threshold
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -313,3 +313,23 @@ func TestGetStateCacheRetentionSize(t *testing.T) {
 	viper.Set(confStateCacheRetentionSize, 55)
 	require.Equal(t, 55, GetStateCacheRetentionSize())
 }
+
+func TestGetValidationSinglePeerTransactionThreshold(t *testing.T) {
+	oldVal := viper.Get(confValidationSinglePeerTransactionThreshold)
+	defer viper.Set(confValidationSinglePeerTransactionThreshold, oldVal)
+
+	require.Equal(t, defaultValidationSinglePeerTransactionThreshold, GetValidationSinglePeerTransactionThreshold())
+
+	viper.Set(confValidationSinglePeerTransactionThreshold, 23)
+	require.Equal(t, 23, GetValidationSinglePeerTransactionThreshold())
+}
+
+func TestGetValidationCommitterTransactionThreshold(t *testing.T) {
+	oldVal := viper.Get(confValidationCommitterTransactionThreshold)
+	defer viper.Set(confValidationCommitterTransactionThreshold, oldVal)
+
+	require.Equal(t, defaultValidationCommitterTransactionThreshold, GetValidationCommitterTransactionThreshold())
+
+	viper.Set(confValidationCommitterTransactionThreshold, 13)
+	require.Equal(t, 13, GetValidationCommitterTransactionThreshold())
+}

--- a/pkg/roles/roles.go
+++ b/pkg/roles/roles.go
@@ -23,21 +23,16 @@ const (
 )
 
 // Role is the role of the peer
-type Role string
+type Role = string
 
 // Roles is a set of peer roles
 type Roles []Role
-
-// New creates Roles from the given slice of roles
-func New(r ...Role) Roles {
-	return Roles(r)
-}
 
 // FromStrings creates Roles from the given slice of strings
 func FromStrings(r ...string) Roles {
 	rls := make(Roles, len(r))
 	for i, s := range r {
-		rls[i] = Role(strings.ToLower(s))
+		rls[i] = strings.ToLower(s)
 	}
 	return rls
 }
@@ -98,7 +93,7 @@ func GetRoles() []Role {
 func AsString() []string {
 	var ret []string
 	for role := range getRoles() {
-		ret = append(ret, string(role))
+		ret = append(ret, role)
 	}
 	return ret
 }
@@ -125,7 +120,7 @@ func initRoles() map[Role]struct{} {
 
 	for _, r := range strings.Split(strRoles, ",") {
 		r = strings.ToLower(strings.TrimSpace(r))
-		rolesMap[Role(r)] = exists
+		rolesMap[r] = exists
 	}
 
 	return rolesMap

--- a/pkg/roles/roles_test.go
+++ b/pkg/roles/roles_test.go
@@ -28,7 +28,7 @@ const (
 )
 
 func TestRoles_Contains(t *testing.T) {
-	roles := New(role1, role2, role3)
+	roles := Roles{role1, role2, role3}
 
 	require.True(t, roles.Contains(role1))
 	require.True(t, roles.Contains(role2))

--- a/pkg/validation/validationpolicy/mocks/mockpolicyevaluator.go
+++ b/pkg/validation/validationpolicy/mocks/mockpolicyevaluator.go
@@ -1,0 +1,61 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mocks
+
+import (
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric/common/policies"
+	mspi "github.com/hyperledger/fabric/msp"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+)
+
+// PolicyProvider is a mock policy provider
+type PolicyProvider struct {
+}
+
+// NewPolicyProvider returns a new mock policy provider
+func NewPolicyProvider() *PolicyProvider {
+	return &PolicyProvider{}
+}
+
+// NewPolicy returns a new policy evaluator
+func (pp *PolicyProvider) NewPolicy(policyBytes []byte) (policies.Policy, proto.Message, error) {
+	return NewPolicyEvaluator(), nil, nil
+}
+
+// PolicyEvaluator is a mock policy evaluator
+type PolicyEvaluator struct {
+}
+
+// NewPolicyEvaluator returns a new mock policy ealuator
+func NewPolicyEvaluator() *PolicyEvaluator {
+	return &PolicyEvaluator{}
+}
+
+// EvaluateSignedData takes a set of SignedData and evaluates whether this set of signatures satisfies
+// the policy with the given bytes
+func (pe *PolicyEvaluator) EvaluateSignedData(signatureSet []*protoutil.SignedData) error {
+	for _, data := range signatureSet {
+		if len(data.Data) == 0 {
+			return errors.New("Got empty data")
+		}
+		if len(data.Signature) == 0 {
+			return errors.New("Got empty signature")
+		}
+		if len(data.Identity) == 0 {
+			return errors.New("Got empty identity")
+		}
+	}
+	return nil
+}
+
+// EvaluateIdentities takes an array of identities and evaluates whether
+// they satisfy the policy
+func (pe *PolicyEvaluator) EvaluateIdentities(identities []mspi.Identity) error {
+	panic("not implemented")
+}

--- a/pkg/validation/validationpolicy/peergroups.go
+++ b/pkg/validation/validationpolicy/peergroups.go
@@ -1,0 +1,82 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationpolicy
+
+import (
+	"sort"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+)
+
+type peerGroups []discovery.PeerGroup
+
+func (g peerGroups) String() string {
+	s := "("
+
+	for i, p := range g {
+		s += p.String()
+		if i+1 < len(g) {
+			s += ", "
+		}
+	}
+
+	s += ")"
+
+	return s
+}
+
+func (g peerGroups) sort() {
+	// First sort each peer group
+	for _, pg := range g {
+		pg.Sort()
+	}
+
+	// Now sort the peer groups
+	sort.Sort(g)
+}
+
+// contains returns true if the given peer is contained within any of the peer groups
+func (g peerGroups) contains(p *discovery.Member) bool {
+	for _, pg := range g {
+		if pg.Contains(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAll returns true if all of the peers within the given peer group are contained within the peer groups
+func (g peerGroups) containsAll(peerGroup discovery.PeerGroup) bool {
+	for _, p := range peerGroup {
+		if !g.contains(p) {
+			return false
+		}
+	}
+	return true
+}
+
+// containsAny returns true if any of the peers within the given peer group are contained within the peer groups
+func (g peerGroups) containsAny(peerGroup discovery.PeerGroup) bool {
+	for _, pg := range g {
+		if pg.ContainsAny(peerGroup) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g peerGroups) Len() int {
+	return len(g)
+}
+
+func (g peerGroups) Less(i, j int) bool {
+	return g[i].String() < g[j].String()
+}
+
+func (g peerGroups) Swap(i, j int) {
+	g[i], g[j] = g[j], g[i]
+}

--- a/pkg/validation/validationpolicy/peergroups_test.go
+++ b/pkg/validation/validationpolicy/peergroups_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationpolicy
+
+import (
+	"testing"
+
+	gdiscovery "github.com/hyperledger/fabric/gossip/discovery"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+)
+
+const (
+	org1MSP = "org1MSP"
+
+	p1Endpoint = "p1.org1.com"
+	p2Endpoint = "p2.org1.com"
+	p3Endpoint = "p3.org1.com"
+	p4Endpoint = "p4.org1.com"
+	p5Endpoint = "p5.org1.com"
+	p6Endpoint = "p6.org1.com"
+	p7Endpoint = "p7.org1.com"
+)
+
+var (
+	p1 = newMember(org1MSP, p1Endpoint)
+	p2 = newMember(org1MSP, p2Endpoint)
+	p3 = newMember(org1MSP, p3Endpoint)
+	p4 = newMember(org1MSP, p4Endpoint)
+	p5 = newMember(org1MSP, p5Endpoint)
+	p6 = newMember(org1MSP, p6Endpoint)
+	p7 = newMember(org1MSP, p7Endpoint)
+)
+
+func TestPeerGroupsSort(t *testing.T) {
+	pg1 := discovery.PeerGroup{p2, p1, p3}
+	pg2 := discovery.PeerGroup{p5, p4}
+	pg3 := discovery.PeerGroup{p7, p6}
+
+	pgs := peerGroups{pg3, pg1, pg2}
+
+	pgs.sort()
+
+	// The peer groups should be sorted
+	require.Equal(t, pg1, pgs[0])
+	require.Equal(t, pg2, pgs[1])
+	require.Equal(t, pg3, pgs[2])
+
+	// Each peer group should be sorted
+	require.Equal(t, p1, pg1[0])
+	require.Equal(t, p2, pg1[1])
+	require.Equal(t, p3, pg1[2])
+
+	require.Equal(t, p4, pg2[0])
+	require.Equal(t, p5, pg2[1])
+
+	require.Equal(t, p6, pg3[0])
+	require.Equal(t, p7, pg3[1])
+}
+
+func TestPeerGroupsContains(t *testing.T) {
+	pg1 := discovery.PeerGroup{p1, p2, p3}
+	pg2 := discovery.PeerGroup{p3, p4, p5}
+	pg3 := discovery.PeerGroup{p1, p4}
+	pg4 := discovery.PeerGroup{p2, p5, p6}
+	pg5 := discovery.PeerGroup{p6, p7}
+
+	pgs1 := peerGroups{pg1, pg2}
+
+	require.True(t, pgs1.contains(p1))
+	require.True(t, pgs1.contains(p2))
+	require.True(t, pgs1.contains(p3))
+	require.True(t, pgs1.contains(p4))
+	require.True(t, pgs1.contains(p5))
+	require.False(t, pgs1.contains(p6))
+
+	require.True(t, pgs1.containsAll(pg3))
+	require.False(t, pgs1.containsAll(pg4))
+	require.True(t, pgs1.containsAny(pg4))
+	require.False(t, pgs1.containsAny(pg5))
+}
+
+func TestPeerGroups_String(t *testing.T) {
+	pg1 := discovery.PeerGroup{p2, p1, p3}
+	pg2 := discovery.PeerGroup{p5, p4}
+	pg3 := discovery.PeerGroup{p7, p6}
+
+	pgs := peerGroups{pg3, pg1, pg2}
+
+	require.Equal(t, "([p7.org1.com, p6.org1.com], [p2.org1.com, p1.org1.com, p3.org1.com], [p5.org1.com, p4.org1.com])", pgs.String())
+}
+
+func newMember(mspID, endpoint string) *discovery.Member {
+	return &discovery.Member{
+		NetworkMember: gdiscovery.NetworkMember{
+			Endpoint: endpoint,
+		},
+		MSPID: mspID,
+	}
+}

--- a/pkg/validation/validationpolicy/peergroupselector.go
+++ b/pkg/validation/validationpolicy/peergroupselector.go
@@ -1,0 +1,171 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationpolicy
+
+import (
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/pkg/errors"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+// peerGroupSelector selects the groups of peers for validating a block based on a validation policy
+type peerGroupSelector struct {
+	policy     *policy
+	channelID  string
+	block      *cb.Block
+	committers discovery.PeerGroup
+	validators discovery.PeerGroup
+}
+
+func newPeerGroupSelector(channelID string, policy *policy, disc *discovery.Discovery, block *cb.Block) *peerGroupSelector {
+	return &peerGroupSelector{
+		policy:     policy,
+		channelID:  channelID,
+		block:      block,
+		committers: peersWithRole(disc, roles.CommitterRole),
+		validators: peersWithRole(disc, roles.ValidatorRole),
+	}
+}
+
+// groups selects the groups of peers for validating a block based on a validation policy. The choice of peers is based on the following criteria:
+//
+// (1) committerTransactionThreshold - This transaction threshold indicates that the committer should validate the block if
+//    the number of transactions is less than this value, even if the committer does not have the validator role. If set to 0
+//    then the committer (without the validator role) will never perform validation unless there are no validators available.
+//
+// (2) singlePeerTransactionThreshold - This transaction threshold indicates that only a single peer with the validator role should
+//    validate the block if the number of transactions is less than this threshold.
+//
+// Example 1:
+//  Given:
+//   - Peer0 = committer
+//   - Peer1 = validator
+//   - Peer2 = validator
+//   - committerTransactionThreshold = 5
+//   - singlePeerTransactionThreshold = 20
+//  If:
+//   - Block 1 has 4 transactions then the peer group is [Peer0] (since Peer0 is a committer)
+//   - Block 2 has 5 transactions then the peer group is [Peer1 or Peer2]
+//   - Block 3 has 20 transactions then the peer group is [Peer1 and Peer2]
+//
+// Example 2:
+//   Given:
+//   - Peer0 = committer,validator
+//   - Peer1 = validator
+//   - Peer2 = validator
+//   - committerTransactionThreshold = 5
+//   - singlePeerTransactionThreshold = 20
+//   If:
+//   - Block 1 has 4 transactions then the peer group is [Peer0] (since Peer0 is a committer)
+//   - Block 2 has 5 transactions then the peer group is [Peer0] (since Peer0 is a committer and validator)
+//   - Block 3 has 20 transactions then the peer group is [Peer0 and Peer1 and Peer2]
+//
+func (s *peerGroupSelector) groups() (peerGroups, error) {
+	logger.Debugf("[%s] Selecting peer groups to validate block %d ...", s.channelID, s.block.Header.Number)
+
+	numTransactions := len(s.block.Data.Data)
+
+	var selectedValidator *discovery.Member
+
+	// check committer threshold
+	if numTransactions < s.policy.committerTransactionThreshold {
+		selectedValidator = s.selectCommitter()
+	}
+
+	// check single peer threshold
+	if selectedValidator == nil && numTransactions < s.policy.singlePeerTransactionThreshold {
+		selectedValidator = s.selectValidator()
+	}
+
+	// select committer if no validators
+	if selectedValidator == nil && len(s.validators) == 0 {
+		logger.Debugf("[%s] There are no validators for block %d. Selecting the committer to validate the block.", s.channelID, s.block.Header.Number)
+
+		selectedValidator = s.selectCommitter()
+
+		if selectedValidator == nil {
+			logger.Errorf("[%s] There are no validators or committers for block %d. Please ensure that at least one peer has the committer role.", s.channelID, s.block.Header.Number)
+
+			return nil, errors.Errorf("there are no validators or committers for block %d", s.block.Header.Number)
+		}
+	}
+
+	var groups peerGroups
+
+	if selectedValidator != nil {
+		groups = asPeerGroups(selectedValidator)
+	} else {
+		groups = asPeerGroups(s.validators...)
+	}
+
+	groups.sort()
+
+	logger.Debugf("[%s] Peer groups for block %d: %s", s.channelID, s.block.Header.Number, groups)
+
+	return groups, nil
+}
+
+func (s *peerGroupSelector) selectCommitter() *discovery.Member {
+	if len(s.committers) == 0 {
+		return nil
+	}
+
+	peer := s.committers[0]
+
+	logger.Debugf("[%s] Selected validator is %s (committer) since the number of transactions in block %d is %d which is less than the committer threshold %d",
+		s.channelID, peer.Endpoint, s.block.Header.Number, len(s.block.Data.Data), s.policy.committerTransactionThreshold)
+
+	return peer
+}
+
+func (s *peerGroupSelector) selectValidator() *discovery.Member {
+	// First check if the peer is also a validator. If so, select the committing peer since it's more efficient, i.s. no Gossip required.
+	for _, peer := range s.committers {
+		if peer.HasRole(roles.ValidatorRole) {
+			logger.Debugf("[%s] Selected validator is %s (committer,validator) since the number of transactions in block %d is %d which is less than the single validator threshold %d",
+				s.channelID, peer.Endpoint, s.block.Header.Number, len(s.block.Data.Data), s.policy.singlePeerTransactionThreshold)
+
+			return peer
+		}
+	}
+
+	if len(s.validators) == 0 {
+		return nil
+	}
+
+	// Pick one peer deterministically from the set of validators
+	peer := s.validators[s.block.Header.Number%uint64(len(s.validators))]
+
+	logger.Debugf("[%s] Selected validator is %s since the number of transactions in block %d is %d which is less than the single validator threshold %d",
+		s.channelID, peer.Endpoint, s.block.Header.Number, len(s.block.Data.Data), s.policy.singlePeerTransactionThreshold)
+
+	return peer
+}
+
+func peersWithRole(disc *discovery.Discovery, role roles.Role) discovery.PeerGroup {
+	return disc.GetMembers(
+		func(member *discovery.Member) bool {
+			if member.MSPID != disc.Self().MSPID || member.Properties == nil {
+				return false
+			}
+
+			return roles.FromStrings(member.Properties.Roles...).Contains(role)
+		},
+	)
+}
+
+func asPeerGroups(peers ...*discovery.Member) peerGroups {
+	groups := make(peerGroups, len(peers))
+
+	for i, v := range peers {
+		groups[i] = discovery.PeerGroup{v}
+	}
+
+	return groups
+}

--- a/pkg/validation/validationpolicy/peergroupselector_test.go
+++ b/pkg/validation/validationpolicy/peergroupselector_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationpolicy
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/gossip/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	extmocks "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+)
+
+//go:generate counterfeiter -o ./mocks/policiesprovider.gen.go --fake-name PoliciesProvider github.com/hyperledger/fabric/common/policies.Provider
+
+var (
+	org1MSPID = "Org1MSP"
+	org2MSPID = "Org2MSP"
+
+	p1Org1Endpoint = "p1.org1.com"
+	p1Org1PKIID    = common.PKIidType("pkiid_P1O1")
+	p2Org1Endpoint = "p2.org1.com"
+	p2Org1PKIID    = common.PKIidType("pkiid_P2O1")
+	p3Org1Endpoint = "p3.org1.com"
+	p3Org1PKIID    = common.PKIidType("pkiid_P3O1")
+
+	p1Org2Endpoint = "p1.org2.com"
+	p1Org2PKIID    = common.PKIidType("pkiid_P1O2")
+)
+
+// Ensure that the roles are initialized
+var _ = roles.GetRoles()
+
+func TestEvaluator_PeerGroups(t *testing.T) {
+	channelID := "testchannel"
+
+	bb := extmocks.NewBlockBuilder(channelID, 1000)
+	bb.Transaction("tx1", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx2", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx3", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx4", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx5", peer.TxValidationCode_NOT_VALIDATED)
+	block := bb.Build()
+
+	t.Run("Num transactions less than committer threshold -> committer validates", func(t *testing.T) {
+		reset := setRoles(roles.ValidatorRole)
+		defer reset()
+
+		cfg := &policy{
+			committerTransactionThreshold:  6,
+			singlePeerTransactionThreshold: 0,
+		}
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.ValidatorRole)).
+			Member(org2MSPID, extmocks.NewMember(p1Org2Endpoint, p1Org2PKIID, roles.ValidatorRole))
+
+		peerGroups, err := newPeerGroupSelector(channelID, cfg, discovery.New(channelID, gossip), block).groups()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(peerGroups))
+		require.Equal(t, []string{p2Org1Endpoint}, asEndpoints(peerGroups[0]...))
+	})
+
+	t.Run("Num transactions less than single-peer transaction threshold -> one validator validates", func(t *testing.T) {
+		reset := setRoles(roles.ValidatorRole)
+		defer reset()
+
+		cfg := &policy{
+			committerTransactionThreshold:  2,
+			singlePeerTransactionThreshold: 6,
+		}
+
+		t.Run("Committer also validator -> committer validates", func(t *testing.T) {
+			gossip := extmocks.NewMockGossipAdapter().
+				Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+				Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole, roles.ValidatorRole)).
+				Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.ValidatorRole))
+
+			peerGroups, err := newPeerGroupSelector(channelID, cfg, discovery.New(channelID, gossip), block).groups()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(peerGroups))
+			require.Equal(t, []string{p2Org1Endpoint}, asEndpoints(peerGroups[0]...))
+		})
+
+		t.Run("Committer not validator -> non-committer validates", func(t *testing.T) {
+			gossip := extmocks.NewMockGossipAdapter().
+				Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+				Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole)).
+				Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.ValidatorRole))
+
+			peerGroups, err := newPeerGroupSelector(channelID, cfg, discovery.New(channelID, gossip), block).groups()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(peerGroups))
+			require.Equal(t, []string{p3Org1Endpoint}, asEndpoints(peerGroups[0]...))
+		})
+
+		t.Run("No validators -> committer validates", func(t *testing.T) {
+			reset := setRoles(roles.EndorserRole)
+			defer reset()
+
+			gossip := extmocks.NewMockGossipAdapter().
+				Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+				Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole)).
+				Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.EndorserRole))
+
+			peerGroups, err := newPeerGroupSelector(channelID, cfg, discovery.New(channelID, gossip), block).groups()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(peerGroups))
+			require.Equal(t, []string{p2Org1Endpoint}, asEndpoints(peerGroups[0]...))
+		})
+	})
+
+	t.Run("Num transactions greater than single-peer transaction threshold -> all validators validate", func(t *testing.T) {
+		reset := setRoles(roles.ValidatorRole)
+		defer reset()
+
+		cfg := &policy{
+			committerTransactionThreshold:  2,
+			singlePeerTransactionThreshold: 5,
+		}
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.ValidatorRole))
+
+		peerGroups, err := newPeerGroupSelector(channelID, cfg, discovery.New(channelID, gossip), block).groups()
+		require.NoError(t, err)
+		require.Equal(t, 2, len(peerGroups))
+		require.Equal(t, []string{p1Org1Endpoint}, asEndpoints(peerGroups[0]...))
+		require.Equal(t, []string{p3Org1Endpoint}, asEndpoints(peerGroups[1]...))
+	})
+
+	t.Run("No validators -> committer validates", func(t *testing.T) {
+		reset := setRoles(roles.EndorserRole)
+		defer reset()
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.EndorserRole))
+
+		cfg := &policy{
+			committerTransactionThreshold:  2,
+			singlePeerTransactionThreshold: 5,
+		}
+
+		peerGroups, err := newPeerGroupSelector(channelID, cfg, discovery.New(channelID, gossip), block).groups()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(peerGroups))
+		require.Equal(t, []string{p2Org1Endpoint}, asEndpoints(peerGroups[0]...))
+	})
+
+	t.Run("No validators & no committers -> error", func(t *testing.T) {
+		reset := setRoles(roles.EndorserRole)
+		defer reset()
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.EndorserRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.EndorserRole))
+
+		cfg := &policy{
+			committerTransactionThreshold:  2,
+			singlePeerTransactionThreshold: 5,
+		}
+
+		peerGroups, err := newPeerGroupSelector(channelID, cfg, discovery.New(channelID, gossip), block).groups()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no validators or committers")
+		require.Empty(t, peerGroups)
+	})
+}
+
+func asEndpoints(members ...*discovery.Member) []string {
+	var endpoints []string
+	for _, member := range members {
+		endpoints = append(endpoints, member.Endpoint)
+	}
+	return endpoints
+}
+
+func setRoles(role ...roles.Role) func() {
+	rolesValue := make(map[roles.Role]struct{})
+
+	for _, r := range role {
+		rolesValue[r] = struct{}{}
+	}
+
+	roles.SetRoles(rolesValue)
+
+	return func() { roles.SetRoles(nil) }
+}

--- a/pkg/validation/validationpolicy/policyevaluator.go
+++ b/pkg/validation/validationpolicy/policyevaluator.go
@@ -1,0 +1,210 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationpolicy
+
+import (
+	"encoding/binary"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/common/flogging"
+	"github.com/hyperledger/fabric/common/policies"
+	"github.com/hyperledger/fabric/common/policydsl"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	"github.com/trustbloc/fabric-peer-ext/pkg/config"
+	"github.com/trustbloc/fabric-peer-ext/pkg/validation/validationresults"
+)
+
+var logger = flogging.MustGetLogger("ext_validation")
+
+// traceLogger is used for very detailed logging
+var traceLogger = flogging.MustGetLogger("ext_validation_trace")
+
+// policy contains the validation policy parameters
+type policy struct {
+	// committerTransactionThreshold is the threshold at which the committer will validate the block, i.e. if
+	// the number of transactions is less than this threshold then the committer will validate the block,
+	// even though the committer does not have the validator role. If set to 0 then the committer won't perform validation
+	// unless there are no validators available.
+	committerTransactionThreshold int
+
+	// singlePeerTransactionThreshold is the threshold at which only a single peer with the validator role will
+	// validate the block, i.e. if the number of transactions is less than this threshold then only a single validator
+	// is selected for validation.
+	singlePeerTransactionThreshold int
+}
+
+// PolicyEvaluator evaluates the validation policy
+type PolicyEvaluator struct {
+	policy *policy
+	*discovery.Discovery
+	channelID       string
+	policyValidator policies.Policy
+	policyProvider  policies.Provider
+	mutex           sync.RWMutex
+}
+
+// New returns a new Validation PolicyEvaluator
+func New(channelID string, disc *discovery.Discovery, pp policies.Provider) *PolicyEvaluator {
+	policy := &policy{
+		committerTransactionThreshold:  config.GetValidationCommitterTransactionThreshold(),
+		singlePeerTransactionThreshold: config.GetValidationSinglePeerTransactionThreshold(),
+	}
+
+	logger.Infof("[%s] Creating new policy evaluator...", channelID)
+
+	return &PolicyEvaluator{
+		channelID:      channelID,
+		Discovery:      disc,
+		policy:         policy,
+		policyProvider: pp,
+	}
+}
+
+// GetValidatingPeers returns the set of peers that are involved in validating the given block
+func (p *PolicyEvaluator) GetValidatingPeers(block *cb.Block) (discovery.PeerGroup, error) {
+	groups, err := newPeerGroupSelector(p.channelID, p.policy, p.Discovery, block).groups()
+	if err != nil {
+		return nil, err
+	}
+
+	peerMap := make(map[string]*discovery.Member)
+	for _, pg := range groups {
+		for _, p := range pg {
+			peerMap[p.Endpoint] = p
+		}
+	}
+
+	var peers []*discovery.Member
+	for _, p := range peerMap {
+		peers = append(peers, p)
+	}
+
+	return peers, nil
+}
+
+// GetTxFilter returns the transaction filter that determines whether or not the local peer
+// should validate the transaction at a given index.
+func (p *PolicyEvaluator) GetTxFilter(block *cb.Block) TxFilter {
+	groups, err := newPeerGroupSelector(p.channelID, p.policy, p.Discovery, block).groups()
+	if err != nil {
+		logger.Warningf("Error calculating peer groups for block %d: %s. Will validate all transactions.", block.Header.Number, err)
+		return TxFilterAcceptAll
+	}
+
+	logger.Debugf("[%s] All validator groups for block %d: %s", p.channelID, block.Header.Number, groups)
+
+	return func(txIdx int) bool {
+		peerGroupForTx := groups[txIdx%len(groups)]
+
+		traceLogger.Debugf("[%s] Validator group for block %d, TxIdx [%d] is %s", p.channelID, block.Header.Number, txIdx, peerGroupForTx)
+
+		return peerGroupForTx.ContainsLocal()
+	}
+}
+
+// ValidateResults validates that the given results have come from a reliable source
+// and that the validation policy has been satisfied.
+func (p *PolicyEvaluator) ValidateResults(results []*validationresults.Results) error {
+	// If one of the results in the set came from this peer then no need to validate.
+	// If one of the results in the set is from another peer in our own org then validate
+	// the signature to ensure the result came from our org.)
+	for _, result := range results {
+		if result.Local {
+			logger.Debugf("[%s] No need to validate since results for block %d originated locally", p.channelID, result.BlockNumber)
+
+			return nil
+		}
+
+		if result.MSPID != p.Self().MSPID {
+			logger.Debugf("[%s] Ignoring validation results for block %d which came from [%s] which is in another org [%s]", p.channelID, results[0].BlockNumber, result.Endpoint, result.MSPID)
+
+			continue
+		}
+
+		logger.Debugf("[%s] Validating results for block %d that came from [%s] which is in our own org", p.channelID, result.BlockNumber, result.Endpoint)
+
+		policyValidator, err := p.getPolicyValidator()
+		if err != nil {
+			return errors.WithMessagef(err, "unable to get policy validator")
+		}
+
+		return policyValidator.EvaluateSignedData(getSignatureSet([]*validationresults.Results{result}))
+	}
+
+	return errors.Errorf("[%s] No validation results from the local org for block %d", p.channelID, results[0].BlockNumber)
+}
+
+func (p *PolicyEvaluator) getPolicyValidator() (policies.Policy, error) {
+	var policyValidator policies.Policy
+
+	p.mutex.RLock()
+	policyValidator = p.policyValidator
+	p.mutex.RUnlock()
+
+	if policyValidator != nil {
+		return policyValidator, nil
+	}
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	if p.policyValidator != nil {
+		return p.policyValidator, nil
+	}
+
+	// 'local-org' policy
+	policyBytes, err := proto.Marshal(policydsl.SignedByMspMember(p.Self().MSPID))
+	if err != nil {
+		return nil, errors.WithMessage(err, "error marshaling 'local-org' policy")
+	}
+
+	policyValidator, _, err = p.policyProvider.NewPolicy(policyBytes)
+	if err != nil {
+		return nil, errors.WithMessage(err, "error creating 'local-org' policy evaluator")
+	}
+
+	p.policyValidator = policyValidator
+
+	return policyValidator, nil
+}
+
+func getSignatureSet(validationResults []*validationresults.Results) []*protoutil.SignedData {
+	var sigSet []*protoutil.SignedData
+
+	for _, vr := range validationResults {
+		signedData := &protoutil.SignedData{
+			Data:      GetDataToSign(vr.BlockNumber, vr.TxFlags, vr.Identity),
+			Signature: vr.Signature,
+			Identity:  vr.Identity,
+		}
+		sigSet = append(sigSet, signedData)
+	}
+
+	return sigSet
+}
+
+// GetDataToSign appends the block number, Tx Flags, and the serialized identity
+// into a byte buffer to be signed by the validator.
+func GetDataToSign(blockNum uint64, txFlags, identity []byte) []byte {
+	blockNumBytes := make([]byte, binary.MaxVarintLen64)
+	binary.PutUvarint(blockNumBytes, blockNum)
+	data := append(blockNumBytes, txFlags...)
+	return append(data, identity...)
+}
+
+// TxFilter determines which transactions are to be validated
+type TxFilter func(txIdx int) bool
+
+// TxFilterAcceptAll accepts all transactions
+var TxFilterAcceptAll = func(int) bool {
+	return true
+}

--- a/pkg/validation/validationpolicy/policyevaluator_test.go
+++ b/pkg/validation/validationpolicy/policyevaluator_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationpolicy
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/validation/validationresults"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/discovery"
+	extmocks "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+	"github.com/trustbloc/fabric-peer-ext/pkg/roles"
+	"github.com/trustbloc/fabric-peer-ext/pkg/validation/validationpolicy/mocks"
+)
+
+//go:generate counterfeiter -o ./mocks/policiesprovider.gen.go --fake-name PoliciesProvider github.com/hyperledger/fabric/common/policies.Provider
+
+func TestPolicyEvaluator_New(t *testing.T) {
+	channelID := "testchannel"
+
+	require.NotNil(t, New(channelID, discovery.New(channelID, extmocks.NewMockGossipAdapter()), &mocks.PolicyProvider{}))
+}
+
+func TestPolicyEvaluator_GetValidatingPeers(t *testing.T) {
+	channelID := "testchannel"
+
+	bb := extmocks.NewBlockBuilder(channelID, 1000)
+	bb.Transaction("tx1", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx2", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx3", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx4", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx5", peer.TxValidationCode_NOT_VALIDATED)
+	block := bb.Build()
+
+	t.Run("Success", func(t *testing.T) {
+		reset := setRoles(roles.ValidatorRole)
+		defer reset()
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.ValidatorRole))
+
+		policy := &policy{
+			committerTransactionThreshold:  1,
+			singlePeerTransactionThreshold: 3,
+		}
+
+		evaluator := &PolicyEvaluator{
+			channelID:      channelID,
+			Discovery:      discovery.New(channelID, gossip),
+			policy:         policy,
+			policyProvider: &mocks.PolicyProvider{},
+		}
+
+		peers, err := evaluator.GetValidatingPeers(block)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(peers))
+	})
+
+	t.Run("No validators or committers -> error", func(t *testing.T) {
+		reset := setRoles(roles.EndorserRole)
+		defer reset()
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.EndorserRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.EndorserRole))
+
+		policy := &policy{
+			committerTransactionThreshold:  1,
+			singlePeerTransactionThreshold: 3,
+		}
+
+		evaluator := &PolicyEvaluator{
+			channelID:      channelID,
+			Discovery:      discovery.New(channelID, gossip),
+			policy:         policy,
+			policyProvider: &mocks.PolicyProvider{},
+		}
+
+		peers, err := evaluator.GetValidatingPeers(block)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no validators or committers")
+		require.Empty(t, peers)
+	})
+}
+
+func TestPolicyEvaluator_GetTxFilter(t *testing.T) {
+	channelID := "testchannel"
+
+	bb := extmocks.NewBlockBuilder(channelID, 1000)
+	bb.Transaction("tx1", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx2", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx3", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx4", peer.TxValidationCode_NOT_VALIDATED)
+	bb.Transaction("tx5", peer.TxValidationCode_NOT_VALIDATED)
+	block := bb.Build()
+
+	t.Run("Success", func(t *testing.T) {
+		reset := setRoles(roles.ValidatorRole)
+		defer reset()
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.CommitterRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.ValidatorRole))
+
+		policy := &policy{
+			committerTransactionThreshold:  1,
+			singlePeerTransactionThreshold: 3,
+		}
+
+		evaluator := &PolicyEvaluator{
+			channelID:      channelID,
+			Discovery:      discovery.New(channelID, gossip),
+			policy:         policy,
+			policyProvider: &mocks.PolicyProvider{},
+		}
+
+		txFilter := evaluator.GetTxFilter(block)
+		require.NotNil(t, txFilter)
+
+		require.True(t, txFilter(0))
+		require.False(t, txFilter(1))
+		require.True(t, txFilter(2))
+		require.False(t, txFilter(3))
+		require.True(t, txFilter(4))
+	})
+
+	t.Run("Policy error -> local peer validates all transactions", func(t *testing.T) {
+		reset := setRoles(roles.EndorserRole)
+		defer reset()
+
+		gossip := extmocks.NewMockGossipAdapter().
+			Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+			Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.EndorserRole)).
+			Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.EndorserRole))
+
+		policy := &policy{
+			committerTransactionThreshold:  1,
+			singlePeerTransactionThreshold: 3,
+		}
+
+		evaluator := &PolicyEvaluator{
+			channelID:      channelID,
+			Discovery:      discovery.New(channelID, gossip),
+			policy:         policy,
+			policyProvider: &mocks.PolicyProvider{},
+		}
+
+		txFilter := evaluator.GetTxFilter(block)
+		require.NotNil(t, txFilter)
+		require.True(t, txFilter(0))
+		require.True(t, txFilter(1))
+		require.True(t, txFilter(2))
+		require.True(t, txFilter(3))
+		require.True(t, txFilter(4))
+	})
+}
+
+func TestPolicyEvaluator_ValidateResults(t *testing.T) {
+	channelID := "testchannel"
+
+	gossip := extmocks.NewMockGossipAdapter().
+		Self(org1MSPID, extmocks.NewMember(p1Org1Endpoint, p1Org1PKIID)).
+		Member(org1MSPID, extmocks.NewMember(p2Org1Endpoint, p2Org1PKIID, roles.EndorserRole)).
+		Member(org1MSPID, extmocks.NewMember(p3Org1Endpoint, p3Org1PKIID, roles.EndorserRole)).
+		Member(org2MSPID, extmocks.NewMember(p1Org2Endpoint, p1Org2PKIID, roles.ValidatorRole))
+
+	evaluator := New(channelID, discovery.New(channelID, gossip), &mocks.PolicyProvider{})
+	require.NotNil(t, evaluator)
+
+	t.Run("Local peer", func(t *testing.T) {
+		err := evaluator.ValidateResults(
+			[]*validationresults.Results{
+				{
+					BlockNumber: 1000,
+					Endpoint:    p1Org1Endpoint,
+					MSPID:       org1MSPID,
+					TxFlags:     []uint8{0},
+					Local:       true,
+				},
+			},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("Remote peers", func(t *testing.T) {
+		err := evaluator.ValidateResults(
+			[]*validationresults.Results{
+				{
+					BlockNumber: 1000,
+					Endpoint:    p1Org2Endpoint,
+					MSPID:       org2MSPID,
+					TxFlags:     []uint8{0},
+					Identity:    []byte(p1Org2Endpoint),
+					Signature:   []byte("p1Org2signature"),
+				},
+				{
+					BlockNumber: 1000,
+					Endpoint:    p2Org1Endpoint,
+					MSPID:       org1MSPID,
+					TxFlags:     []uint8{0},
+					Identity:    []byte(p2Org1Endpoint),
+					Signature:   []byte("p2Org1signature"),
+				},
+			},
+		)
+		require.NoError(t, err)
+	})
+}

--- a/pkg/validation/validationresults/validationresults.go
+++ b/pkg/validation/validationresults/validationresults.go
@@ -1,0 +1,119 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationresults
+
+import (
+	"fmt"
+	"hash/fnv"
+	"sync"
+
+	"github.com/hyperledger/fabric/common/flogging"
+
+	"github.com/trustbloc/fabric-peer-ext/pkg/common/txflags"
+)
+
+var logger = flogging.MustGetLogger("ext_validation")
+
+// Results contains the validation results for the given block number.
+type Results struct {
+	BlockNumber uint64
+	TxFlags     txflags.ValidationFlags
+	TxIDs       []string
+	Err         error
+	Endpoint    string // Endpoint is the endpoint of the peer that provided the results.
+	Local       bool   // If true then that means the results were generated locally and policy validation is not required
+	MSPID       string
+	Signature   []byte
+	Identity    []byte
+}
+
+// Results returns a string representation of the validation results (used in logging).
+func (vr *Results) String() string {
+	if vr.Err == nil {
+		return fmt.Sprintf("(MSP: [%s], Endpoint: [%s], Block: %d, TxFlags: %v)", vr.MSPID, vr.Endpoint, vr.BlockNumber, vr.TxFlags)
+	}
+
+	return fmt.Sprintf("(MSP: [%s], Endpoint: [%s], Block: %d, Err: %s)", vr.MSPID, vr.Endpoint, vr.BlockNumber, vr.Err)
+}
+
+// Cache is a cache of validation results segmented by TxFlags. One or more
+// peers will validate a certain subset of transactions within a block. If two
+// peers, say, validate the same set of transactions and come up with the exact
+// same results then both of the results will be added to the same segment under
+// the block.
+type Cache struct {
+	lock           sync.Mutex
+	resultsByBlock map[uint64]results
+}
+
+// NewCache returns a new validation results cache
+func NewCache() *Cache {
+	return &Cache{
+		resultsByBlock: make(map[uint64]results),
+	}
+}
+
+// Add adds the given validation result to the cache under the appropriate
+// block/segment and returns all validation results for the segment.
+func (c *Cache) Add(result *Results) []*Results {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.get(result.BlockNumber).add(result)
+}
+
+// Remove removes validation results for the given block and deletes the results from any previous block
+// TODO: Delete all previous blocks
+func (c *Cache) Remove(blockNum uint64) []*Results {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	segmentsForBlock, ok := c.resultsByBlock[blockNum]
+	if !ok {
+		return nil
+	}
+
+	var resultsForBlock []*Results
+	for _, results := range segmentsForBlock {
+		resultsForBlock = append(resultsForBlock, results...)
+	}
+
+	logger.Infof("Removing cached validation results for block %d", blockNum)
+
+	delete(c.resultsByBlock, blockNum)
+
+	return resultsForBlock
+}
+
+func (c *Cache) get(blockNum uint64) results {
+	resultsForBlock, ok := c.resultsByBlock[blockNum]
+	if !ok {
+		resultsForBlock = make(results)
+		c.resultsByBlock[blockNum] = resultsForBlock
+	}
+	return resultsForBlock
+}
+
+func hash(txFlags txflags.ValidationFlags) uint32 {
+	h := fnv.New32a()
+	_, err := h.Write(txFlags)
+	if err != nil {
+		panic(err.Error())
+	}
+	return h.Sum32()
+}
+
+type results map[uint32][]*Results
+
+func (r results) add(result *Results) []*Results {
+	segment := hash(result.TxFlags)
+
+	results := append(r[segment], result)
+	r[segment] = results
+
+	return results
+}

--- a/pkg/validation/validationresults/validationresults_test.go
+++ b/pkg/validation/validationresults/validationresults_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validationresults
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	org1MSP = "Org1MSP"
+	org2MSP = "Org2MSP"
+
+	p1Org1 = "p1.org1.com"
+	p1Org2 = "p1.org2.com"
+	p2Org2 = "p2.org2.com"
+)
+
+func TestResults_String(t *testing.T) {
+	t.Run("No error", func(t *testing.T) {
+		r := &Results{
+			BlockNumber: 1000,
+			TxFlags:     []uint8{255, 0, 255, 0},
+			MSPID:       org1MSP,
+			Endpoint:    p1Org1,
+		}
+		require.Equal(t, "(MSP: [Org1MSP], Endpoint: [p1.org1.com], Block: 1000, TxFlags: [255 0 255 0])", r.String())
+	})
+
+	t.Run("With error", func(t *testing.T) {
+		r := &Results{
+			BlockNumber: 1000,
+			Err:         fmt.Errorf("validation error"),
+			MSPID:       org1MSP,
+			Endpoint:    p1Org1,
+		}
+		require.Equal(t, "(MSP: [Org1MSP], Endpoint: [p1.org1.com], Block: 1000, Err: validation error)", r.String())
+	})
+}
+
+func TestValidationResultsCache(t *testing.T) {
+	cache := NewCache()
+
+	blockNum := uint64(1000)
+
+	r1 := &Results{
+		BlockNumber: blockNum,
+		TxFlags:     []uint8{255, 0, 255, 0},
+		MSPID:       org1MSP,
+		Endpoint:    p1Org1,
+	}
+	r2 := &Results{
+		BlockNumber: blockNum,
+		TxFlags:     []uint8{255, 0, 255, 0},
+		MSPID:       org2MSP,
+		Endpoint:    p2Org2,
+	}
+	r3 := &Results{
+		BlockNumber: blockNum,
+		TxFlags:     []uint8{0, 255, 0, 255},
+		MSPID:       org2MSP,
+		Endpoint:    p1Org2,
+	}
+
+	results := cache.Add(r1)
+	require.Equal(t, 1, len(results))
+	require.Equal(t, r1, results[0])
+
+	results = cache.Add(r2)
+	require.Equal(t, 2, len(results))
+	require.Equal(t, r1, results[0])
+	require.Equal(t, r2, results[1])
+
+	results = cache.Add(r3)
+	require.Equal(t, 1, len(results))
+	require.Equal(t, r3, results[0])
+
+	results = cache.Remove(blockNum)
+	require.Equal(t, 3, len(results))
+
+	results = cache.Remove(blockNum)
+	require.Empty(t, results)
+}


### PR DESCRIPTION
Defined a validation policy and implemented a policy evaluator that selects the peers that should validate transactions within a block. The policy evaluator also validates validation results according to the policy.

closes #556

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>